### PR TITLE
fix(wpe): preview thumbnails fill (Apple Photos thumbnail style)

### DIFF
--- a/LiveWallpaper/Views/ScreenDetail/WPEPreviewView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEPreviewView.swift
@@ -1,11 +1,14 @@
 import SwiftUI
 import AppKit
+import ImageIO
 
-/// 16:9 preview tile for a Wallpaper Engine project. Wraps `NSImageView` so
-/// `preview.gif` plays its frames natively; static jpg/png are also rendered.
-/// Eagerly loads bytes inside the caller's security-scoped bookmark so the
-/// image survives sandbox restrictions (`NSImage(byReferencing:)` is lazy
-/// and would fail after scope expiration).
+/// 16:9 preview tile for a Wallpaper Engine project.
+///
+/// Renders into a CALayer with `contentsGravity = .resizeAspectFill` so
+/// previews of any source aspect (square — WPE editor's 512×512 default,
+/// 16:9 wallpapers, 9:16 vertical, etc.) fill the slot without dead bars.
+/// GIF animation is preserved by stepping `CGImageSource` frames manually
+/// (NSImageView's built-in `.animates` cannot pair with `.aspectFill`).
 struct WPEPreviewView: View {
     let imageURL: URL?
     let securityScopedBookmarkData: Data?
@@ -26,7 +29,7 @@ struct WPEPreviewView: View {
                     .font(.system(size: 24))
                     .foregroundStyle(.secondary)
             } else {
-                AnimatedImage(
+                AspectFillImage(
                     imageURL: imageURL,
                     securityScopedBookmarkData: securityScopedBookmarkData,
                     loadAttempt: loadAttempt,
@@ -34,6 +37,7 @@ struct WPEPreviewView: View {
                         loadFailed = !success
                     }
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                 if loadFailed {
                     retryOverlay
@@ -73,36 +77,29 @@ struct WPEPreviewView: View {
     }
 }
 
-private struct AnimatedImage: NSViewRepresentable {
+// MARK: - Aspect-fill bridge
+
+private struct AspectFillImage: NSViewRepresentable {
     let imageURL: URL?
     let securityScopedBookmarkData: Data?
     let loadAttempt: Int
     let onLoadResult: (Bool) -> Void
 
-    func makeNSView(context: Context) -> NSImageView {
-        let imageView = NSImageView()
-        imageView.imageScaling = .scaleProportionallyUpOrDown
-        imageView.animates = true
-        // Layer-back so SwiftUI's clipShape reliably clips animated-GIF frames
-        // drawn through CoreAnimation. Without this, AppKit-side layers can
-        // paint past the SwiftUI clip during animated transitions.
-        imageView.wantsLayer = true
-        imageView.layer?.masksToBounds = true
-        return imageView
+    func makeNSView(context: Context) -> AspectFillAnimatedImageView {
+        AspectFillAnimatedImageView()
     }
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
 
-    func updateNSView(_ nsView: NSImageView, context: Context) {
+    func updateNSView(_ nsView: AspectFillAnimatedImageView, context: Context) {
         guard let url = imageURL else {
             context.coordinator.reset()
-            nsView.image = nil
+            nsView.clearImage()
             return
         }
 
-        // Re-evaluate whenever URL OR loadAttempt changes; otherwise skip.
         if context.coordinator.currentURL == url,
            context.coordinator.lastAttempt == loadAttempt {
             return
@@ -111,16 +108,13 @@ private struct AnimatedImage: NSViewRepresentable {
         context.coordinator.currentURL = url
         context.coordinator.lastAttempt = loadAttempt
 
-        let image = loadImage(from: url)
-        nsView.image = image
-        // Defer state mutation off the current render frame to avoid
-        // "modifying state during view update" warnings.
+        let success = loadInto(view: nsView, url: url)
         DispatchQueue.main.async {
-            onLoadResult(image != nil)
+            onLoadResult(success)
         }
     }
 
-    private func loadImage(from url: URL) -> NSImage? {
+    private func loadInto(view: AspectFillAnimatedImageView, url: URL) -> Bool {
         var scopedURL: URL?
         if let securityScopedBookmarkData {
             var isStale = false
@@ -135,8 +129,11 @@ private struct AnimatedImage: NSViewRepresentable {
         let didStart = scopedURL?.startAccessingSecurityScopedResource() ?? false
         defer { if didStart { scopedURL?.stopAccessingSecurityScopedResource() } }
 
-        guard let data = try? Data(contentsOf: url) else { return nil }
-        return NSImage(data: data)
+        guard let data = try? Data(contentsOf: url) else {
+            view.clearImage()
+            return false
+        }
+        return view.setImage(data: data)
     }
 
     final class Coordinator {
@@ -146,6 +143,131 @@ private struct AnimatedImage: NSViewRepresentable {
         func reset() {
             currentURL = nil
             lastAttempt = 0
+        }
+    }
+}
+
+/// CALayer-backed image view with aspect-fill semantics + manual GIF/APNG
+/// frame stepping. We use this instead of `NSImageView` because the latter
+/// only offers fit-style scaling — we need fill-with-crop ("Apple Photos
+/// thumbnail mode") so square 512×512 WPE previews don't render with
+/// horizontal letterbox bars.
+private final class AspectFillAnimatedImageView: NSView {
+    private var imageSource: CGImageSource?
+    private var frameCount: Int = 0
+    private var currentFrameIndex: Int = 0
+    private var frameDelays: [TimeInterval] = []
+    private var animationTimer: Timer?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        let imageLayer = CALayer()
+        imageLayer.contentsGravity = .resizeAspectFill
+        imageLayer.masksToBounds = true
+        imageLayer.frame = bounds
+        imageLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+        layer = imageLayer
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override var intrinsicContentSize: NSSize { .zero }
+
+    // No deinit-side timer invalidation: every Timer is captured weakly
+    // (closures use `[weak self]`), and `setImage` / `clearImage` invalidate
+    // the prior timer before scheduling new work or tearing down. Swift 6
+    // disallows touching non-Sendable Timer from a nonisolated deinit anyway.
+
+    /// Returns `true` on success, `false` on decode failure.
+    @discardableResult
+    func setImage(data: Data) -> Bool {
+        animationTimer?.invalidate()
+        animationTimer = nil
+        currentFrameIndex = 0
+        frameCount = 0
+        frameDelays = []
+
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            layer?.contents = nil
+            imageSource = nil
+            return false
+        }
+
+        let count = CGImageSourceGetCount(source)
+        guard count > 0,
+              let firstFrame = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            layer?.contents = nil
+            imageSource = nil
+            return false
+        }
+
+        imageSource = source
+        frameCount = count
+        layer?.contents = firstFrame
+
+        if count > 1 {
+            frameDelays = Self.readFrameDelays(from: source, frameCount: count)
+            scheduleNextFrame()
+        }
+        return true
+    }
+
+    func clearImage() {
+        animationTimer?.invalidate()
+        animationTimer = nil
+        imageSource = nil
+        frameCount = 0
+        currentFrameIndex = 0
+        frameDelays = []
+        layer?.contents = nil
+    }
+
+    private func scheduleNextFrame() {
+        guard frameCount > 1, imageSource != nil else { return }
+        let delay = frameDelays.indices.contains(currentFrameIndex)
+            ? frameDelays[currentFrameIndex]
+            : 0.1
+        animationTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            self?.advanceFrame()
+        }
+    }
+
+    private func advanceFrame() {
+        guard let source = imageSource, frameCount > 1 else { return }
+        currentFrameIndex = (currentFrameIndex + 1) % frameCount
+        if let next = CGImageSourceCreateImageAtIndex(source, currentFrameIndex, nil) {
+            layer?.contents = next
+        }
+        scheduleNextFrame()
+    }
+
+    private static func readFrameDelays(from source: CGImageSource, frameCount: Int) -> [TimeInterval] {
+        (0..<frameCount).map { idx in
+            guard let props = CGImageSourceCopyPropertiesAtIndex(source, idx, nil) as? [String: Any] else {
+                return 0.1
+            }
+            // GIF
+            if let gif = props[kCGImagePropertyGIFDictionary as String] as? [String: Any] {
+                if let unclamped = (gif[kCGImagePropertyGIFUnclampedDelayTime as String] as? NSNumber)?.doubleValue, unclamped > 0 {
+                    return max(unclamped, 0.02)
+                }
+                if let delay = (gif[kCGImagePropertyGIFDelayTime as String] as? NSNumber)?.doubleValue, delay > 0 {
+                    return max(delay, 0.02)
+                }
+            }
+            // APNG
+            if let png = props[kCGImagePropertyPNGDictionary as String] as? [String: Any] {
+                if let delay = (png[kCGImagePropertyAPNGUnclampedDelayTime as String] as? NSNumber)?.doubleValue, delay > 0 {
+                    return max(delay, 0.02)
+                }
+                if let delay = (png[kCGImagePropertyAPNGDelayTime as String] as? NSNumber)?.doubleValue, delay > 0 {
+                    return max(delay, 0.02)
+                }
+            }
+            return 0.1
         }
     }
 }


### PR DESCRIPTION
## Summary

WPE Workshop preview images come in three common aspects:
- **1:1 square** — the Wallpaper Engine editor's "Generate preview" produces 512×512 by default
- **16:9 horizontal** — creators using the wallpaper's native aspect
- **9:16 vertical** — mobile-oriented wallpapers

The previous `NSImageView` with `.scaleProportionallyUpOrDown` mode behaved like SwiftUI's `.fit` — square previews rendered with horizontal letterbox bars inside the 16:9 card slot, looking awkward in the history grid and Workshop gallery (and outright unusable in the unsupported-card detail view at 320pt).

## Approach (Option A — confirmed by user)

Apple Photos thumbnail behavior: the image fills its container and crop-overshoots the long axis. To get this working with animated GIFs (NSImageView's built-in `.animates` cannot pair with `.aspectFill`), I replace the entire bridge:

| Before | After |
|---|---|
| `NSImageView` + `imageScaling = .scaleProportionallyUpOrDown` | Custom `AspectFillAnimatedImageView: NSView` |
| Built-in `.animates = true` (driven by `NSImage`) | `CGImageSource` + per-frame one-shot Timer |
| Layout via `intrinsicContentSize = imageSize` | Layout via `intrinsicContentSize = .zero` (SwiftUI is sole source of truth) |
| Visual: `.fit` letterbox on non-16:9 sources | Visual: `.aspectFill` + `masksToBounds` clip |

### Implementation notes
- `layer.contentsGravity = .resizeAspectFill` + `masksToBounds = true` gives the cropping behavior
- GIF/APNG frame stepping reads delays from `kCGImagePropertyGIFDictionary` / `kCGImagePropertyPNGDictionary` (with sane fallbacks for malformed timing data, minimum 20ms)
- Timer callback uses `[weak self]`; every prior timer is invalidated in `setImage` / `clearImage` so there's no Swift 6 nonisolated-deinit hazard (which is why there's no explicit `deinit` — verified to compile with strict concurrency)
- 4K/8K Workshop previews can no longer punch through the surrounding `clipShape` even before the outer `.aspectRatio(.fit)` clamp

### Public API unchanged
`WPEPreviewView(imageURL:securityScopedBookmarkData:)` keeps its signature, so all 3 callers (`WPEHistoryRow`, `WPEUnsupportedCard`, `WorkshopGalleryCard`) get the new visual behavior with no edits.

## Test plan

- [x] `xcodebuild` build succeeds (Swift 6 strict concurrency)
- [x] Full test suite: **255/256 passed, 0 failed** (the 1 unrun is the UI-test bundle which runs in a separate Xcode action)
- [ ] Manual visual: open the app, Scene tab → import a square `preview.gif` Workshop project → verify the history thumbnail fills the card edge-to-edge, no horizontal bars
- [ ] Manual visual: same on Workshop Library Gallery cards
- [ ] Manual visual: same in `WPEUnsupportedCard` (320pt-wide preview) when tapping a `.scene` history entry
- [ ] Manual visual: 4K-resolution `preview.gif` does not visually overflow the rounded card boundary at any of the 3 sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)