### PR TITLE
fix(wpe): Scene tab preview clip overflow + constraint cycle

### DIFF
--- a/LiveWallpaper/Views/ScreenDetail/WPEPreviewView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEPreviewView.swift
@@ -29,7 +29,8 @@ struct WPEPreviewView: View {
                 )
             }
         }
-        .aspectRatio(16/9, contentMode: .fill)
+        .aspectRatio(16/9, contentMode: .fit)
+        .clipped()
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .shadow(color: Color.black.opacity(0.12), radius: 6, y: 2)
     }
@@ -43,6 +44,11 @@ private struct AnimatedImage: NSViewRepresentable {
         let imageView = NSImageView()
         imageView.imageScaling = .scaleProportionallyUpOrDown
         imageView.animates = true
+        // Layer-back so SwiftUI's clipShape reliably clips animated-GIF frames
+        // drawn through CoreAnimation. Without this, AppKit-side layers can
+        // paint past the SwiftUI clip during animated transitions.
+        imageView.wantsLayer = true
+        imageView.layer?.masksToBounds = true
         return imageView
     }
 

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
@@ -22,8 +22,12 @@ struct WPESceneSection: View {
                 historyList
             }
         }
+        // Animate only the empty↔grid transition (both pure-SwiftUI subtrees).
+        // Cross-branch animation into `unsupportedDetail` is deliberately
+        // skipped because that branch hosts `WPEPreviewView` (NSViewRepresentable)
+        // and animating across NSView boundaries triggers an AppKit Auto-Layout
+        // constraint cycle (`needs Update Constraints in Window pass …`).
         .animation(.default, value: recentImports.isEmpty)
-        .animation(.default, value: selectedHistoryEntry?.id)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear { reloadHistory() }
         .onReceive(NotificationCenter.default.publisher(for: .wpeImportDidComplete)) { notification in
@@ -152,17 +156,22 @@ struct WPESceneSection: View {
     /// Plan §A4/A5: when a `scene` / `application` / `unknown` import lands for
     /// THIS screen, auto-promote the user into the unsupported placeholder card
     /// so they see the preview + tip without having to dig through the grid.
+    /// Defers state mutation to the next runloop tick so we don't ask SwiftUI
+    /// to switch branches (and remount `NSViewRepresentable` previews) during
+    /// the same body evaluation that just refreshed `recentImports`.
     private func selectUnsupportedImportIfNeeded(from notification: Notification) {
         guard let screenID = notification.userInfo?["screenID"] as? CGDirectDisplayID,
               screenID == screen.id,
               let rawType = notification.userInfo?["type"] as? String,
               let type = WPEType(rawValue: rawType) else { return }
 
-        switch type {
-        case .scene, .application, .unknown:
-            selectedHistoryEntry = recentImports.first { $0.origin.originalType == type }
-        case .video, .web:
-            selectedHistoryEntry = nil
+        DispatchQueue.main.async {
+            switch type {
+            case .scene, .application, .unknown:
+                selectedHistoryEntry = recentImports.first { $0.origin.originalType == type }
+            case .video, .web:
+                selectedHistoryEntry = nil
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #6 (already merged). Two issues surfaced when importing a scene-type Wallpaper Engine project via the new Scene tab:

### Bug 1: Preview overflow
Animated GIF previews painted past the rounded card boundary in the recent-imports grid (visible as a "rainbow" image leaking out of its rounded frame).

**Root cause**: `WPEPreviewView` used `aspectRatio(16/9, contentMode: .fill)` which lets content exceed its 16:9 box. SwiftUI's `clipShape` cannot reliably clip an `NSImageView`'s CALayer-drawn frames across the SwiftUI/AppKit boundary — the GIF frames render outside the SwiftUI compositor's reach.

**Fix**:
- Switch to `.fit` and add explicit `.clipped()` so the SwiftUI layer enforces a hard bound
- Make the underlying `NSImageView` layer-backed with `wantsLayer = true` + `layer.masksToBounds = true` so the GIF frames are also clipped on the AppKit side

### Bug 2: NSWindow constraint cycle warning
SwiftUI logged repeatedly when an unsupported (scene/application) import landed:
```
The window has been marked as needing another Update Constraints in Window pass,
but it has already had more Update Constraints in Window passes than there are
views in the window.
```

**Root cause**: `.animation(.default, value: selectedHistoryEntry?.id)` was animating the `historyList` ↔ `unsupportedDetail` branch swap. The unsupported branch mounts a `WPEPreviewView` (`NSViewRepresentable`). The SwiftUI animation triggered AppKit Auto-Layout passes that — mid-transition — asked for more updates, looping until the watchdog tripped.

**Fix**:
- Keep animation only on the empty↔grid transition (both pure SwiftUI subtrees, no NSView interop)
- Defer `selectedHistoryEntry` mutation in the auto-promote handler to the next runloop tick via `DispatchQueue.main.async` so the branch swap doesn't race with the `recentImports` refresh that landed in the same `.onReceive` cycle

## Notes on unrelated console noise

The same console session also showed:
- `<<<< FigFilePlayer >>>> signalled err=-12860` — `kFigFilePlayerError_InvalidMediaFile` from the **already-running** video wallpaper on `MPG321CX OLED` (its sidebar shows `Playing`). Scene import is non-destructive for `case .unsupported` (does not touch `activeWallpaper`), so this isn't related to the WPE flow.
- `NSXPCDecoder validateAllowedClass …` — Apple WebKit/CoreServices XPC forward-compat warning under macOS 26 SDK; not user-actionable.

These have been left alone as out-of-scope.

## Test plan

- [x] `xcodebuild -scheme LiveWallpaper test` — **TEST SUCCEEDED**
- [x] All 22 WPE tests + existing UI tests pass
- [ ] Manual repro: import the same scene fixture (`~/Documents/Live Wallpapers/431960/3351072238/`) and confirm:
  - The history grid renders preview thumbnails fully inside the rounded card boundary (no overflow)
  - The unsupported placeholder card surfaces without spamming `Update Constraints in Window pass` warnings
  - Existing video wallpaper on the other screen continues playing untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)