### PR TITLE
fix(html): bypass Click-to-Reveal-Desktop, polish HTML wallpaper pipeline

### DIFF
--- a/LiveWallpaper/LiveWallpaperApp.swift
+++ b/LiveWallpaper/LiveWallpaperApp.swift
@@ -57,6 +57,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         Logger.notice("Application starting", category: .startup)
 
+        // 把 tracker rule list 提前编译进 WKContentRuleListStore，
+        // 后续 HTML 壁纸首次启用过滤时直接 lookUp，省掉同步编译开销。
+        HTMLWallpaperView.precompileTrackerRules()
+
         let startupPlan = AppStartupPlan(
             runtimeOptions: runtimeOptions,
             onboardingCompleted: UserDefaults.standard.bool(forKey: "Onboarding.Completed")

--- a/LiveWallpaper/Models/HTMLConfig.swift
+++ b/LiveWallpaper/Models/HTMLConfig.swift
@@ -17,6 +17,10 @@ struct HTMLConfig: Codable, Equatable {
     /// `nil` (the default) means no extra CSS is injected.
     var customCSS: String? = nil
 
+    /// 静音页面内所有 `<audio>` / `<video>` 元素。与 `applyPerformanceProfile`
+    /// 解耦：用户可能希望保留视觉动画但去掉声音。
+    var muteAudio: Bool = false
+
     static let `default` = HTMLConfig()
 
     private enum CodingKeys: String, CodingKey {
@@ -24,18 +28,21 @@ struct HTMLConfig: Codable, Equatable {
         case allowMouseInteraction
         case blockTrackers
         case customCSS
+        case muteAudio
     }
 
     init(
         allowJavaScript: Bool = true,
         allowMouseInteraction: Bool = false,
         blockTrackers: Bool = true,
-        customCSS: String? = nil
+        customCSS: String? = nil,
+        muteAudio: Bool = false
     ) {
         self.allowJavaScript = allowJavaScript
         self.allowMouseInteraction = allowMouseInteraction
         self.blockTrackers = blockTrackers
         self.customCSS = customCSS
+        self.muteAudio = muteAudio
     }
 
     init(from decoder: Decoder) throws {
@@ -44,5 +51,6 @@ struct HTMLConfig: Codable, Equatable {
         allowMouseInteraction = try c.decodeIfPresent(Bool.self, forKey: .allowMouseInteraction) ?? false
         blockTrackers = try c.decodeIfPresent(Bool.self, forKey: .blockTrackers) ?? true
         customCSS = try c.decodeIfPresent(String.self, forKey: .customCSS)
+        muteAudio = try c.decodeIfPresent(Bool.self, forKey: .muteAudio) ?? false
     }
 }

--- a/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
+++ b/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
@@ -6,13 +6,16 @@ final class AmbientWallpaperSessionBuilder {
     func makeHTMLSession(source: HTMLSource, config: HTMLConfig, frame: CGRect) -> AmbientWallpaperSession {
         let window = VideoWallpaperWindow(frame: frame)
         let htmlView = HTMLWallpaperView(frame: frame)
-        window.setWallpaperMouseInteractionEnabled(config.allowMouseInteraction)
         window.contentView = htmlView
 
         htmlView.apply(config)
         htmlView.loadSource(source)
 
-        window.orderBack(nil)
+        // 必须在 contentView 装好之后再切交互态。该方法已经负责 ordering
+        // (interactive → makeKeyAndOrderFront / passive → orderBack)，
+        // 别再追加额外的 orderBack — 否则会把抬升的交互窗户拉回桌面层、
+        // 导致 "Click wallpaper to reveal desktop" 重新生效。
+        window.setWallpaperMouseInteractionEnabled(config.allowMouseInteraction)
         return AmbientWallpaperSession(window: window, wallpaperType: .html, performanceTarget: htmlView)
     }
 

--- a/LiveWallpaper/VideoPlayback/HTMLWallpaperView.swift
+++ b/LiveWallpaper/VideoPlayback/HTMLWallpaperView.swift
@@ -1,34 +1,65 @@
 import AppKit
 import WebKit
 
+/// `WKWebView` 子类：开启 first-mouse 接收（Plash 模式），关闭 Force-Touch 链接预览，
+/// 过滤右键菜单中无意义项（下载图片 / 分享 / 在新窗口打开等）。
+final class HTMLWebView: WKWebView {
+    /// 关键：交互态首次点击就生效，不需要先把 wallpaper window 激活成 key window。
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    /// 借鉴 Plash：右键菜单里这些项在壁纸场景下完全无意义，直接拿掉。
+    private static let blockedMenuTitles: Set<String> = [
+        "Download Image",
+        "Download Linked File",
+        "Download Video",
+        "Open Image in New Window",
+        "Open Video in New Window",
+        "Open Frame in New Window",
+        "Open Link in New Window",
+        "Share",
+        "Enter Full Screen",
+        "Enter Enhanced Full Screen"
+    ]
+
+    override func willOpenMenu(_ menu: NSMenu, with event: NSEvent) {
+        menu.items.removeAll { item in
+            HTMLWebView.blockedMenuTitles.contains(item.title)
+        }
+    }
+}
+
 /// WKWebView-backed HTML wallpaper host.
 @MainActor
 final class HTMLWallpaperView: NSView {
 
+    // MARK: - Shared Resources
+
+    /// 跨屏 / 跨实例共享，避免每个壁纸都拉起独立的 WebContent 进程。
+    private static let sharedProcessPool = WKProcessPool()
+
     // MARK: - Properties
 
-    private let webView: WKWebView
+    private let webView: HTMLWebView
     private var allowMouseInteraction = false
     private var compiledTrackerRuleList: WKContentRuleList?
     private var hasTrackerRulesAttached = false
     private var trackerBlockingRequested = false
     private var activeSecurityScopedURL: URL?
     /// Tracks the last applied `HTMLConfig` so re-`apply()` calls with the
-    /// same toggles skip the user-script teardown / re-install (which forces
-    /// WKWebView to re-evaluate scripts and was a source of GPU churn when
-    /// upstream emitters re-published frequently).
+    /// same toggles skip the user-script teardown / re-install.
     private var lastAppliedConfig: HTMLConfig?
 
     // MARK: - Initialization
 
     override init(frame frameRect: NSRect) {
         let configuration = WKWebViewConfiguration()
+        configuration.processPool = HTMLWallpaperView.sharedProcessPool
         let preferences = WKWebpagePreferences()
         preferences.allowsContentJavaScript = true
         configuration.defaultWebpagePreferences = preferences
         configuration.mediaTypesRequiringUserActionForPlayback = []
 
-        webView = WKWebView(frame: NSRect(origin: .zero, size: frameRect.size), configuration: configuration)
+        webView = HTMLWebView(frame: NSRect(origin: .zero, size: frameRect.size), configuration: configuration)
 
         super.init(frame: frameRect)
 
@@ -49,23 +80,69 @@ final class HTMLWallpaperView: NSView {
 
         webView.allowsMagnification = false
         webView.allowsBackForwardNavigationGestures = false
+        webView.allowsLinkPreview = false
 
-        installBaselineUserScripts()
+        installBaselineUserScripts(for: nil)
         webView.navigationDelegate = self
+        webView.uiDelegate = self
         webView.autoresizingMask = [.width, .height]
     }
 
-    private func installBaselineUserScripts() {
+    /// 注入静态基线脚本 + 反映当前配置的状态脚本。
+    /// - Parameter config: 决定 `lw-browsing-mode` class、自定义 CSS 内容、静音等运行时状态。
+    ///   传 `nil` 表示首次安装（init 阶段，配置未知）。
+    private func installBaselineUserScripts(for config: HTMLConfig?) {
         let controller = webView.configuration.userContentController
         controller.removeAllUserScripts()
-        let hideScrollbar = """
-        var style = document.createElement('style');
-        style.textContent = '::-webkit-scrollbar { display: none; } body { overflow: hidden; }';
-        document.head.appendChild(style);
+
+        // documentStart：尽早注入避免页面闪烁。
+        // 1) 隐藏滚动条 + 锁定 body overflow
+        // 2) 给 root 加 `is-livewallpaper` class（用户 CSS / 站点适配可用）
+        // 3) 预先建好两个 <style> 占位（用户 CSS 与基线 CSS），运行时只改 textContent
+        let cssLiteral = jsStringLiteral(config?.customCSS ?? "")
+        let isBrowsing = (config?.allowMouseInteraction ?? false) ? "true" : "false"
+        let isMuted = (config?.muteAudio ?? false) ? "true" : "false"
+
+        let baseline = """
+        (function () {
+            function bootstrap() {
+                if (!document.documentElement) return;
+                document.documentElement.classList.add('is-livewallpaper');
+                document.documentElement.classList.toggle('lw-browsing-mode', \(isBrowsing));
+
+                if (!document.getElementById('lw-base-css')) {
+                    var base = document.createElement('style');
+                    base.id = 'lw-base-css';
+                    base.textContent = '::-webkit-scrollbar{display:none;}html,body{overflow:hidden;}';
+                    (document.head || document.documentElement).appendChild(base);
+                }
+                if (!document.getElementById('lw-user-css')) {
+                    var user = document.createElement('style');
+                    user.id = 'lw-user-css';
+                    user.textContent = \(cssLiteral);
+                    (document.head || document.documentElement).appendChild(user);
+                }
+            }
+            bootstrap();
+            // <head> 在 documentStart 时可能尚未就绪 — 用 MutationObserver 做兜底。
+            if (!document.head) {
+                var mo = new MutationObserver(function () {
+                    if (document.head) { bootstrap(); mo.disconnect(); }
+                });
+                mo.observe(document.documentElement, { childList: true });
+            }
+            // 静音状态：通过 JS 在 DOMContentLoaded 时统一施加；后续元素由 navigation finish 兜底。
+            if (\(isMuted)) {
+                document.addEventListener('DOMContentLoaded', function () {
+                    document.querySelectorAll('audio,video').forEach(function (el) { el.muted = true; });
+                });
+            }
+        })();
         """
+
         controller.addUserScript(WKUserScript(
-            source: hideScrollbar,
-            injectionTime: .atDocumentEnd,
+            source: baseline,
+            injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         ))
     }
@@ -81,8 +158,7 @@ final class HTMLWallpaperView: NSView {
 
     func apply(_ config: HTMLConfig) {
         if let previous = lastAppliedConfig, previous == config {
-            // No-op fast path: avoids `removeAllUserScripts` + `addUserScript`
-            // churn that forces WebKit to re-evaluate the injection bundle.
+            // 完全相同 — 跳过任何注入操作，避免 WebKit 重新评估脚本包。
             return
         }
 
@@ -90,14 +166,52 @@ final class HTMLWallpaperView: NSView {
         webView.configuration.defaultWebpagePreferences.allowsContentJavaScript = config.allowJavaScript
         allowMouseInteraction = config.allowMouseInteraction
 
-        // Only rebuild user-script bundle when CSS or JS toggle actually changed.
-        if previous?.customCSS != config.customCSS || previous?.allowJavaScript != config.allowJavaScript {
-            applyCustomCSS(config.customCSS)
+        // 任何运行时状态变化都先尝试通过 evaluateJavaScript 热更新 — 不重建 user script。
+        applyRuntimeState(previous: previous, current: config)
+
+        // 仅当下次 reload 时需要的"持久化"状态变化，才重建 user script。
+        let needsScriptRebuild = (previous?.customCSS != config.customCSS)
+            || (previous?.allowMouseInteraction != config.allowMouseInteraction)
+            || (previous?.muteAudio != config.muteAudio)
+            || (previous?.allowJavaScript != config.allowJavaScript)
+
+        if needsScriptRebuild {
+            installBaselineUserScripts(for: config)
         }
+
         if previous?.blockTrackers != config.blockTrackers {
             applyTrackerBlocking(enabled: config.blockTrackers)
         }
         lastAppliedConfig = config
+    }
+
+    /// 当前页面已经渲染时的热更新路径：直接改 DOM，不动 user script。
+    private func applyRuntimeState(previous: HTMLConfig?, current: HTMLConfig) {
+        var statements: [String] = []
+
+        if previous?.customCSS != current.customCSS {
+            let literal = jsStringLiteral(current.customCSS ?? "")
+            statements.append("""
+            (function(){var el=document.getElementById('lw-user-css');if(el){el.textContent=\(literal);}})();
+            """)
+        }
+
+        if previous?.allowMouseInteraction != current.allowMouseInteraction {
+            let flag = current.allowMouseInteraction ? "true" : "false"
+            statements.append("""
+            document.documentElement&&document.documentElement.classList.toggle('lw-browsing-mode',\(flag));
+            """)
+        }
+
+        if previous?.muteAudio != current.muteAudio {
+            let flag = current.muteAudio ? "true" : "false"
+            statements.append("""
+            document.querySelectorAll('audio,video').forEach(function(e){e.muted=\(flag);});
+            """)
+        }
+
+        guard !statements.isEmpty else { return }
+        webView.evaluateJavaScript(statements.joined(separator: "\n"), completionHandler: nil)
     }
 
     func loadSource(_ source: HTMLSource) {
@@ -159,29 +273,23 @@ final class HTMLWallpaperView: NSView {
         webView.setAllMediaPlaybackSuspended(suspended) {}
     }
 
-    // MARK: - Custom CSS
-
-    private func applyCustomCSS(_ css: String?) {
-        installBaselineUserScripts()
-        guard let css, !css.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        // JSON encoding keeps the CSS body a string literal, not script text.
-        guard let encoded = try? JSONEncoder().encode(css),
-              let cssLiteral = String(data: encoded, encoding: .utf8) else { return }
-        let injection = """
-        (function() {
-            var s = document.createElement('style');
-            s.textContent = \(cssLiteral);
-            document.head.appendChild(s);
-        })();
-        """
-        webView.configuration.userContentController.addUserScript(WKUserScript(
-            source: injection,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: true
-        ))
-    }
-
     // MARK: - Tracker Blocking
+
+    /// App 启动时调用一次：把 tracker 规则编译进 `WKContentRuleListStore`，
+    /// 后续每个实例直接 `lookUp`，省去 50–200ms 的同步编译。
+    static func precompileTrackerRules() {
+        WKContentRuleListStore.default()?.compileContentRuleList(
+            forIdentifier: trackerRuleListIdentifier,
+            encodedContentRuleList: trackerRuleListJSON
+        ) { _, error in
+            if let error {
+                Logger.warning(
+                    "Tracker rule list precompile failed: \(error.localizedDescription)",
+                    category: .screenManager
+                )
+            }
+        }
+    }
 
     private func applyTrackerBlocking(enabled: Bool) {
         trackerBlockingRequested = enabled
@@ -200,28 +308,45 @@ final class HTMLWallpaperView: NSView {
             }
             return
         }
+        // 优先 lookUp（命中由 precompile 写入的 store entry）— 失败再编译。
+        WKContentRuleListStore.default()?.lookUpContentRuleList(
+            forIdentifier: HTMLWallpaperView.trackerRuleListIdentifier
+        ) { [weak self] list, _ in
+            Task { @MainActor [weak self] in
+                guard let self, self.trackerBlockingRequested else { return }
+                if let list {
+                    self.attachTrackerList(list)
+                } else {
+                    self.compileAndAttachTrackerList()
+                }
+            }
+        }
+    }
+
+    private func compileAndAttachTrackerList() {
         WKContentRuleListStore.default()?.compileContentRuleList(
             forIdentifier: HTMLWallpaperView.trackerRuleListIdentifier,
             encodedContentRuleList: HTMLWallpaperView.trackerRuleListJSON
         ) { [weak self] list, error in
             Task { @MainActor [weak self] in
-                guard let self else { return }
-                guard self.trackerBlockingRequested, let list else {
-                    if let error {
-                        Logger.warning(
-                            "Tracker rule list compile failed: \(error.localizedDescription)",
-                            category: .screenManager
-                        )
-                    }
-                    return
+                guard let self, self.trackerBlockingRequested else { return }
+                if let error {
+                    Logger.warning(
+                        "Tracker rule list compile failed: \(error.localizedDescription)",
+                        category: .screenManager
+                    )
                 }
-                self.compiledTrackerRuleList = list
-                if !self.hasTrackerRulesAttached {
-                    self.webView.configuration.userContentController.add(list)
-                    self.hasTrackerRulesAttached = true
-                }
+                guard let list else { return }
+                self.attachTrackerList(list)
             }
         }
+    }
+
+    private func attachTrackerList(_ list: WKContentRuleList) {
+        compiledTrackerRuleList = list
+        guard !hasTrackerRulesAttached else { return }
+        webView.configuration.userContentController.add(list)
+        hasTrackerRulesAttached = true
     }
 
     // MARK: - Layout
@@ -237,6 +362,7 @@ final class HTMLWallpaperView: NSView {
         trackerBlockingRequested = false
         webView.stopLoading()
         webView.navigationDelegate = nil
+        webView.uiDelegate = nil
         webView.configuration.userContentController.removeAllUserScripts()
         if let list = compiledTrackerRuleList, hasTrackerRulesAttached {
             webView.configuration.userContentController.remove(list)
@@ -323,19 +449,43 @@ extension HTMLWallpaperView: WKNavigationDelegate {
             } else {
                 decisionHandler(.cancel)
             }
-        case .linkActivated, .formSubmitted, .backForward, .formResubmitted:
+        case .linkActivated:
+            // 交互态：跨域链接交给系统默认浏览器，同源 / file 允许。
+            // 非交互态：所有链接点击都被取消（页面应当只是壁纸，无导航）。
+            guard allowMouseInteraction,
+                  let url = navigationAction.request.url else {
+                decisionHandler(.cancel)
+                return
+            }
+            if isSameOrigin(navigationURL: url, current: webView.url) || url.isFileURL {
+                decisionHandler(.allow)
+            } else {
+                NSWorkspace.shared.open(url)
+                decisionHandler(.cancel)
+            }
+        case .formSubmitted, .backForward, .formResubmitted:
             decisionHandler(.cancel)
         @unknown default:
             decisionHandler(.cancel)
         }
     }
 
-    /// Nudges autoplay media after navigation finishes.
+    /// 同源判断 — host 一致即视为同源；缺 host（例如 about:blank）当作不同源。
+    private func isSameOrigin(navigationURL: URL, current: URL?) -> Bool {
+        guard let current,
+              let lhsHost = navigationURL.host,
+              let rhsHost = current.host else { return false }
+        return lhsHost == rhsHost
+    }
+
+    /// 导航完成后兜底：autoplay nudge + 静音状态再施加一次（覆盖晚到的元素）。
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        let muted = lastAppliedConfig?.muteAudio == true ? "true" : "false"
         let nudge = """
         (function() {
             var elements = document.querySelectorAll('video, audio');
             elements.forEach(function(el) {
+                el.muted = \(muted);
                 if (el.paused && el.autoplay !== false) {
                     try {
                         var promise = el.play();
@@ -349,4 +499,32 @@ extension HTMLWallpaperView: WKNavigationDelegate {
         """
         webView.evaluateJavaScript(nudge, completionHandler: nil)
     }
+}
+
+// MARK: - WKUIDelegate
+
+extension HTMLWallpaperView: WKUIDelegate {
+    /// 页面调用 `window.open()` 时，导航当前 webView 而不是开 popup（壁纸场景没有 popup 窗）。
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        if let url = navigationAction.request.url, allowMouseInteraction {
+            NSWorkspace.shared.open(url)
+        }
+        return nil
+    }
+}
+
+// MARK: - JS literal helper
+
+/// 把任意 Swift 字符串转成可直接嵌入 JS 源码的字符串字面量（含外层引号）。
+private func jsStringLiteral(_ value: String) -> String {
+    if let data = try? JSONEncoder().encode(value),
+       let literal = String(data: data, encoding: .utf8) {
+        return literal
+    }
+    return "\"\""
 }

--- a/LiveWallpaper/VideoPlayback/VideoWallpaperWindow.swift
+++ b/LiveWallpaper/VideoPlayback/VideoWallpaperWindow.swift
@@ -4,7 +4,11 @@ class VideoWallpaperWindow: NSWindow {
     private static let desktopWindowLevel = Int(CGWindowLevelForKey(.desktopWindow))
     private static let desktopIconWindowLevel = Int(CGWindowLevelForKey(.desktopIconWindow))
     private static let passiveWallpaperWindowLevel = desktopWindowLevel - 1
-    private static let interactiveWallpaperWindowLevel = desktopIconWindowLevel - 1
+    // Plash 模式：交互态把 window 抬到桌面图标层之上。
+    // 这样 macOS Sonoma 的 "Click wallpaper to reveal desktop" 手势再也拿不到点击 —
+    // 该手势是派发给系统桌面壁纸 window 的，我们盖在它和图标层之上后事件被消费在自己的 window 里。
+    // 代价：交互态会遮住桌面图标（与 Plash 一致）。
+    private static let interactiveWallpaperWindowLevel = desktopIconWindowLevel + 1
     private var allowsWallpaperMouseInteraction = false
 
     private var wallpaperWindowLevel: Int {
@@ -44,8 +48,9 @@ class VideoWallpaperWindow: NSWindow {
     }
     
     // MARK: - Window Behavior
-    override var canBecomeKey: Bool { false }
-    override var canBecomeMain: Bool { false }
+    // 交互态需要成为 key window，否则 WKWebView 收不到键盘 / 焦点事件。
+    override var canBecomeKey: Bool { allowsWallpaperMouseInteraction }
+    override var canBecomeMain: Bool { allowsWallpaperMouseInteraction }
     
     override func setFrame(_ frameRect: NSRect, display flag: Bool) {
         guard frameRect.width > 0 && frameRect.height > 0 else {
@@ -58,7 +63,13 @@ class VideoWallpaperWindow: NSWindow {
     }
     
     override func makeKeyAndOrderFront(_ sender: Any?) {
-        orderBack(nil)
+        // 非交互态：保持壁纸语义，强制排到背后。
+        // 交互态：放行真正的 key window 行为。
+        if allowsWallpaperMouseInteraction {
+            super.makeKeyAndOrderFront(sender)
+        } else {
+            orderBack(nil)
+        }
     }
     
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
@@ -85,6 +96,13 @@ extension VideoWallpaperWindow {
         level = NSWindow.Level(rawValue: wallpaperWindowLevel)
         ignoresMouseEvents = !allowsWallpaperMouseInteraction
         acceptsMouseMovedEvents = allowsWallpaperMouseInteraction
+        if allowsWallpaperMouseInteraction {
+            // 抬到 desktopIcon + 1 后必须主动 makeKeyAndOrderFront，
+            // 否则 window 仍处于 ordered-back 状态、点击不触发 hit-test。
+            super.makeKeyAndOrderFront(nil)
+        } else {
+            orderBack(nil)
+        }
     }
 
     func updateFrame(_ frame: CGRect, animate: Bool = false) {

--- a/LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift
@@ -172,8 +172,27 @@ struct HTMLSourceSection: View {
                 .controlSize(.small)
             }
             Text(config.allowMouseInteraction
-                 ? "Clicks and scrolls reach the wallpaper. Useful for interactive demos."
-                 : "Clicks fall through to the desktop, so Finder and Dock stay usable.")
+                 ? "Clicks and scrolls reach the wallpaper. Desktop icons are hidden behind the page while this is on."
+                 : "Clicks fall through to the desktop, so Finder icons and the Dock stay usable.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Label("Mute Audio", systemImage: "speaker.slash")
+                Spacer()
+                Toggle("", isOn: Binding(
+                    get: { config.muteAudio },
+                    set: { newValue in
+                        config.muteAudio = newValue
+                        commitConfig()
+                    }
+                ))
+                .labelsHidden()
+                .accessibilityLabel("Mute Audio")
+                .toggleStyle(.switch)
+                .controlSize(.small)
+            }
+            Text("Silences any <audio> or <video> elements without pausing the visuals.")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
 

--- a/LiveWallpaperTests/WallpaperArchitectureTests.swift
+++ b/LiveWallpaperTests/WallpaperArchitectureTests.swift
@@ -380,7 +380,10 @@ struct HTMLWallpaperMouseInteractionTests {
         defer { session.cleanup() }
 
         #expect(session.wallpaperWindow?.ignoresMouseEvents == false)
-        #expect((session.wallpaperWindow?.level.rawValue ?? 0) == CGWindowLevelForKey(.desktopIconWindow) - 1)
+        // 抬到桌面图标层之上 (`desktopIcon + 1`) 是绕过 macOS Sonoma
+        // "Click wallpaper to reveal desktop" 手势的关键 — 与 Plash 的 DesktopWindow 一致。
+        #expect((session.wallpaperWindow?.level.rawValue ?? 0) == CGWindowLevelForKey(.desktopIconWindow) + 1)
+        #expect(session.wallpaperWindow?.canBecomeKey == true)
     }
 
     @Test("Passive HTML wallpapers keep mouse events passing through")


### PR DESCRIPTION
## Summary

- **Root fix**: HTML wallpapers in interactive mode were still triggering macOS Sonoma's "Click wallpaper to reveal desktop" gesture. Adopt Plash's technique — raise the wallpaper window to `desktopIconWindow + 1` so the system handler never receives the click.
- **Bundle of HTML-pipeline polish** while we're in the file: shared `WKProcessPool`, precompiled tracker rules, CSS hot-swap, mute-audio toggle, right-click menu hygiene, external-link routing.

## Why

macOS Sonoma's "Click wallpaper to reveal desktop" is dispatched by the system's desktop wallpaper window. Our previous interactive level (`desktopIconWindow - 1`) sat *between* the wallpaper window and the icon layer — the system gesture still won the race. Plash's open-source history (DesktopWindow.swift) shows the bypass: lift to `desktopIcon + 1` and call `makeKeyAndOrderFront` so the click never reaches the system handler. Trade-off: desktop icons are visually covered while interactive mode is on (same as Plash).

## What changed

### Window — `desktopIcon + 1` + key-window pattern
- `VideoWallpaperWindow.interactiveWallpaperWindowLevel` now `+ 1`.
- `canBecomeKey/Main` and `makeKeyAndOrderFront` honor `allowsWallpaperMouseInteraction` instead of unconditionally `orderBack`.
- `AmbientWallpaperSessionBuilder.makeHTMLSession` drops the trailing `orderBack(nil)` that would have undone the lift.

### WebView — Plash-style polish
- New `HTMLWebView` subclass: `acceptsFirstMouse = true` (kills two-click warm-up), `allowsLinkPreview = false`, `willOpenMenu` strips download / share / open-in-new-window items.
- Shared `WKProcessPool` across instances → fewer WebContent processes on multi-screen setups.
- `precompileTrackerRules()` runs at `applicationDidFinishLaunching`; per-instance `applyTrackerBlocking` uses `lookUpContentRuleList` first → first-toggle is no longer a 50–200 ms blocking compile.
- Custom CSS lives in `<style id="lw-user-css">` injected at documentStart; runtime updates swap `textContent` via `evaluateJavaScript` instead of `removeAllUserScripts` + reinstall — kills the GPU-churn regression introduced in `19ca421`.
- documentStart adds `is-livewallpaper` / `lw-browsing-mode` classes so user CSS can branch.
- New `HTMLConfig.muteAudio` toggle silences `<audio>` / `<video>` without pausing visuals.
- `linkActivated` cross-origin links route to default browser via `NSWorkspace.shared.open`; same-origin / file links allowed only when `allowMouseInteraction == true`.

### UI
- `HTMLSourceSection`: new "Mute Audio" toggle, copy update on Mouse Interaction (warns about icon coverage).

## Test plan

- [x] `xcodebuild ... build` — `BUILD SUCCEEDED`
- [x] `xcodebuild ... test -only-testing:LiveWallpaperTests` — **153 / 153 passing**, including:
  - Updated assertion in `HTMLWallpaperMouseInteractionTests`: `level == desktopIconWindow + 1`, `canBecomeKey == true`.
- [ ] Manual: enable HTML wallpaper → toggle Mouse Interaction → click on wallpaper area; confirm no "show desktop" trigger and first-click works (no warm-up click required).
- [ ] Manual: toggle Mute Audio while a video plays — visuals continue, audio drops.
- [ ] Manual: edit Custom CSS while wallpaper is live — change applies without page reload / flicker.

## Notes for reviewers

- The level lift means desktop icons are hidden behind the page **only while interactive mode is on**. Plash makes the same trade-off; surfaced in the inspector copy.
- `VideoWallpaperWindow` is shared by video / Metal / HTML sessions, but only HTML calls `setWallpaperMouseInteractionEnabled(true)` — passive paths are unchanged (`desktopWindow - 1`, `orderBack`).
- Shared `WKProcessPool` is process-global by design (per Plash). No persistence implications since `WKWebsiteDataStore` is still the default per-instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)