### PR TITLE
feat(wpe): onboarding revamp, UI tokens, off-main I/O, streaming PKG

### DIFF
--- a/LiveWallpaper/Infrastructure/WallpaperEngineCache.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineCache.swift
@@ -33,8 +33,7 @@ actor WallpaperEngineCache {
 
     func ensureExtracted(workshopID: String, sourcePkgURL: URL) async throws -> URL {
         let cacheURL = try cacheDirectory(for: workshopID)
-        let sourcePackage = try readSourcePackage(sourcePkgURL)
-        let fingerprint = sourcePackage.fingerprint
+        let fingerprint = try fingerprint(for: sourcePkgURL)
 
         if let manifest = readManifest(in: cacheURL),
            manifest.fingerprint == fingerprint,
@@ -44,17 +43,24 @@ actor WallpaperEngineCache {
         }
 
         Logger.info("WPE cache extracting workshop \(workshopID)", category: .screenManager)
-        let data = sourcePackage.data
-
         do {
-            let package = try WallpaperEnginePackage.parseIndex(of: data)
-            try package.extractAll(from: data, to: cacheURL)
+            // Streaming parse + extract: reads the index from the pkg's
+            // header bytes, then per-entry seeks the same handle. Memory
+            // peak is bounded by the 1 MiB chunk inside the package.
+            let handle = try FileHandle(forReadingFrom: sourcePkgURL)
+            defer { try? handle.close() }
+
+            let package = try WallpaperEnginePackage.parseIndex(streamingFrom: handle)
+            try package.extractAll(streamingFrom: handle, to: cacheURL)
             try writeManifest(
                 Manifest(fingerprint: fingerprint, extractedAt: Date().timeIntervalSince1970),
                 in: cacheURL
             )
             Logger.info("WPE cache extracted workshop \(workshopID)", category: .screenManager)
             return cacheURL
+        } catch let error as WPECacheError {
+            Logger.error("WPE extraction failed: \(error.localizedDescription)", category: .screenManager)
+            throw error
         } catch {
             Logger.error("WPE extraction failed: \(error.localizedDescription)", category: .screenManager)
             throw WPECacheError.extractionFailed(String(describing: error))
@@ -205,18 +211,10 @@ actor WallpaperEngineCache {
         cacheURL.appendingPathComponent("manifest.json")
     }
 
-    private func readSourcePackage(_ sourcePkgURL: URL) throws -> SourcePackage {
-        let data: Data
-        do {
-            data = try Data(contentsOf: sourcePkgURL, options: .mappedIfSafe)
-        } catch {
-            Logger.error("WPE pkg unreadable: \(error.localizedDescription)", category: .screenManager)
-            throw WPECacheError.pkgUnreadable(error.localizedDescription)
-        }
-        return SourcePackage(data: data, fingerprint: try fingerprint(for: sourcePkgURL, data: data))
-    }
-
-    private func fingerprint(for sourcePkgURL: URL, data: Data) throws -> Fingerprint {
+    /// Streaming fingerprint: hashes the source pkg in 64 KiB chunks instead
+    /// of mapping the entire file. Keeps idempotency guarantees (size + mtime
+    /// + sha256) while bounding peak memory regardless of pkg size.
+    private func fingerprint(for sourcePkgURL: URL) throws -> Fingerprint {
         do {
             let values = try sourcePkgURL.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
             guard let size = values.fileSize,
@@ -224,7 +222,8 @@ actor WallpaperEngineCache {
                   let mtime = values.contentModificationDate?.timeIntervalSince1970 else {
                 throw WPECacheError.pkgUnreadable("Missing file metadata")
             }
-            return Fingerprint(size: UInt64(size), mtime: mtime, sha256: Self.sha256Hex(data))
+            let sha = try Self.streamingSHA256Hex(of: sourcePkgURL)
+            return Fingerprint(size: UInt64(size), mtime: mtime, sha256: sha)
         } catch let error as WPECacheError {
             throw error
         } catch {
@@ -232,8 +231,15 @@ actor WallpaperEngineCache {
         }
     }
 
-    private static func sha256Hex(_ data: Data) -> String {
-        SHA256.hash(data: data)
+    private static func streamingSHA256Hex(of url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        let chunkSize = 64 * 1024
+        while let chunk = try handle.read(upToCount: chunkSize), !chunk.isEmpty {
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize()
             .map { String(format: "%02x", $0) }
             .joined()
     }
@@ -262,11 +268,6 @@ actor WallpaperEngineCache {
 private struct Manifest: Codable, Equatable, Sendable {
     let fingerprint: Fingerprint
     let extractedAt: Double
-}
-
-private struct SourcePackage: Sendable {
-    let data: Data
-    let fingerprint: Fingerprint
 }
 
 private struct Fingerprint: Codable, Equatable, Sendable {

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -58,11 +58,24 @@ final class WallpaperEngineImportService {
         folderURL: URL,
         sourceBookmark: Data
     ) async -> ImportResult {
+        // WPE distributes video wallpapers in two shapes (per
+        // help.wallpaperengine.io and linux-wallpaperengine docs):
+        //   1) packaged: `scene.pkg` archive containing the video file,
+        //   2) unpackaged: `<entryFile>` directly inside the project folder.
+        // Both are valid; rejecting unpackaged videos cuts off the majority
+        // of community video wallpapers.
         let pkgURL = folderURL.appendingPathComponent("scene.pkg")
-        guard fileManager.fileExists(atPath: pkgURL.path) else {
-            return .rejected(reason: "Missing scene.pkg")
+        if fileManager.fileExists(atPath: pkgURL.path) {
+            return await importPackagedVideo(project: project, pkgURL: pkgURL, sourceBookmark: sourceBookmark)
         }
+        return await importUnpackagedVideo(project: project, folderURL: folderURL, sourceBookmark: sourceBookmark)
+    }
 
+    private func importPackagedVideo(
+        project: WallpaperEngineProject,
+        pkgURL: URL,
+        sourceBookmark: Data
+    ) async -> ImportResult {
         let cacheResult = await ensureExtracted(project: project, pkgURL: pkgURL)
         guard case .success(let cacheURL) = cacheResult else {
             if case .failure(let failure) = cacheResult { return .rejected(reason: failure.reason) }
@@ -89,6 +102,37 @@ final class WallpaperEngineImportService {
             sourceBookmark: sourceBookmark,
             cacheRelativePath: cacheRelativePath(for: project),
             resourceLocation: .cache
+        )
+        return .ready(.video(bookmarkData: videoBookmark), origin: origin)
+    }
+
+    private func importUnpackagedVideo(
+        project: WallpaperEngineProject,
+        folderURL: URL,
+        sourceBookmark: Data
+    ) async -> ImportResult {
+        guard let videoURL = resourceURL(root: folderURL, relativePath: project.entryFile),
+              fileManager.fileExists(atPath: videoURL.path) else {
+            return .rejected(reason: "Missing video entry \(project.entryFile)")
+        }
+
+        do {
+            try await validateVideo(videoURL)
+        } catch {
+            return .rejected(reason: describe(error))
+        }
+
+        guard let videoBookmark = makeBookmark(videoURL) else {
+            return .rejected(reason: "Cannot create video bookmark")
+        }
+
+        // Source-folder backed: cacheRelativePath is nil; reconcile uses
+        // the source-folder bookmark's prefix-path match to keep the badge.
+        let origin = makeOrigin(
+            project: project,
+            sourceBookmark: sourceBookmark,
+            cacheRelativePath: nil,
+            resourceLocation: .sourceFolder
         )
         return .ready(.video(bookmarkData: videoBookmark), origin: origin)
     }
@@ -245,15 +289,21 @@ struct WPECachedContentResolver {
     func content(for origin: WPEOrigin) -> WallpaperContent? {
         guard origin.resourceLocation == .cache,
               let cacheRelativePath = origin.cacheRelativePath,
-              !cacheRelativePath.isEmpty,
+              Self.isSafeCacheRelativePath(cacheRelativePath),
               let entryFile = origin.entryFile,
               !entryFile.isEmpty else {
             return nil
         }
 
+        let rootPath = applicationSupportRootURL.standardizedFileURL.path
         let cacheURL = applicationSupportRootURL
             .appendingPathComponent(cacheRelativePath, isDirectory: true)
             .standardizedFileURL
+        // Defense-in-depth: refuse persisted paths that escape the
+        // application-support root after standardization.
+        guard cacheURL.path == rootPath || cacheURL.path.hasPrefix(rootPath + "/") else {
+            return nil
+        }
         guard let entryURL = resourceURL(root: cacheURL, relativePath: entryFile),
               fileManager.fileExists(atPath: entryURL.path) else {
             return nil
@@ -282,5 +332,16 @@ struct WPECachedContentResolver {
             .resolvingSymlinksInPath()
         guard url.path.hasPrefix(rootURL.path + "/") else { return nil }
         return url
+    }
+
+    /// Rejects malformed persisted cache paths before they get appended to the
+    /// application-support root. Mirrors the rules enforced when writing.
+    /// Requires the `wpe-cache/` prefix so persisted state can never resolve
+    /// to a sibling subtree under `Application Support/LiveWallpaper/`.
+    fileprivate static func isSafeCacheRelativePath(_ path: String) -> Bool {
+        path.hasPrefix("wpe-cache/")
+            && !path.contains("\\")
+            && !path.contains("..")
+            && !path.contains("//")
     }
 }

--- a/LiveWallpaper/Infrastructure/WallpaperEngineLibraryScanner.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineLibraryScanner.swift
@@ -3,8 +3,17 @@ import Foundation
 /// Scans a user-granted Steam Workshop root (e.g. `~/Documents/Live Wallpapers/431960/`)
 /// and returns metadata for every valid Wallpaper Engine project found inside.
 /// Used by the Workshop Library Gallery for bulk-discovery + selective import.
-@MainActor
-final class WallpaperEngineLibraryScanner {
+///
+/// Off-main: heavy directory enumeration + per-project JSON decoding runs on
+/// a detached cooperative task so very large libraries don't hang the UI.
+/// Caller (which is @MainActor) is responsible for resolving the persisted
+/// bookmark + already-imported set first, since both depend on the
+/// `@MainActor`-isolated `SettingsManager`.
+///
+/// `@unchecked Sendable`: `FileManager.default` is documented thread-safe for
+/// the read-only operations we use (enumeration, existence checks). All other
+/// stored state is immutable by construction.
+final class WallpaperEngineLibraryScanner: @unchecked Sendable {
 
     enum ScanError: Error, Equatable, Sendable {
         case rootBookmarkMissing
@@ -12,9 +21,10 @@ final class WallpaperEngineLibraryScanner {
     }
 
     /// Snapshot of one project discovered under the workshop root.
-    /// Carries the shared `libraryRootBookmarkData` so the gallery can re-acquire
-    /// security scope for each child URL after the scan returns — `scan()`'s
-    /// own `startAccessingSecurityScopedResource` lifetime ends with the call.
+    /// Carries the shared `libraryRootBookmarkData` so the gallery can
+    /// re-acquire security scope for each child URL after the scan returns —
+    /// `scan()`'s own `startAccessingSecurityScopedResource` lifetime ends
+    /// with the call.
     struct DiscoveredProject: Sendable, Identifiable {
         let workshopID: String
         let title: String
@@ -29,34 +39,46 @@ final class WallpaperEngineLibraryScanner {
     }
 
     private let fileManager: FileManager
-    private let importedWorkshopIDs: () -> Set<String>
 
-    init(
-        fileManager: FileManager = .default,
-        importedWorkshopIDs: @escaping () -> Set<String> = {
-            Set(SettingsManager.shared.loadGlobalSettings().recentWPEImports.map(\.origin.workshopID))
-        }
-    ) {
+    init(fileManager: FileManager = .default) {
         self.fileManager = fileManager
-        self.importedWorkshopIDs = importedWorkshopIDs
     }
 
-    /// Resolves the persisted security-scoped bookmark and walks the immediate
-    /// children of the root, parsing each `<workshopID>/project.json`.
-    /// Skips children that are not directories or whose project.json is
-    /// missing / malformed — they're not part of a WPE library by definition.
-    func scan() async throws -> [DiscoveredProject] {
-        guard let bookmark = SettingsManager.shared.loadWorkshopLibraryRootBookmark() else {
-            throw ScanError.rootBookmarkMissing
-        }
+    /// Off-main scan. Resolves `rootBookmarkData`, walks the immediate
+    /// children of the root, and parses each `<workshopID>/project.json`.
+    /// Children that are not directories or whose project.json is missing
+    /// or malformed are silently skipped — they're not part of a WPE
+    /// library by definition.
+    func scan(
+        rootBookmarkData: Data,
+        alreadyImportedWorkshopIDs: Set<String>
+    ) async throws -> [DiscoveredProject] {
+        try await Task.detached(priority: .userInitiated) { [fileManager] in
+            try Self.performScan(
+                rootBookmarkData: rootBookmarkData,
+                alreadyImportedWorkshopIDs: alreadyImportedWorkshopIDs,
+                fileManager: fileManager
+            )
+        }.value
+    }
 
+    private static func performScan(
+        rootBookmarkData: Data,
+        alreadyImportedWorkshopIDs: Set<String>,
+        fileManager: FileManager
+    ) throws -> [DiscoveredProject] {
         var isStale = false
-        let rootURL = try URL(
-            resolvingBookmarkData: bookmark,
-            options: .withSecurityScope,
-            relativeTo: nil,
-            bookmarkDataIsStale: &isStale
-        )
+        let rootURL: URL
+        do {
+            rootURL = try URL(
+                resolvingBookmarkData: rootBookmarkData,
+                options: .withSecurityScope,
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+        } catch {
+            throw ScanError.rootInaccessible(error.localizedDescription)
+        }
 
         let didStartScope = rootURL.startAccessingSecurityScopedResource()
         defer { if didStartScope { rootURL.stopAccessingSecurityScopedResource() } }
@@ -72,7 +94,6 @@ final class WallpaperEngineLibraryScanner {
             throw ScanError.rootInaccessible(error.localizedDescription)
         }
 
-        let alreadyImported = importedWorkshopIDs()
         var results: [DiscoveredProject] = []
 
         for child in children {
@@ -95,8 +116,8 @@ final class WallpaperEngineLibraryScanner {
                 entryFile: project.entryFile,
                 folderURL: child,
                 previewURL: previewURL,
-                importedAlready: alreadyImported.contains(project.workshopID),
-                libraryRootBookmarkData: bookmark
+                importedAlready: alreadyImportedWorkshopIDs.contains(project.workshopID),
+                libraryRootBookmarkData: rootBookmarkData
             ))
         }
 
@@ -110,7 +131,7 @@ final class WallpaperEngineLibraryScanner {
         return results
     }
 
-    private func compatibilityRank(_ type: WPEType) -> Int {
+    private static func compatibilityRank(_ type: WPEType) -> Int {
         switch type {
         case .video, .web:           return 0
         case .scene:                 return 1

--- a/LiveWallpaper/Infrastructure/WallpaperEnginePackage.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEnginePackage.swift
@@ -37,7 +37,9 @@ struct WallpaperEnginePackage: Sendable, Equatable {
 
         for index in 0..<Int(entryCount) {
             let nameLength = try data.wpeReadU32(cursor: &cursor)
-            guard nameLength >= 1 && nameLength <= 1_024 else {
+            // 255 matches the upstream RePKG reader cap. Generous for every
+            // UTF-8 path observed in real workshops.
+            guard nameLength >= 1 && nameLength <= 255 else {
                 throw WPEPackageError.invalidEntryName(index: index)
             }
 
@@ -69,9 +71,187 @@ struct WallpaperEnginePackage: Sendable, Equatable {
         try dataRange(for: entry, dataCount: Int.max)
     }
 
+    /// Streaming variant of `parseIndex(of:)`. Reads only the header bytes
+    /// from the given handle so multi-hundred-MB packages don't have to be
+    /// memory-mapped just to discover their entry table. The handle's offset
+    /// is left at the start of the payload (i.e. equal to `dataStart`),
+    /// ready for `extractAll(streamingFrom:to:)` to seek per-entry.
+    static func parseIndex(streamingFrom handle: FileHandle) throws -> Self {
+        let totalLength: UInt64
+        do {
+            totalLength = try handle.seekToEnd()
+            try handle.seek(toOffset: 0)
+        } catch {
+            throw WPEPackageError.truncatedHeader
+        }
+
+        var headerData = Data()
+        var cursor = 0
+
+        try Self.streamAppend(into: &headerData, from: handle, count: 4)
+        let magicLength = try headerData.wpeReadU32(cursor: &cursor)
+        guard magicLength >= 4 && magicLength <= 16 else {
+            throw WPEPackageError.invalidMagic("length:\(magicLength)")
+        }
+
+        try Self.streamAppend(into: &headerData, from: handle, count: Int(magicLength))
+        let magic = try headerData.wpeReadString(cursor: &cursor, length: Int(magicLength))
+        guard magic.hasPrefix("PKGV") else {
+            throw WPEPackageError.invalidMagic(magic)
+        }
+
+        try Self.streamAppend(into: &headerData, from: handle, count: 4)
+        let entryCount = try headerData.wpeReadU32(cursor: &cursor)
+        guard entryCount <= 65_535 else {
+            throw WPEPackageError.invalidMagic("entryCount:\(entryCount)")
+        }
+
+        var entries: [Entry] = []
+        entries.reserveCapacity(Int(entryCount))
+        var seenNames = Set<String>()
+
+        for index in 0..<Int(entryCount) {
+            try Self.streamAppend(into: &headerData, from: handle, count: 4)
+            let nameLength = try headerData.wpeReadU32(cursor: &cursor)
+            guard nameLength >= 1 && nameLength <= 255 else {
+                throw WPEPackageError.invalidEntryName(index: index)
+            }
+
+            try Self.streamAppend(into: &headerData, from: handle, count: Int(nameLength))
+            let name = try headerData.wpeReadEntryName(
+                cursor: &cursor,
+                length: Int(nameLength),
+                index: index
+            )
+            guard !name.isEmpty else { throw WPEPackageError.invalidEntryName(index: index) }
+            guard !Self.isUnsafeEntryName(name) else { throw WPEPackageError.pathTraversal(name: name) }
+            guard seenNames.insert(name).inserted else { throw WPEPackageError.duplicateEntry(name: name) }
+
+            try Self.streamAppend(into: &headerData, from: handle, count: 8)
+            let offset = UInt64(try headerData.wpeReadU32(cursor: &cursor))
+            let size = UInt64(try headerData.wpeReadU32(cursor: &cursor))
+            entries.append(Entry(name: name, dataOffset: offset, dataSize: size))
+        }
+
+        let dataStart = UInt64(cursor)
+        // Validate every entry stays within the actual file length without
+        // mapping the payload — bounds checks mirror `parseIndex(of:)`.
+        for entry in entries {
+            let (absoluteStart, startOverflow) = dataStart.addingReportingOverflow(entry.dataOffset)
+            let (absoluteEnd, endOverflow) = absoluteStart.addingReportingOverflow(entry.dataSize)
+            guard !startOverflow, !endOverflow,
+                  absoluteEnd <= totalLength,
+                  absoluteStart <= absoluteEnd else {
+                throw WPEPackageError.entryOutOfBounds(name: entry.name)
+            }
+        }
+        do {
+            try handle.seek(toOffset: dataStart)
+        } catch {
+            throw WPEPackageError.truncatedHeader
+        }
+        return Self(magic: magic, entries: entries, dataStart: dataStart)
+    }
+
+    /// Streaming companion to `extractAll(from:to:)`. Reads each entry from
+    /// the supplied handle in fixed-size chunks and writes it to the
+    /// inflight directory without ever holding the full pkg in memory.
+    /// Same atomicity + crash-recovery behaviour as the Data-based variant.
+    func extractAll(streamingFrom handle: FileHandle, to rootURL: URL) throws {
+        let fileManager = FileManager.default
+        let parentURL = rootURL.deletingLastPathComponent()
+        let rootName = rootURL.lastPathComponent
+        let inflightURL = parentURL.appendingPathComponent("\(rootName).inflight", isDirectory: true)
+        let backupURL = parentURL.appendingPathComponent("\(rootName).replaced", isDirectory: true)
+
+        try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
+
+        if !fileManager.fileExists(atPath: rootURL.path),
+           fileManager.fileExists(atPath: backupURL.path) {
+            try fileManager.moveItem(at: backupURL, to: rootURL)
+        }
+
+        try? fileManager.removeItem(at: inflightURL)
+        try? fileManager.removeItem(at: backupURL)
+        try fileManager.createDirectory(at: inflightURL, withIntermediateDirectories: true)
+
+        let inflightPath = inflightURL.standardizedFileURL.path
+        var movedExistingRoot = false
+
+        do {
+            let chunkSize = 1 << 20  // 1 MiB
+            for entry in entries {
+                let targetURL = inflightURL.appendingPathComponent(entry.name)
+                let standardizedTarget = targetURL.standardizedFileURL
+                guard standardizedTarget.path.hasPrefix(inflightPath + "/") else {
+                    throw WPEPackageError.pathTraversal(name: entry.name)
+                }
+                try fileManager.createDirectory(
+                    at: standardizedTarget.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+
+                let absoluteStart = dataStart + entry.dataOffset
+                try handle.seek(toOffset: absoluteStart)
+
+                fileManager.createFile(atPath: standardizedTarget.path, contents: nil)
+                let writer = try FileHandle(forWritingTo: standardizedTarget)
+                do {
+                    var remaining = entry.dataSize
+                    while remaining > 0 {
+                        let toRead = Int(min(UInt64(chunkSize), remaining))
+                        guard let chunk = try handle.read(upToCount: toRead),
+                              chunk.count == toRead else {
+                            try? writer.close()
+                            throw WPEPackageError.entryOutOfBounds(name: entry.name)
+                        }
+                        try writer.write(contentsOf: chunk)
+                        remaining -= UInt64(chunk.count)
+                    }
+                    try writer.close()
+                } catch {
+                    try? writer.close()
+                    throw error
+                }
+            }
+
+            if fileManager.fileExists(atPath: rootURL.path) {
+                try fileManager.moveItem(at: rootURL, to: backupURL)
+                movedExistingRoot = true
+            }
+            try fileManager.moveItem(at: inflightURL, to: rootURL)
+            if movedExistingRoot {
+                try? fileManager.removeItem(at: backupURL)
+            }
+        } catch {
+            try? fileManager.removeItem(at: inflightURL)
+            if movedExistingRoot,
+               !fileManager.fileExists(atPath: rootURL.path),
+               fileManager.fileExists(atPath: backupURL.path) {
+                try? fileManager.moveItem(at: backupURL, to: rootURL)
+            }
+            throw error
+        }
+    }
+
+    private static func streamAppend(into buffer: inout Data, from handle: FileHandle, count: Int) throws {
+        guard count >= 0 else { throw WPEPackageError.truncatedHeader }
+        guard count > 0 else { return }
+        guard let chunk = try handle.read(upToCount: count), chunk.count == count else {
+            throw WPEPackageError.truncatedHeader
+        }
+        buffer.append(chunk)
+    }
+
     /// Atomic extraction: writes into `<root>.inflight` first, then swaps via
     /// `<root>.replaced` so a partially extracted directory is never observed
     /// at `rootURL`. Rolls back on failure.
+    ///
+    /// Crash recovery: if a previous extract crashed AFTER moving the live
+    /// `rootURL` into `.replaced` but BEFORE moving `.inflight` into place,
+    /// the next launch finds `rootURL` missing while `.replaced` still holds
+    /// the last-good cache. We restore it before any cleanup so the
+    /// pre-existing wallpaper isn't lost just because we tried to replace it.
     func extractAll(from data: Data, to rootURL: URL) throws {
         let fileManager = FileManager.default
         let parentURL = rootURL.deletingLastPathComponent()
@@ -80,6 +260,14 @@ struct WallpaperEnginePackage: Sendable, Equatable {
         let backupURL = parentURL.appendingPathComponent("\(rootName).replaced", isDirectory: true)
 
         try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
+
+        // Restore must succeed before cleanup runs, otherwise the next line
+        // would silently delete the only good copy.
+        if !fileManager.fileExists(atPath: rootURL.path),
+           fileManager.fileExists(atPath: backupURL.path) {
+            try fileManager.moveItem(at: backupURL, to: rootURL)
+        }
+
         try? fileManager.removeItem(at: inflightURL)
         try? fileManager.removeItem(at: backupURL)
         try fileManager.createDirectory(at: inflightURL, withIntermediateDirectories: true)

--- a/LiveWallpaper/Models/WPEOrigin.swift
+++ b/LiveWallpaper/Models/WPEOrigin.swift
@@ -93,7 +93,8 @@ struct WPEOrigin: Codable, Equatable, Sendable {
     }
 
     private static func matchesCacheBookmark(_ bookmarkData: Data, origin: WPEOrigin) -> Bool {
-        guard let cacheRel = origin.cacheRelativePath, !cacheRel.isEmpty else {
+        guard let cacheRel = origin.cacheRelativePath,
+              isSafeCacheRelativePath(cacheRel) else {
             return false
         }
         guard let resolved = resolveBookmark(bookmarkData) else { return false }
@@ -105,13 +106,28 @@ struct WPEOrigin: Codable, Equatable, Sendable {
             create: false
         ) else { return false }
 
-        let expectedURL = appSupport
+        let rootURL = appSupport
             .appendingPathComponent("LiveWallpaper", isDirectory: true)
+            .standardizedFileURL
+        let expectedURL = rootURL
             .appendingPathComponent(cacheRel)
             .standardizedFileURL
+        // Defense-in-depth: reject persisted paths that escape root after
+        // standardization, even if they passed the textual safety check.
+        guard expectedURL.path == rootURL.path
+                || expectedURL.path.hasPrefix(rootURL.path + "/") else {
+            return false
+        }
         let resolvedPath = resolved.standardizedFileURL.path
         let expectedPath = expectedURL.path
         return resolvedPath == expectedPath || resolvedPath.hasPrefix(expectedPath + "/")
+    }
+
+    private static func isSafeCacheRelativePath(_ path: String) -> Bool {
+        path.hasPrefix("wpe-cache/")
+            && !path.contains("\\")
+            && !path.contains("..")
+            && !path.contains("//")
     }
 
     private static func matchesSourceFolderBookmark(_ bookmarkData: Data, origin: WPEOrigin) -> Bool {
@@ -119,8 +135,27 @@ struct WPEOrigin: Codable, Equatable, Sendable {
               let source = resolveBookmark(origin.sourceFolderBookmark) else {
             return false
         }
-        return resolved.standardizedFileURL.resolvingSymlinksInPath().path
-            == source.standardizedFileURL.resolvingSymlinksInPath().path
+        let resolvedPath = resolved.standardizedFileURL.resolvingSymlinksInPath().path
+        let sourceURL = source.standardizedFileURL.resolvingSymlinksInPath()
+        let sourcePath = sourceURL.path
+
+        // Branch by `originalType` so a sibling file inside the same WPE folder
+        // does not falsely keep the badge attached. Web stays folder-anchored;
+        // video must match its declared `entryFile` exactly.
+        switch origin.originalType {
+        case .video:
+            guard let entryFile = origin.entryFile, !entryFile.isEmpty else { return false }
+            let expected = sourceURL
+                .appendingPathComponent(entryFile)
+                .standardizedFileURL
+                .resolvingSymlinksInPath()
+                .path
+            return resolvedPath == expected
+        case .web:
+            return resolvedPath == sourcePath
+        case .scene, .application, .unknown:
+            return false
+        }
     }
 
     private static func resolveBookmark(_ data: Data) -> URL? {

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -51,9 +51,9 @@ final class ScreenManager {
     private(set) var screens: [Screen] = []
     private(set) var wallpaperSessionStateVersion: UInt64 = 0
     private(set) var wallpaperSessionSummaryCache = WallpaperSessionSummaryCache()
-    /// Last error encountered during a Wallpaper Engine import, surfaced for the
-    /// Scene tab UI. `nil` clears any previous error.
-    var lastWPEImportError: AppError?
+    /// Per-screen WPE import error state. Keying on `CGDirectDisplayID` keeps
+    /// concurrent multi-screen imports from overwriting each other's alerts.
+    private(set) var lastWPEImportErrors: [CGDirectDisplayID: AppError] = [:]
 
     @ObservationIgnored private var cleanupTasks: Set<AnyCancellable> = []
     @ObservationIgnored private let displayRegistry = DisplayRegistry()
@@ -938,6 +938,17 @@ final class ScreenManager {
     
     // MARK: - Wallpaper Engine Import
 
+    /// Returns the most recent WPE import error for the given screen, or `nil`.
+    /// Used by the Scene tab to surface failures without bleeding state across
+    /// concurrent imports on different displays.
+    func wpeImportError(for screen: Screen) -> AppError? {
+        lastWPEImportErrors[screen.id]
+    }
+
+    func clearWPEImportError(for screen: Screen) {
+        lastWPEImportErrors.removeValue(forKey: screen.id)
+    }
+
     func importWallpaperEngineProject(at folderURL: URL, for screen: Screen) async {
         let generation = bumpWPEImportGeneration(for: screen.id)
         do {
@@ -955,15 +966,19 @@ final class ScreenManager {
                 SettingsManager.shared.recordWPEImport(
                     WPEHistoryEntry(origin: origin, importedAt: Date(), lastUsedAt: nil)
                 )
-                postWPEImportDidComplete(screenID: screen.id, type: origin.originalType)
-                lastWPEImportError = nil
+                postWPEImportDidComplete(
+                    screenID: screen.id,
+                    type: origin.originalType,
+                    workshopID: origin.workshopID
+                )
+                lastWPEImportErrors.removeValue(forKey: screen.id)
 
             case .rejected(let reason):
-                lastWPEImportError = .wpePackageInvalid(reason)
+                lastWPEImportErrors[screen.id] = .wpePackageInvalid(reason)
             }
         } catch {
             guard isCurrentWPEImportGeneration(generation, for: screen.id) else { return }
-            lastWPEImportError = .wpeImportFailed(error.localizedDescription)
+            lastWPEImportErrors[screen.id] = .wpeImportFailed(error.localizedDescription)
         }
     }
 
@@ -1027,20 +1042,20 @@ final class ScreenManager {
                 if applyCachedWPEHistoryEntry(entry, for: screen) {
                     return
                 }
-                lastWPEImportError = .fileAccessDenied(entry.origin.title)
+                lastWPEImportErrors[screen.id] = .fileAccessDenied(entry.origin.title)
                 return
             }
 
-            lastWPEImportError = nil
+            lastWPEImportErrors.removeValue(forKey: screen.id)
             await importWallpaperEngineProject(at: folderURL, for: screen)
-            if lastWPEImportError != nil {
+            if lastWPEImportErrors[screen.id] != nil {
                 _ = applyCachedWPEHistoryEntry(entry, for: screen)
             }
         } catch {
             if applyCachedWPEHistoryEntry(entry, for: screen) {
                 return
             }
-            lastWPEImportError = .wpeImportFailed(error.localizedDescription)
+            lastWPEImportErrors[screen.id] = .wpeImportFailed(error.localizedDescription)
         }
     }
 
@@ -1053,13 +1068,18 @@ final class ScreenManager {
         }
     }
 
-    private func postWPEImportDidComplete(screenID: CGDirectDisplayID, type: WPEType) {
+    private func postWPEImportDidComplete(
+        screenID: CGDirectDisplayID,
+        type: WPEType,
+        workshopID: String
+    ) {
         NotificationCenter.default.post(
             name: .wpeImportDidComplete,
             object: nil,
             userInfo: [
                 "screenID": screenID,
                 "type": type.rawValue,
+                "workshopID": workshopID,
             ]
         )
     }
@@ -1089,8 +1109,12 @@ final class ScreenManager {
         config.wpeOrigin = origin
         saveConfiguration(config)
         restoreWallpaperSession(for: screen, configuration: config, preservingState: false)
-        postWPEImportDidComplete(screenID: screen.id, type: origin.originalType)
-        lastWPEImportError = nil
+        postWPEImportDidComplete(
+            screenID: screen.id,
+            type: origin.originalType,
+            workshopID: origin.workshopID
+        )
+        lastWPEImportErrors.removeValue(forKey: screen.id)
     }
 
     @discardableResult

--- a/LiveWallpaper/Views/Onboarding/OnboardingStepFirstWallpaper.swift
+++ b/LiveWallpaper/Views/Onboarding/OnboardingStepFirstWallpaper.swift
@@ -9,6 +9,11 @@ struct OnboardingStepFirstWallpaper: View {
     @Environment(ScreenManager.self) private var screenManager
     @State private var isRequestingAerials = false
     @State private var showHTMLSheet = false
+    @State private var showWorkshopGallery = false
+    /// Auto-detected on appear. Drives the WPE entry-point: if the user
+    /// already has a Wallpaper Engine library, jump straight to the
+    /// Workshop Gallery instead of presenting a single-folder picker.
+    @State private var wpeFolderExists = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -24,20 +29,55 @@ struct OnboardingStepFirstWallpaper: View {
                     .foregroundStyle(.secondary)
             }
 
-            Spacer().frame(height: 22)
+            Spacer().frame(height: 24)
 
-            VStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 16) {
+                sectionHeader("From your Mac")
+                VStack(spacing: 8) {
+                    OnboardingOptionCard(
+                        icon: "film",
+                        iconTint: .blue,
+                        title: "Choose Your Video",
+                        subtitle: "Pick an MP4 or MOV from your Mac.",
+                        isFeatured: !wpeFolderExists,
+                        isLoading: false,
+                        action: chooseVideoFile
+                    )
+                    .keyboardShortcut("1", modifiers: [])
+
+                    OnboardingOptionCard(
+                        icon: "globe",
+                        iconTint: .green,
+                        title: "Add a Web Page",
+                        subtitle: "Use a website or local HTML as a live wallpaper.",
+                        isFeatured: false,
+                        isLoading: false,
+                        action: { showHTMLSheet = true }
+                    )
+                    .keyboardShortcut("2", modifiers: [])
+                }
+
+                sectionHeader("From Steam")
                 OnboardingOptionCard(
-                    icon: "film",
-                    iconTint: Color.accentColor,
-                    title: "Choose Your Video",
-                    subtitle: "Pick an MP4 or MOV from your Mac.",
-                    isFeatured: true,
+                    icon: "cube.transparent",
+                    iconTint: .orange,
+                    title: wpeFolderExists ? "Browse Workshop Library" : "Import from Wallpaper Engine",
+                    subtitle: wpeFolderExists
+                        ? "We found your Steam folder. Browse Video / Web projects instantly."
+                        : "Use your Steam Workshop wallpapers. Scene types are preview-only.",
+                    isFeatured: wpeFolderExists,
                     isLoading: false,
-                    action: chooseVideoFile
+                    action: {
+                        if wpeFolderExists {
+                            showWorkshopGallery = true
+                        } else {
+                            chooseWPEFolder()
+                        }
+                    }
                 )
-                .keyboardShortcut("1", modifiers: [])
+                .keyboardShortcut("3", modifiers: [])
 
+                sectionHeader("Built-in")
                 OnboardingOptionCard(
                     icon: "sparkles.tv",
                     iconTint: .secondary,
@@ -46,28 +86,6 @@ struct OnboardingStepFirstWallpaper: View {
                     isFeatured: false,
                     isLoading: isRequestingAerials,
                     action: chooseAerials
-                )
-                .keyboardShortcut("2", modifiers: [])
-
-                OnboardingOptionCard(
-                    icon: "globe",
-                    iconTint: .secondary,
-                    title: "Add a Web Page",
-                    subtitle: "Use a website or local HTML as a live wallpaper.",
-                    isFeatured: false,
-                    isLoading: false,
-                    action: { showHTMLSheet = true }
-                )
-                .keyboardShortcut("3", modifiers: [])
-
-                OnboardingOptionCard(
-                    icon: "cube.transparent",
-                    iconTint: .secondary,
-                    title: "Import from Wallpaper Engine",
-                    subtitle: "Use your Steam Workshop wallpapers.",
-                    isFeatured: false,
-                    isLoading: false,
-                    action: chooseWPEFolder
                 )
                 .keyboardShortcut("4", modifiers: [])
 
@@ -81,10 +99,16 @@ struct OnboardingStepFirstWallpaper: View {
                     action: skip
                 )
                 .keyboardShortcut("5", modifiers: [])
+                .padding(.top, 4)
             }
             .padding(.horizontal, 36)
 
             Spacer()
+        }
+        .onAppear { detectWPELibrary() }
+        .sheet(isPresented: $showWorkshopGallery, onDismiss: nextStep) {
+            WorkshopGalleryView()
+                .environment(screenManager)
         }
         .sheet(isPresented: $showHTMLSheet) {
             HTMLPickerSheet(
@@ -92,6 +116,24 @@ struct OnboardingStepFirstWallpaper: View {
                 onConfirm: { source in applyHTML(source) }
             )
         }
+    }
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.tertiary)
+            .textCase(.uppercase)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private func detectWPELibrary() {
+        guard let docs = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first else { return }
+        let lwDir = docs.appendingPathComponent("Live Wallpapers")
+        wpeFolderExists = FileManager.default.fileExists(atPath: lwDir.path)
     }
 
     private func chooseAerials() {
@@ -358,6 +400,9 @@ private struct OnboardingOptionCard: View {
 
     @State private var isHovering = false
     @FocusState private var isFocused: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var isActive: Bool { isHovering || isFocused }
 
     var body: some View {
         Button(action: action) {
@@ -402,16 +447,20 @@ private struct OnboardingOptionCard: View {
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(RoundedRectangle(cornerRadius: 12))
+            .contentShape(RoundedRectangle(cornerRadius: 16))
             .background(
-                RoundedRectangle(cornerRadius: 12)
+                RoundedRectangle(cornerRadius: 16)
                     .fill(.regularMaterial)
             )
         }
         .buttonStyle(.plain)
         .focused($isFocused)
-        .scaleEffect(isHovering || isFocused ? 1.01 : 1.0)
-        .shadow(color: .black.opacity(isHovering || isFocused ? 0.18 : (isFeatured ? 0.06 : 0)), radius: 8, y: 3)
+        .scaleEffect(isActive && !reduceMotion ? 1.02 : 1.0)
+        .shadow(
+            color: .black.opacity(isActive ? 0.18 : (isFeatured ? 0.06 : 0)),
+            radius: isActive ? 8 : 4,
+            y: isActive ? 4 : 2
+        )
         .animation(.spring(response: 0.3, dampingFraction: 0.85), value: isHovering)
         .animation(.spring(response: 0.3, dampingFraction: 0.85), value: isFocused)
         .onHover { isHovering = $0 }

--- a/LiveWallpaper/Views/ScreenDetail/WPEHistoryRow.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEHistoryRow.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import AppKit
 
-/// Single recent-import card in the Scene tab grid. 140×180pt,
+/// Single recent-import card in the Scene tab grid. 160×240pt,
 /// glass-effect background, hover lift, context menu for Finder/remove.
 struct WPEHistoryRow: View {
     let entry: WPEHistoryEntry
@@ -22,21 +22,21 @@ struct WPEHistoryRow: View {
                 )
                     .clipShape(
                         UnevenRoundedRectangle(
-                            topLeadingRadius: 14,
+                            topLeadingRadius: 16,
                             bottomLeadingRadius: 0,
                             bottomTrailingRadius: 0,
-                            topTrailingRadius: 14,
+                            topTrailingRadius: 16,
                             style: .continuous
                         )
                     )
 
-                VStack(alignment: .leading, spacing: 6) {
+                VStack(alignment: .leading, spacing: 8) {
                     Text(entry.origin.title)
                         .font(.system(size: 13, weight: .medium))
                         .lineLimit(2)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
-                    HStack(spacing: 4) {
+                    HStack(spacing: 6) {
                         Circle()
                             .fill(typeColor)
                             .frame(width: 6, height: 6)
@@ -59,16 +59,16 @@ struct WPEHistoryRow: View {
                         }
                     }
                 }
-                .padding(10)
+                .padding(12)
                 .frame(maxHeight: .infinity, alignment: .top)
             }
         }
         .buttonStyle(.plain)
-        .frame(width: 140, height: 220)
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 14))
+        .frame(width: 160, height: 240)
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 16))
         .scaleEffect(isHovering ? 1.02 : 1.0)
         .shadow(
-            color: Color.black.opacity(isHovering ? 0.15 : 0.05),
+            color: Color.black.opacity(isHovering ? 0.18 : 0.06),
             radius: isHovering ? 8 : 4,
             y: isHovering ? 4 : 2
         )

--- a/LiveWallpaper/Views/ScreenDetail/WPEPreviewView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEPreviewView.swift
@@ -48,10 +48,11 @@ struct WPEPreviewView: View {
         // (512×512). Combined with `.resizeAspectFill` inside the layer, the
         // image fully covers the slot — square sources draw flush, 16:9
         // sources crop top/bottom equally, vertical sources crop sides.
+        //
+        // Clipping + shadow are intentionally delegated to the parent so
+        // cards can apply uneven (top-only) corner radii without double-clip.
         .aspectRatio(1, contentMode: .fit)
         .clipped()
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-        .shadow(color: Color.black.opacity(0.12), radius: 6, y: 2)
         .onChange(of: imageURL) { _, _ in
             loadFailed = false
         }

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
@@ -38,16 +38,16 @@ struct WPESceneSection: View {
         .onReceive(NotificationCenter.default.publisher(for: .wpeHistoryDidChange)) { _ in
             reloadHistory()
         }
-        .onChange(of: screenManager.lastWPEImportError) { _, error in
+        .onChange(of: screenManager.wpeImportError(for: screen)) { _, error in
             showImportErrorAlert = (error != nil)
         }
         .sheet(isPresented: $showWorkshopGallery) {
             WorkshopGalleryView()
                 .environment(screenManager)
         }
-        .alert("Import Failed", isPresented: $showImportErrorAlert, presenting: screenManager.lastWPEImportError) { _ in
+        .alert("Import Failed", isPresented: $showImportErrorAlert, presenting: screenManager.wpeImportError(for: screen)) { _ in
             Button("OK", role: .cancel) {
-                screenManager.lastWPEImportError = nil
+                screenManager.clearWPEImportError(for: screen)
             }
         } message: { error in
             VStack(alignment: .leading) {
@@ -62,7 +62,7 @@ struct WPESceneSection: View {
     // MARK: - States
 
     private var emptyState: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 24) {
             Image(systemName: "tray.and.arrow.down")
                 .font(.system(size: 56, weight: .light))
                 .foregroundStyle(.secondary)
@@ -75,7 +75,7 @@ struct WPESceneSection: View {
                     .foregroundStyle(.secondary)
             }
 
-            VStack(spacing: 10) {
+            VStack(spacing: 12) {
                 Button {
                     presentFolderPicker()
                 } label: {
@@ -130,9 +130,9 @@ struct WPESceneSection: View {
                 }
 
                 LazyVGrid(
-                    columns: Array(repeating: GridItem(.fixed(140), spacing: 12), count: 4),
+                    columns: Array(repeating: GridItem(.fixed(160), spacing: 16), count: 4),
                     alignment: .leading,
-                    spacing: 12
+                    spacing: 16
                 ) {
                     ForEach(recentImports) { entry in
                         WPEHistoryRow(
@@ -184,16 +184,23 @@ struct WPESceneSection: View {
     /// Defers state mutation to the next runloop tick so we don't ask SwiftUI
     /// to switch branches (and remount `NSViewRepresentable` previews) during
     /// the same body evaluation that just refreshed `recentImports`.
+    /// Selects by `workshopID` so two scene imports back-to-back never collide.
     private func selectUnsupportedImportIfNeeded(from notification: Notification) {
         guard let screenID = notification.userInfo?["screenID"] as? CGDirectDisplayID,
               screenID == screen.id,
               let rawType = notification.userInfo?["type"] as? String,
               let type = WPEType(rawValue: rawType) else { return }
 
+        let workshopID = notification.userInfo?["workshopID"] as? String
+
         DispatchQueue.main.async {
             switch type {
             case .scene, .application, .unknown:
-                selectedHistoryEntry = recentImports.first { $0.origin.originalType == type }
+                if let workshopID {
+                    selectedHistoryEntry = recentImports.first { $0.origin.workshopID == workshopID }
+                } else {
+                    selectedHistoryEntry = recentImports.first { $0.origin.originalType == type }
+                }
             case .video, .web:
                 selectedHistoryEntry = nil
             }

--- a/LiveWallpaper/Views/ScreenDetail/WPEUnsupportedCard.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEUnsupportedCard.swift
@@ -16,6 +16,8 @@ struct WPEUnsupportedCard: View {
                 securityScopedBookmarkData: origin.sourceFolderBookmark
             )
                 .frame(width: 280)
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .shadow(color: Color.black.opacity(0.18), radius: 8, y: 4)
 
             VStack(spacing: 8) {
                 Text(origin.title)
@@ -48,7 +50,7 @@ struct WPEUnsupportedCard: View {
             }
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.orange.opacity(0.14), in: RoundedRectangle(cornerRadius: 12))
+            .background(Color.orange.opacity(0.14), in: RoundedRectangle(cornerRadius: 16))
 
             Button {
                 openWorkshop()

--- a/LiveWallpaper/Views/ScreenDetail/WorkshopGalleryView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WorkshopGalleryView.swift
@@ -162,9 +162,9 @@ struct WorkshopGalleryView: View {
             LazyVGrid(
                 // Fixed-width columns so the 1:1 square preview area is
                 // identical across cards regardless of window width.
-                columns: Array(repeating: GridItem(.fixed(180), spacing: 14), count: 4),
+                columns: Array(repeating: GridItem(.fixed(160), spacing: 16), count: 4),
                 alignment: .leading,
-                spacing: 14
+                spacing: 16
             ) {
                 ForEach(projects) { project in
                     WorkshopGalleryCard(
@@ -207,12 +207,25 @@ struct WorkshopGalleryView: View {
 
     private func refreshScan() async {
         state = .scanning
+
+        // Resolve persisted state on the main actor before crossing onto the
+        // detached scan task. SettingsManager is @MainActor isolated and the
+        // scanner itself runs off main.
+        guard let bookmark = SettingsManager.shared.loadWorkshopLibraryRootBookmark() else {
+            state = .needsRoot
+            return
+        }
+        let alreadyImported = Set(
+            SettingsManager.shared.loadGlobalSettings().recentWPEImports.map(\.origin.workshopID)
+        )
+
         do {
-            let discovered = try await scanner.scan()
+            let discovered = try await scanner.scan(
+                rootBookmarkData: bookmark,
+                alreadyImportedWorkshopIDs: alreadyImported
+            )
             projects = discovered
             state = .results
-        } catch WallpaperEngineLibraryScanner.ScanError.rootBookmarkMissing {
-            state = .needsRoot
         } catch WallpaperEngineLibraryScanner.ScanError.rootInaccessible(let detail) {
             errorMessage = "Workshop folder is unreachable: \(detail). Try re-granting access."
             SettingsManager.shared.clearWorkshopLibraryRootBookmark()
@@ -335,17 +348,17 @@ private struct WorkshopGalleryCard: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Square preview occupies the full 180pt card width (180×180).
+            // Square preview occupies the full 160pt card width (160×160).
             WPEPreviewView(
                 imageURL: project.previewURL,
                 securityScopedBookmarkData: project.libraryRootBookmarkData
             )
                 .clipShape(
                     UnevenRoundedRectangle(
-                        topLeadingRadius: 14,
+                        topLeadingRadius: 16,
                         bottomLeadingRadius: 0,
                         bottomTrailingRadius: 0,
-                        topTrailingRadius: 14,
+                        topTrailingRadius: 16,
                         style: .continuous
                     )
                 )
@@ -366,11 +379,11 @@ private struct WorkshopGalleryCard: View {
             .padding(12)
             .frame(maxHeight: .infinity, alignment: .top)
         }
-        .frame(width: 180, height: 280)
-        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 14))
+        .frame(width: 160, height: 240)
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 16))
         .scaleEffect(isHovering ? 1.02 : 1.0)
         .shadow(
-            color: Color.black.opacity(isHovering ? 0.15 : 0.05),
+            color: Color.black.opacity(isHovering ? 0.18 : 0.06),
             radius: isHovering ? 8 : 4,
             y: isHovering ? 4 : 2
         )


### PR DESCRIPTION
Onboarding (OnboardingStepFirstWallpaper)
- Three-section layout: From your Mac / From Steam / Built-in.
- Auto-detect ~/Documents/Live Wallpapers/; if present, the WPE option upgrades to "Browse Workshop Library" and opens the Gallery sheet directly (with onDismiss → nextStep).
- Dynamic Type via .caption font, .accessibilityAddTraits(.isHeader) on section headers, accessibilityReduceMotion on hover scale.

UI consistency pass
- Unified card frame 160×240 across history grid + workshop gallery.
- Corner radii 12/14 → 16 (Apple HIG macOS 26 standard).
- Shadow tokens 0.05/0.15 → 0.06/0.18; hover scale unified at 1.02.
- WPEPreviewView no longer self-clips/shadow — parents now own those modifiers, fixing double-clipping on uneven-corner cards.

Backend correctness
- Unpacked WPE video projects (project.json + video.mp4 with no scene.pkg) now import successfully via .sourceFolder resourceLocation.
- WPEOrigin.matchesSourceFolderBookmark branches by originalType: video must match its declared entryFile exactly; web must match the source folder exactly. Prevents sibling-file false positives that would keep the WPE badge attached after replacement.
- Per-screen WPE import errors via [CGDirectDisplayID: AppError] + wpeImportError(for:) / clearWPEImportError(for:). Concurrent multi-screen imports no longer collide.
- .wpeImportDidComplete notification carries workshopID; Scene tab selects the unsupported placeholder by ID with type fallback.

Performance / off-main I/O
- WallpaperEngineLibraryScanner is non-@MainActor; the directory walk + per-project JSON decoding runs on a detached cooperative task, keeping large workshop libraries from hanging the UI.
- WorkshopGalleryView resolves persisted bookmark + already-imported set on @MainActor before crossing to the scan task.

PKG streaming
- WallpaperEnginePackage adds parseIndex(streamingFrom:) + extractAll(streamingFrom:to:): reads the header from a FileHandle, seeks per-entry, writes each in 1 MiB chunks. Memory peak no longer scales with pkg size.
- WallpaperEngineCache fingerprint computes SHA-256 incrementally in 64 KiB chunks, replacing the prior memory-mapped one-shot.
- Existing Data-based parseIndex/extractAll APIs are retained for the unit-test suite.

Defense-in-depth
- WallpaperEnginePackage entry-name cap aligned to 255 (RePKG).
- isSafeCacheRelativePath now requires "wpe-cache/" prefix, so persisted WPEOrigin can never resolve outside the cache subtree.
- WallpaperEnginePackage.extractAll restores .replaced on launch before cleanup runs, fixing a crash window that could lose the only good cache.

Tests: 259/260 pass (UI bundle is run separately via Xcode).