### PR TITLE
chore(tests): drop unnecessary `try` on rethrows helper calls

### DIFF
--- a/LiveWallpaperTests/GeneralSettingsRegressionTests.swift
+++ b/LiveWallpaperTests/GeneralSettingsRegressionTests.swift
@@ -10,7 +10,7 @@ import Testing
 struct GeneralSettingsRegressionTests {
     @Test("Saving with only pause/login flags preserved must keep recentWPEImports")
     func savingPartialFieldsPreservesWPEHistory() throws {
-        try withIsolatedGlobalSettings {
+        withIsolatedGlobalSettings {
             let manager = SettingsManager.shared
 
             // Seed history first.
@@ -46,7 +46,7 @@ struct GeneralSettingsRegressionTests {
 
     @Test("The legacy bug pattern (rebuild GlobalSettings without recentWPEImports) wipes history")
     func legacyRebuildPatternWipesHistory() throws {
-        try withIsolatedGlobalSettings {
+        withIsolatedGlobalSettings {
             let manager = SettingsManager.shared
             let entry = WPEHistoryEntry(
                 origin: WPEOrigin(

--- a/LiveWallpaperTests/WPEHistoryTests.swift
+++ b/LiveWallpaperTests/WPEHistoryTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct WPEHistoryTests {
     @Test("Record pushes to front")
     func recordPushesToFront() throws {
-        try withIsolatedGlobalSettings {
+        withIsolatedGlobalSettings {
             let manager = SettingsManager.shared
             manager.recordWPEImport(makeEntry("1"))
             manager.recordWPEImport(makeEntry("2"))
@@ -18,7 +18,7 @@ struct WPEHistoryTests {
 
     @Test("Duplicate moves to front")
     func duplicateMovesToFront() throws {
-        try withIsolatedGlobalSettings {
+        withIsolatedGlobalSettings {
             let manager = SettingsManager.shared
             let lastUsedAt = Date(timeIntervalSince1970: 50)
             manager.recordWPEImport(makeEntry("1"))
@@ -34,7 +34,7 @@ struct WPEHistoryTests {
 
     @Test("Caps at 20")
     func capsAt20() throws {
-        try withIsolatedGlobalSettings {
+        withIsolatedGlobalSettings {
             let manager = SettingsManager.shared
             for index in 0..<25 {
                 manager.recordWPEImport(makeEntry("\(index)"))

--- a/LiveWallpaperTests/WPEReconciliationTests.swift
+++ b/LiveWallpaperTests/WPEReconciliationTests.swift
@@ -144,7 +144,7 @@ struct WPEReconciliationTests {
 
     @Test("Plan §A14: SettingsManager.removeWPEImport drops only the requested workshop")
     func removeWPEImportTargetsOnlyMatchingWorkshop() throws {
-        try withIsolatedGlobalSettings {
+        withIsolatedGlobalSettings {
             let manager = SettingsManager.shared
             let now = Date()
             manager.recordWPEImport(WPEHistoryEntry(origin: makeOrigin(workshopID: "alpha"), importedAt: now, lastUsedAt: now))


### PR DESCRIPTION
`withIsolatedGlobalSettings` is `rethrows`, but the bodies in these six call sites never throw, so the `try` keyword is dead code that Swift now warns about. Removing it clears all 6 navigator warnings.