### PR TITLE
fix(html): audio-leader policy + multi-instance diagnostics

### DIFF
--- a/LiveWallpaper/Models/HTMLSource.swift
+++ b/LiveWallpaper/Models/HTMLSource.swift
@@ -99,4 +99,20 @@ enum HTMLSource: Codable, Equatable {
         }
         return false
     }
+
+    /// Stable identity used to detect the same source running on multiple
+    /// screens (multi-instance audio + GPU avoidance). Equatable already
+    /// gives us comparison; this gives us a Dictionary key.
+    var diagnosticSignature: String {
+        switch self {
+        case .file(let data):
+            return "file:" + data.base64EncodedString()
+        case .folder(let data, let index):
+            return "folder:" + data.base64EncodedString() + ":" + index
+        case .url(let url):
+            return "url:" + url.absoluteString
+        case .inline(let html):
+            return "inline:" + String(html.hashValue)
+        }
+    }
 }

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -1223,8 +1223,19 @@ final class ScreenManager {
 
         switch definition {
         case .html(let source, let htmlConfig):
-            session = ambientSessionBuilder.makeHTMLSession(source: source, config: htmlConfig, frame: screen.frame)
-            Logger.info("Set HTML wallpaper for screen \(screen.id) — \(source.displayName)", category: .screenManager)
+            // Audio-leader policy: same source on multiple screens means N
+            // independent webviews would each decode audio + render WebGL.
+            // Force-mute all but the leader to avoid stacked audio. The
+            // visual remains identical so users still get N×GPU — they're
+            // warned via the Inspector banner.
+            let isLeader = isAudioLeaderForHTML(source: source, excluding: screen.id)
+            var effectiveConfig = htmlConfig
+            if !isLeader, !effectiveConfig.muteAudio {
+                effectiveConfig.muteAudio = true
+                Logger.info("Multi-instance HTML wallpaper: muting screen \(screen.id) (audio leader is another screen running same source)", category: .screenManager)
+            }
+            session = ambientSessionBuilder.makeHTMLSession(source: source, config: effectiveConfig, frame: screen.frame)
+            Logger.info("Set HTML wallpaper for screen \(screen.id) — \(source.displayName) [leader=\(isLeader)]", category: .screenManager)
         case .metalShader(let preset):
             session = ambientSessionBuilder.makeShaderSession(preset: preset, frame: screen.frame)
             Logger.info("Set shader wallpaper (\(preset.rawValue)) for screen \(screen.id)", category: .screenManager)
@@ -1242,6 +1253,41 @@ final class ScreenManager {
                 fullScreenDetector.isDesktopHidden(for: screen.id)
         )
         notifyWallpaperSessionChanged()
+    }
+
+    // MARK: - HTML Multi-Instance Diagnostics
+
+    /// Maps each currently-active HTML source signature to the screens that
+    /// run it. Inspector uses this to surface "also active on N other screen(s)"
+    /// when the user is configuring a wallpaper that's already in use elsewhere.
+    func htmlSourceMultiplicity() -> [String: [CGDirectDisplayID]] {
+        var map: [String: [CGDirectDisplayID]] = [:]
+        for screen in screens {
+            guard screen.runtimeSession?.wallpaperType == .html,
+                  let config = configurationStore.get(for: screen.id),
+                  case .html(let source, _) = config.activeWallpaper else { continue }
+            map[source.diagnosticSignature, default: []].append(screen.id)
+        }
+        return map
+    }
+
+    /// Screens (other than `excluding`) currently running the same HTML source.
+    func screensRunningSameHTMLSource(as source: HTMLSource, excluding: CGDirectDisplayID) -> [Screen] {
+        let signature = source.diagnosticSignature
+        return screens.filter { other in
+            other.id != excluding
+                && other.runtimeSession?.wallpaperType == .html
+                && (configurationStore.get(for: other.id)?.activeWallpaper).flatMap { content -> String? in
+                    if case .html(let s, _) = content { return s.diagnosticSignature }
+                    return nil
+                } == signature
+        }
+    }
+
+    /// True when no other screen is already playing this HTML source — the
+    /// caller becomes the audio leader.
+    private func isAudioLeaderForHTML(source: HTMLSource, excluding screenID: CGDirectDisplayID) -> Bool {
+        screensRunningSameHTMLSource(as: source, excluding: screenID).isEmpty
     }
 
     // MARK: - HTML Wallpaper

--- a/LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift
@@ -37,6 +37,7 @@ struct HTMLSourceSection: View {
                     insecureURLBanner
                 }
                 if let source { trustBanner(for: source) }
+                if let source { multiInstanceBanner(for: source) }
 
                 Divider()
 
@@ -137,6 +138,31 @@ struct HTMLSourceSection: View {
             .padding(.vertical, 4)
             .padding(.horizontal, 8)
             .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    @ViewBuilder
+    private func multiInstanceBanner(for source: HTMLSource) -> some View {
+        let others = screenManager.screensRunningSameHTMLSource(as: source, excluding: screen.id)
+        if !others.isEmpty {
+            let names = others.map(\.name).joined(separator: ", ")
+            HStack(spacing: 8) {
+                Image(systemName: "rectangle.on.rectangle.angled")
+                    .foregroundStyle(.indigo)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Same wallpaper is running on \(others.count) other screen\(others.count == 1 ? "" : "s")")
+                        .font(.caption)
+                    Text("Audio is locked to the first screen. GPU cost scales with screen count — consider a different source per display.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .help("Also active on: \(names)")
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .background(Color.indigo.opacity(0.10), in: RoundedRectangle(cornerRadius: 6))
+        }
     }
 
     @ViewBuilder

--- a/LiveWallpaperTests/HTMLSourceMultiplicityTests.swift
+++ b/LiveWallpaperTests/HTMLSourceMultiplicityTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import LiveWallpaper
+
+@Suite("HTMLSource diagnostic signature")
+struct HTMLSourceDiagnosticSignatureTests {
+
+    @Test("Same URL produces identical signature")
+    func sameURLEqualSignatures() {
+        let a = HTMLSource.url(URL(string: "https://shadertoy.com/view/abc")!)
+        let b = HTMLSource.url(URL(string: "https://shadertoy.com/view/abc")!)
+        #expect(a.diagnosticSignature == b.diagnosticSignature)
+    }
+
+    @Test("Different URLs produce different signatures")
+    func differentURLsDistinct() {
+        let a = HTMLSource.url(URL(string: "https://a.com")!)
+        let b = HTMLSource.url(URL(string: "https://b.com")!)
+        #expect(a.diagnosticSignature != b.diagnosticSignature)
+    }
+
+    @Test("Folder source signature includes index file name")
+    func folderSignatureIncludesIndex() {
+        let bookmark = Data([0x01, 0x02])
+        let withIndex = HTMLSource.folder(bookmarkData: bookmark, indexFileName: "index.html")
+        let withOther = HTMLSource.folder(bookmarkData: bookmark, indexFileName: "main.html")
+        #expect(withIndex.diagnosticSignature != withOther.diagnosticSignature)
+    }
+
+    @Test("File and folder with same bookmark are different")
+    func fileVsFolderDistinct() {
+        let bookmark = Data([0xFF])
+        let f = HTMLSource.file(bookmarkData: bookmark)
+        let d = HTMLSource.folder(bookmarkData: bookmark, indexFileName: "index.html")
+        #expect(f.diagnosticSignature != d.diagnosticSignature)
+    }
+
+    @Test("Inline content signature is stable across instances of same string")
+    func inlineSignatureStable() {
+        let a = HTMLSource.inline("<h1>Hello</h1>")
+        let b = HTMLSource.inline("<h1>Hello</h1>")
+        #expect(a.diagnosticSignature == b.diagnosticSignature)
+    }
+}


### PR DESCRIPTION
## Summary

When the same HTML source runs on multiple screens (very common with WPE folders + multi-display setups), every screen spins up an independent `WKWebView` that decodes audio + renders WebGL independently. Visually each screen looks fine but:

1. **Audio stacks N×** — turning on volume reveals N copies of every sound layered on top of each other.
2. **GPU cost scales with screen count** — on Retina dual-4K with a Pixi/Spine wallpaper this can saturate the GPU even though no individual screen *looks* overloaded.
3. **With audio muted (the default for WPE), neither symptom is visible** — the user pays 2× / 3× resource cost without knowing. This is the user-reported \"can't detect multi-instance because sound is off\" issue.

## Fix

| Component | Change |
|---|---|
| `HTMLSource.diagnosticSignature` | Stable string identity for cross-screen comparison (Equatable already gave us `==` but Dictionary keys + Set membership need a string handle that doesn't depend on Hashable conformance churn). |
| `ScreenManager.htmlSourceMultiplicity()` | Returns `[signature: [screenIDs]]` — primary diagnostic API for inspector / future automation. |
| `ScreenManager.screensRunningSameHTMLSource(as:excluding:)` | Convenience for the inspector banner. |
| `ScreenManager.activateAmbientWallpaper(.html(...))` | Elects an **audio leader** (first screen to load the source). Late joiners get `effective.muteAudio = true` regardless of `HTMLConfig` — visual stays identical, audio cost is 1× instead of N×. |
| `HTMLSourceSection` (inspector) | Indigo banner appears when the current source is also running on ≥1 other screen, names them in the tooltip and explains the GPU-cost tradeoff. |

## Test plan

- [x] **5 new tests** for `HTMLSource.diagnosticSignature` covering URL equality, URL divergence, folder index sensitivity, file-vs-folder distinction, inline stability.
- [x] **198 tests / 40 suites pass** (was 193 / 39).
- [x] Build clean.
- [ ] **Manual**:
  1. Apply the same WPE folder to two displays.
  2. Console.app should show: `📢 Multi-instance HTML wallpaper: muting screen <ID> (audio leader is another screen running same source)` for the second screen.
  3. Inspector for either screen shows indigo banner: \"Same wallpaper is running on 1 other screen\".
  4. Turn audio on (set `HTMLConfig.muteAudio = false` via inspector toggle): only one screen should make sound.
  5. Single-screen mode: banner hidden, no muting.

## Why a banner instead of auto-deduplicating

Two screens running the same wallpaper *visually* is sometimes intentional (matching ambient setup). The fix preserves that user choice while making the cost explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)