### PR TITLE
feat(wpe): Phase 2.0 image-only scene runtime + UI state machine

### DIFF
--- a/LiveWallpaper/Infrastructure/BookmarkStore.swift
+++ b/LiveWallpaper/Infrastructure/BookmarkStore.swift
@@ -76,6 +76,8 @@ final class BookmarkStore {
             return source.displayName
         case .metalShader(let preset):
             return preset.rawValue
+        case .scene(let descriptor):
+            return "Scene \(descriptor.workshopID)"
         }
     }
 }

--- a/LiveWallpaper/Infrastructure/SceneResourceResolver.swift
+++ b/LiveWallpaper/Infrastructure/SceneResourceResolver.swift
@@ -1,0 +1,110 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// Phase 2.0 resource resolver for `.scene` content. Reads images out of the
+/// extracted cache root using `ImageIO`. Path safety mirrors the WPE folder
+/// scheme handler — every relative path is standardized + symlink-resolved
+/// and rejected if it escapes the cache root.
+///
+/// `.tex` is a Wallpaper Engine binary texture format that Phase 2.0 does
+/// not parse yet. `resolveImage(...)` will throw `.unsupportedTexture` so
+/// the import service can flag the scene as `degraded`/`unsupported` and the
+/// runtime can render the scene minus that layer instead of crashing.
+struct SceneResourceResolver: Sendable {
+    enum ResolveError: Error, Equatable, Sendable {
+        case pathEscape
+        case fileMissing
+        case decodeFailed
+        case unsupportedTexture
+    }
+
+    let cacheRootURL: URL
+
+    init(cacheRootURL: URL) {
+        // Standardize once so subsequent prefix checks are stable.
+        self.cacheRootURL = cacheRootURL.standardizedFileURL.resolvingSymlinksInPath()
+    }
+
+    /// Single point where the resolver touches the filesystem. Pulled out as
+    /// a computed property so the struct stays `Sendable` (FileManager is
+    /// not Sendable, and storing one as a property is a hard error in
+    /// strict-concurrency mode).
+    private var fileManager: FileManager { .default }
+
+    /// Returns a CGImage decoded from the cache. The returned image is
+    /// independent of the source file handle so the caller can hold it as
+    /// long as needed.
+    func resolveImage(relativePath: String) throws -> CGImage {
+        guard !relativePath.isEmpty else { throw ResolveError.fileMissing }
+        let target = try resolveURL(for: relativePath)
+
+        let lowered = target.pathExtension.lowercased()
+        if lowered == "tex" {
+            // Phase 2.0 stub: surface as unsupported so the caller picks a
+            // policy (skip layer / show fallback). 2.1 will add a real .tex
+            // first-frame extractor.
+            throw ResolveError.unsupportedTexture
+        }
+
+        guard fileManager.fileExists(atPath: target.path) else {
+            throw ResolveError.fileMissing
+        }
+
+        guard let source = CGImageSourceCreateWithURL(target as CFURL, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw ResolveError.decodeFailed
+        }
+        return image
+    }
+
+    /// File existence probe used by tests + the import service to decide
+    /// whether a scene's declared image layers are actually shipped.
+    func exists(relativePath: String) -> Bool {
+        (try? resolveExistingFileURL(relativePath: relativePath)) != nil
+    }
+
+    /// Validates `relativePath`, joins it onto the cache root, and confirms
+    /// the result is a regular file inside the cache. Used by callers that
+    /// need a safe URL up-front (e.g. `SceneRenderingController.load()` for
+    /// the entry file safety probe). Throws `.fileMissing` for both missing
+    /// files and directory hits so callers don't accidentally try to read
+    /// a directory as data.
+    func resolveExistingFileURL(relativePath: String) throws -> URL {
+        let url = try resolveURL(for: relativePath)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue else {
+            throw ResolveError.fileMissing
+        }
+        return url
+    }
+
+    /// Standardize the candidate URL and verify it falls under cache root.
+    /// Mirrors `FolderURLSchemeHandler` and `WPECachedContentResolver`.
+    private func resolveURL(for relativePath: String) throws -> URL {
+        // Component-level guard so a tampered relativePath cannot smuggle
+        // `..` or absolute segments past the textual check that misses
+        // mid-path components.
+        let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
+        if relativePath.hasPrefix("/")
+            || relativePath.contains("\\")
+            || components.contains("..")
+            || components.contains(".")
+            || components.contains("") {
+            throw ResolveError.pathEscape
+        }
+
+        let resolved = cacheRootURL
+            .appendingPathComponent(relativePath)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+
+        let rootPath = cacheRootURL.path
+        let resolvedPath = resolved.path
+        guard resolvedPath == rootPath || resolvedPath.hasPrefix(rootPath + "/") else {
+            throw ResolveError.pathEscape
+        }
+        return resolved
+    }
+}

--- a/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
@@ -1,0 +1,241 @@
+import CoreGraphics
+import Foundation
+
+/// Stateless flexible parser for Wallpaper Engine `scene.json`. The shipping
+/// format mixes JSON objects, scalar arrays, and space-separated string
+/// vectors (`"0 1 0"`); we accept all three to cover the long tail of
+/// community projects without forking the spec.
+///
+/// Phase 2.0 contract:
+///   - Required: top-level object with `camera` + `general` blocks.
+///   - Image objects (`type` either missing or "image") feed
+///     `WPESceneDocument.imageObjects`.
+///   - Anything else (text / particles / sound / shaders / FBO passes /
+///     bloom / parallax) emits a `WPESceneDiagnostic` and the parser keeps
+///     going so the import flow can still light up image-only scenes.
+enum WPESceneDocumentParser {
+
+    static func parse(data: Data) throws -> WPESceneDocument {
+        guard !data.isEmpty else {
+            throw WPESceneDocumentError.invalidUTF8
+        }
+        let json: Any
+        do {
+            json = try JSONSerialization.jsonObject(with: data, options: [.allowFragments])
+        } catch {
+            throw WPESceneDocumentError.invalidUTF8
+        }
+        guard let root = json as? [String: Any] else {
+            throw WPESceneDocumentError.rootNotObject
+        }
+
+        var diagnostics: [WPESceneDiagnostic] = []
+
+        guard let cameraDict = root["camera"] as? [String: Any] else {
+            throw WPESceneDocumentError.missingCamera
+        }
+        guard let generalDict = root["general"] as? [String: Any] else {
+            throw WPESceneDocumentError.missingGeneral
+        }
+
+        let camera = parseCamera(cameraDict, diagnostics: &diagnostics)
+        let general = parseGeneral(generalDict, diagnostics: &diagnostics)
+
+        let rawObjects: [[String: Any]] = (root["objects"] as? [[String: Any]]) ?? []
+        var imageObjects: [WPESceneImageObject] = []
+
+        for entry in rawObjects {
+            let type = (entry["type"] as? String)?.lowercased() ?? "image"
+            switch type {
+            case "image", "":
+                if let object = parseImageObject(entry, diagnostics: &diagnostics) {
+                    imageObjects.append(object)
+                }
+            case "text":
+                diagnostics.append(.init(severity: .info, message: "Text object \(entry["name"] as? String ?? "?") is unsupported in Phase 2.0"))
+            case "sound":
+                diagnostics.append(.init(severity: .info, message: "Sound object \(entry["name"] as? String ?? "?") is unsupported in Phase 2.0"))
+            case "particle":
+                diagnostics.append(.init(severity: .info, message: "Particle object \(entry["name"] as? String ?? "?") is unsupported in Phase 2.0"))
+            default:
+                diagnostics.append(.init(severity: .info, message: "Object type \(type) is unsupported in Phase 2.0"))
+            }
+        }
+
+        if (root["effects"] as? [Any])?.isEmpty == false {
+            diagnostics.append(.init(severity: .info, message: "Top-level effects are not yet rendered"))
+        }
+
+        // Optional general fields we do not yet consume: bloom*, cameraparallax*,
+        // camerashake*. Surfacing them as info-level diagnostics keeps the
+        // import service's tier classifier honest.
+        for key in generalDict.keys {
+            let lowered = key.lowercased()
+            if lowered.hasPrefix("bloom") || lowered.hasPrefix("cameraparallax") || lowered.hasPrefix("camerashake") {
+                diagnostics.append(.init(severity: .info, message: "general.\(key) is unsupported in Phase 2.0"))
+            }
+        }
+
+        return WPESceneDocument(
+            camera: camera,
+            general: general,
+            imageObjects: imageObjects,
+            diagnostics: diagnostics
+        )
+    }
+
+    // MARK: - Camera
+
+    private static func parseCamera(_ dict: [String: Any], diagnostics: inout [WPESceneDiagnostic]) -> WPESceneCamera {
+        let center = parseVector3(dict["center"]) ?? WPESceneCamera.defaultCamera.center
+        let eye = parseVector3(dict["eye"]) ?? WPESceneCamera.defaultCamera.eye
+        let up = parseVector3(dict["up"]) ?? WPESceneCamera.defaultCamera.up
+        let nearZ = parseDouble(dict["nearz"]) ?? WPESceneCamera.defaultCamera.nearZ
+        let farZ = parseDouble(dict["farz"]) ?? WPESceneCamera.defaultCamera.farZ
+        let fov = parseDouble(dict["fov"]) ?? WPESceneCamera.defaultCamera.fov
+        return WPESceneCamera(center: center, eye: eye, up: up, nearZ: nearZ, farZ: farZ, fov: fov)
+    }
+
+    // MARK: - General
+
+    private static func parseGeneral(_ dict: [String: Any], diagnostics: inout [WPESceneDiagnostic]) -> WPESceneGeneral {
+        let clearColor = parseVector3(dict["clearcolor"]) ?? WPESceneGeneral.defaultGeneral.clearColor
+        let projection: WPESceneOrthogonalProjection
+        if let nested = dict["orthogonalprojection"] as? [String: Any] {
+            let width = parseDouble(nested["width"]) ?? WPESceneGeneral.defaultGeneral.orthogonalProjection.width
+            let height = parseDouble(nested["height"]) ?? WPESceneGeneral.defaultGeneral.orthogonalProjection.height
+            let auto = (nested["auto"] as? Bool) ?? WPESceneGeneral.defaultGeneral.orthogonalProjection.auto
+            projection = WPESceneOrthogonalProjection(width: width, height: height, auto: auto)
+        } else {
+            diagnostics.append(.init(severity: .info, message: "general.orthogonalprojection missing — using 1920×1080"))
+            projection = WPESceneGeneral.defaultGeneral.orthogonalProjection
+        }
+        return WPESceneGeneral(clearColor: clearColor, orthogonalProjection: projection)
+    }
+
+    // MARK: - Image objects
+
+    private static func parseImageObject(
+        _ dict: [String: Any],
+        diagnostics: inout [WPESceneDiagnostic]
+    ) -> WPESceneImageObject? {
+        guard let imagePath = dict["image"] as? String, !imagePath.isEmpty else {
+            // No image path means nothing to draw — skip but log so the
+            // import service can flag obviously broken scenes.
+            diagnostics.append(.init(severity: .warning, message: "Image object \(dict["name"] as? String ?? "?") has no image path"))
+            return nil
+        }
+
+        let id = (dict["id"] as? String)
+            ?? (dict["id"] as? Int).map(String.init)
+            ?? (dict["name"] as? String)
+            ?? imagePath
+        let name = (dict["name"] as? String) ?? id
+        let origin = parseVector3(dict["origin"]) ?? SIMD3<Double>(0, 0, 0)
+        let scale = parseVector3(dict["scale"]) ?? SIMD3<Double>(1, 1, 1)
+        let angles = parseVector3(dict["angles"]) ?? SIMD3<Double>(0, 0, 0)
+        let visible = parseBool(dict["visible"]) ?? true
+        let alpha = parseDouble(dict["alpha"]) ?? 1.0
+        let color = parseVector3(dict["color"]) ?? SIMD3<Double>(1, 1, 1)
+        let brightness = parseDouble(dict["brightness"]) ?? 1.0
+        let blend = WPESceneBlendMode(rawWPEValue: dict["blendmode"] as? String)
+        let alignment = WPESceneAlignment(rawWPEValue: dict["alignment"] as? String)
+        let size: CGSize?
+        if let vec = parseVector3(dict["size"]) {
+            size = CGSize(width: vec.x, height: vec.y)
+        } else {
+            size = nil
+        }
+
+        // Track unsupported features so the import flow can downgrade tier.
+        if let effects = dict["effects"] as? [Any], !effects.isEmpty {
+            diagnostics.append(.init(severity: .info, message: "Image \(name) declares effects — rendered without effects in Phase 2.0"))
+        }
+        if dict["material"] != nil {
+            diagnostics.append(.init(severity: .info, message: "Image \(name) declares material — Phase 2.0 ignores material/shader"))
+        }
+        if dict["animationlayers"] != nil {
+            diagnostics.append(.init(severity: .info, message: "Image \(name) declares animationlayers — unsupported in Phase 2.0"))
+        }
+        if imagePath.lowercased().hasSuffix(".tex") {
+            diagnostics.append(.init(severity: .warning, message: "Image \(name) uses .tex texture — falls back to first-frame stub if available"))
+        }
+
+        return WPESceneImageObject(
+            id: id,
+            name: name,
+            imageRelativePath: imagePath,
+            origin: origin,
+            scale: scale,
+            angles: angles,
+            visible: visible,
+            alpha: alpha,
+            color: color,
+            brightness: brightness,
+            blendMode: blend,
+            alignment: alignment,
+            size: size
+        )
+    }
+
+    // MARK: - Primitive parsing
+
+    /// Accepts JSON arrays of numbers, JSON dictionaries with x/y/z keys,
+    /// or WPE's space-separated strings ("0.5 0 0").
+    static func parseVector3(_ raw: Any?) -> SIMD3<Double>? {
+        if let array = raw as? [Any] {
+            let values = array.compactMap(parseDouble)
+            guard values.count >= 2 else { return nil }
+            let x = values[0]
+            let y = values[1]
+            let z = values.count >= 3 ? values[2] : 0
+            return SIMD3<Double>(x, y, z)
+        }
+        if let dict = raw as? [String: Any] {
+            let x = parseDouble(dict["x"]) ?? 0
+            let y = parseDouble(dict["y"]) ?? 0
+            let z = parseDouble(dict["z"]) ?? 0
+            if x == 0 && y == 0 && z == 0 { return nil }
+            return SIMD3<Double>(x, y, z)
+        }
+        if let string = raw as? String {
+            let pieces = string.split(whereSeparator: { $0.isWhitespace || $0 == "," })
+            let values = pieces.compactMap { Double($0) }
+            guard values.count >= 2 else { return nil }
+            let x = values[0]
+            let y = values[1]
+            let z = values.count >= 3 ? values[2] : 0
+            return SIMD3<Double>(x, y, z)
+        }
+        return nil
+    }
+
+    static func parseDouble(_ raw: Any?) -> Double? {
+        if let number = raw as? NSNumber {
+            return number.doubleValue
+        }
+        if let double = raw as? Double {
+            return double
+        }
+        if let int = raw as? Int {
+            return Double(int)
+        }
+        if let string = raw as? String {
+            return Double(string)
+        }
+        return nil
+    }
+
+    private static func parseBool(_ raw: Any?) -> Bool? {
+        if let bool = raw as? Bool { return bool }
+        if let int = raw as? Int { return int != 0 }
+        if let string = raw as? String {
+            switch string.lowercased() {
+            case "true", "yes", "1": return true
+            case "false", "no", "0": return false
+            default: return nil
+            }
+        }
+        return nil
+    }
+}

--- a/LiveWallpaper/Infrastructure/WallpaperConfigurationStore.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperConfigurationStore.swift
@@ -137,6 +137,11 @@ final class WallpaperConfigurationStore {
             return false
         case .metalShader:
             return false
+        case .scene:
+            // Scene wallpapers live under our own application support cache,
+            // not under a user-granted security scope; the resolver checks
+            // existence on its own. No bookmark reachability test needed.
+            return false
         }
     }
 }

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -43,7 +43,9 @@ final class WallpaperEngineImportService {
             return await importVideo(project: project, folderURL: folderURL, sourceBookmark: sourceBookmark)
         case .web:
             return await importWeb(project: project, folderURL: folderURL, sourceBookmark: sourceBookmark)
-        case .scene, .application, .unknown:
+        case .scene:
+            return await importScene(project: project, folderURL: folderURL, sourceBookmark: sourceBookmark)
+        case .application, .unknown:
             return .unsupported(origin: makeOrigin(
                 project: project,
                 sourceBookmark: sourceBookmark,
@@ -204,6 +206,113 @@ final class WallpaperEngineImportService {
         return .ready(content, origin: origin)
     }
 
+    private func importScene(
+        project: WallpaperEngineProject,
+        folderURL: URL,
+        sourceBookmark: Data
+    ) async -> ImportResult {
+        // Phase 2.0 contract: scene wallpapers must ship a `scene.pkg` (the
+        // unpacked-folder shape rarely lands in workshop downloads). If the
+        // pkg is missing we still surface as unsupported with a clear reason
+        // so the UI can show the fallback card instead of a generic error.
+        let pkgURL = folderURL.appendingPathComponent("scene.pkg")
+        guard fileManager.fileExists(atPath: pkgURL.path) else {
+            return .unsupported(origin: makeOrigin(
+                project: project,
+                sourceBookmark: sourceBookmark,
+                cacheRelativePath: nil,
+                resourceLocation: .unsupported
+            ))
+        }
+
+        let cacheResult = await ensureExtracted(project: project, pkgURL: pkgURL)
+        guard case .success(let cacheURL) = cacheResult else {
+            if case .failure(let failure) = cacheResult { return .rejected(reason: failure.reason) }
+            return .rejected(reason: "Extraction failed")
+        }
+
+        guard let entryURL = resourceURL(root: cacheURL, relativePath: project.entryFile),
+              fileManager.fileExists(atPath: entryURL.path) else {
+            return .rejected(reason: "Missing scene entry \(project.entryFile)")
+        }
+
+        // Parse `scene.json` to classify capability tier. Failures here are
+        // user-actionable (file shipped malformed) so we reject rather than
+        // mark unsupported — the UI surfaces the parse error to help the
+        // user nudge the wallpaper author.
+        let sceneData: Data
+        do {
+            sceneData = try Data(contentsOf: entryURL)
+        } catch {
+            return .rejected(reason: "Cannot read \(project.entryFile): \(describe(error))")
+        }
+
+        let document: WPESceneDocument
+        do {
+            document = try WPESceneDocumentParser.parse(data: sceneData)
+        } catch {
+            return .rejected(reason: describe(error))
+        }
+
+        let tier = capabilityTier(for: document, cacheURL: cacheURL)
+        let descriptor = SceneDescriptor(
+            workshopID: project.workshopID,
+            cacheRelativePath: cacheRelativePath(for: project),
+            entryFile: project.entryFile,
+            capabilityTier: tier
+        )
+        let origin = makeOrigin(
+            project: project,
+            sourceBookmark: sourceBookmark,
+            cacheRelativePath: cacheRelativePath(for: project),
+            resourceLocation: .cache
+        )
+
+        if tier == .unsupported {
+            return .unsupported(origin: origin)
+        }
+        return .ready(.scene(descriptor), origin: origin)
+    }
+
+    /// Walk `imageObjects` against the cache root: if every layer's asset is
+    /// present the scene is `.imageOnly`; if some are present and others are
+    /// missing we tag it `.degraded` so the UI shows a "missing assets"
+    /// notice; if none are renderable we surface as `.unsupported` and let
+    /// the import flow fall back to the placeholder card.
+    private func capabilityTier(for document: WPESceneDocument, cacheURL: URL) -> SceneCapabilityTier {
+        guard !document.imageObjects.isEmpty else {
+            return .unsupported
+        }
+        let resolver = SceneResourceResolver(cacheRootURL: cacheURL)
+        var resolvable = 0
+        var unresolvable = 0
+        for object in document.imageObjects {
+            let path = object.imageRelativePath
+            // Treat .tex as unresolvable for tier purposes — the resolver
+            // throws unsupportedTexture, the runtime will skip the layer.
+            if path.lowercased().hasSuffix(".tex") {
+                unresolvable += 1
+                continue
+            }
+            if resolver.exists(relativePath: path) {
+                resolvable += 1
+            } else {
+                unresolvable += 1
+            }
+        }
+
+        if resolvable == 0 { return .unsupported }
+        // Pure imageOnly only when EVERY layer resolves AND the parser saw no
+        // diagnostics at all. Info-level diagnostics include unsupported
+        // particle/text/sound objects — a scene that mixes a PNG layer with
+        // a particle emitter is degraded (the PNG renders, the particles
+        // don't), not fully imageOnly.
+        if unresolvable == 0 && document.diagnostics.isEmpty {
+            return .imageOnly
+        }
+        return .degraded
+    }
+
     private func ensureExtracted(project: WallpaperEngineProject, pkgURL: URL) async -> Result<URL, ExtractionFailure> {
         do {
             let url = try await cache.ensureExtracted(workshopID: project.workshopID, sourcePkgURL: pkgURL)
@@ -295,12 +404,15 @@ struct WPECachedContentResolver {
             return nil
         }
 
-        let rootPath = applicationSupportRootURL.standardizedFileURL.path
-        let cacheURL = applicationSupportRootURL
+        // Resolve symlinks before containment check — otherwise an
+        // attacker-controlled symlink at `Application Support/LiveWallpaper`
+        // could point at a sibling directory and still pass the prefix test.
+        let safeSupportRoot = applicationSupportRootURL.standardizedFileURL.resolvingSymlinksInPath()
+        let rootPath = safeSupportRoot.path
+        let cacheURL = safeSupportRoot
             .appendingPathComponent(cacheRelativePath, isDirectory: true)
             .standardizedFileURL
-        // Defense-in-depth: refuse persisted paths that escape the
-        // application-support root after standardization.
+            .resolvingSymlinksInPath()
         guard cacheURL.path == rootPath || cacheURL.path.hasPrefix(rootPath + "/") else {
             return nil
         }
@@ -319,7 +431,20 @@ struct WPECachedContentResolver {
                 source: .folder(bookmarkData: bookmark, indexFileName: entryFile),
                 config: HTMLConfig(physicalPixelLayout: true)
             )
-        case .scene, .application, .unknown:
+        case .scene:
+            // Phase 2.0 cache rebuild: do NOT re-parse `scene.json` here —
+            // the runtime layer already validates the descriptor on mount.
+            // We only need to confirm the cache entry exists, then hand back
+            // a `.scene(SceneDescriptor)` so ScreenManager can restore it
+            // without help from the import service.
+            return .scene(SceneDescriptor(
+                workshopID: origin.workshopID,
+                cacheRelativePath: cacheRelativePath,
+                entryFile: entryFile,
+                // Optimistic — runtime downgrades on first parse if needed.
+                capabilityTier: .imageOnly
+            ))
+        case .application, .unknown:
             return nil
         }
     }

--- a/LiveWallpaper/Models/SceneDescriptor.swift
+++ b/LiveWallpaper/Models/SceneDescriptor.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Persisted Wallpaper Engine `.scene` content identifier. Saved inside
+/// `WallpaperContent.scene(...)` so a scene wallpaper can be restored across
+/// launches without re-extracting `scene.pkg` or asking the user to re-grant
+/// access to the Steam Workshop folder.
+///
+/// `cacheRelativePath` is rooted under `Application Support/LiveWallpaper/`
+/// (e.g. `wpe-cache/<workshopID>`); both the import service and the runtime
+/// resolver re-validate the path before joining it onto the application
+/// support directory, so a malformed persisted blob can never escape root.
+struct SceneDescriptor: Codable, Equatable, Sendable {
+    let workshopID: String
+    /// Path beneath `Application Support/LiveWallpaper/` — must satisfy
+    /// `WPECachedContentResolver.isSafeCacheRelativePath`.
+    let cacheRelativePath: String
+    /// Entry filename inside the cache root, e.g. `scene.json`.
+    let entryFile: String
+    /// Best-effort runtime capability assessment from the import flow.
+    let capabilityTier: SceneCapabilityTier
+
+    init(
+        workshopID: String,
+        cacheRelativePath: String,
+        entryFile: String,
+        capabilityTier: SceneCapabilityTier
+    ) {
+        self.workshopID = workshopID
+        self.cacheRelativePath = cacheRelativePath
+        self.entryFile = entryFile
+        self.capabilityTier = capabilityTier
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case workshopID
+        case cacheRelativePath
+        case entryFile
+        case capabilityTier
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        workshopID = try c.decode(String.self, forKey: .workshopID)
+        cacheRelativePath = try c.decode(String.self, forKey: .cacheRelativePath)
+        entryFile = try c.decode(String.self, forKey: .entryFile)
+        // Lossy: an unrecognised tier (e.g. future Phase 2.x value) decodes
+        // to `.unsupported` so an old build does not blow up on new payloads.
+        capabilityTier = (try? c.decode(SceneCapabilityTier.self, forKey: .capabilityTier)) ?? .unsupported
+    }
+}
+
+/// Phase 2.0 capability gate. Computed by the import service after parsing
+/// `scene.json`; persisted so the runtime can short-circuit obviously
+/// degraded scenes without re-walking the JSON.
+enum SceneCapabilityTier: String, Codable, Equatable, Sendable {
+    /// All declared objects render via the image-only pipeline.
+    case imageOnly
+    /// Some objects are renderable but at least one is missing assets or
+    /// uses unsupported features. Runtime still mounts an SKScene.
+    case degraded
+    /// No object can render — UI must fall back to the placeholder card.
+    case unsupported
+}

--- a/LiveWallpaper/Models/ScreenConfiguration.swift
+++ b/LiveWallpaper/Models/ScreenConfiguration.swift
@@ -164,9 +164,11 @@ struct ScreenConfiguration: Codable, Equatable {
                 setAsLockScreen: setAsLockScreen
             )
         case .html, .metalShader, .scene:
-            // .scene is a UI-only label without direct WallpaperContent;
-            // legacy/test paths that hit this branch get the same safe
-            // degraded mapping as `.html` (empty inline source).
+            // `.scene` no longer maps to a synthetic HTML placeholder — Phase 2.0
+            // ships a real renderer. This convenience initializer is still
+            // hit by legacy tests and migration paths that have no descriptor;
+            // they degrade to an empty video so the type-pivot UI surfaces a
+            // "not configured" Scene tab instead of crashing.
             let wallpaper: WallpaperContent = switch wallpaperType {
             case .html:
                 .html(source: HTMLSource(legacyString: htmlContent ?? ""), config: .default)
@@ -175,7 +177,7 @@ struct ScreenConfiguration: Codable, Equatable {
             case .video:
                 .video(bookmarkData: videoBookmarkData)
             case .scene:
-                .html(source: HTMLSource(legacyString: ""), config: .default)
+                .video(bookmarkData: Data())
             }
 
             self.init(
@@ -298,13 +300,44 @@ struct ScreenConfiguration: Codable, Equatable {
             )
             savedVideoBookmarkData = legacySavedBookmark
         case .scene:
-            // .scene cannot legitimately appear in legacy data (the case did
-            // not exist before the WPE-import feature). Treat as empty video
-            // wallpaper to keep the configuration valid; ScreenManager's
-            // restoration path then surfaces the Scene tab placeholder.
-            activeWallpaper = .video(bookmarkData: Data())
-            savedVideoBookmarkData = legacySavedBookmark
+            // Legacy payloads predate `WallpaperContent.scene`. Backfill from
+            // wpeOrigin when the user already imported a Steam scene workshop:
+            // a valid `cacheRelativePath` + `entryFile` lets us reconstruct
+            // a `SceneDescriptor` (.imageOnly is the optimistic default — the
+            // import service will downgrade on next reconcile if needed).
+            // Otherwise fall back to an empty video so the Scene tab surfaces
+            // its placeholder instead of throwing decode errors.
+            if let backfilled = Self.backfillSceneFromLegacyOrigin(wpeOrigin) {
+                activeWallpaper = .scene(backfilled)
+                savedVideoBookmarkData = legacySavedBookmark
+            } else {
+                activeWallpaper = .video(bookmarkData: Data())
+                savedVideoBookmarkData = legacySavedBookmark
+            }
         }
+    }
+
+    /// Phase 2.0 migration: a previously-stored `wallpaperType == .scene`
+    /// blob from before the `.scene(SceneDescriptor)` case existed cannot
+    /// carry a descriptor in `activeWallpaper`. Reconstruct one when the
+    /// sibling `wpeOrigin` has the necessary fields; otherwise return nil
+    /// so the caller falls back to an empty placeholder configuration.
+    private static func backfillSceneFromLegacyOrigin(_ origin: WPEOrigin?) -> SceneDescriptor? {
+        guard let origin,
+              origin.originalType == .scene,
+              origin.resourceLocation == .cache,
+              let cacheRelativePath = origin.cacheRelativePath,
+              !cacheRelativePath.isEmpty,
+              let entryFile = origin.entryFile,
+              !entryFile.isEmpty else {
+            return nil
+        }
+        return SceneDescriptor(
+            workshopID: origin.workshopID,
+            cacheRelativePath: cacheRelativePath,
+            entryFile: entryFile,
+            capabilityTier: .imageOnly
+        )
     }
 
     func encode(to encoder: Encoder) throws {
@@ -430,6 +463,16 @@ struct ScreenConfiguration: Codable, Equatable {
             }
         case .metalShader:
             return
+        case .scene(let descriptor):
+            // Scene content is cache-backed and identified by workshopID +
+            // cacheRelativePath. Drop the origin only if either side disagrees
+            // with the persisted descriptor (e.g. user re-imported a different
+            // workshop project in-place).
+            guard origin.workshopID == descriptor.workshopID,
+                  origin.cacheRelativePath == descriptor.cacheRelativePath else {
+                wpeOrigin = nil
+                return
+            }
         }
     }
 

--- a/LiveWallpaper/Models/WPESceneDocument.swift
+++ b/LiveWallpaper/Models/WPESceneDocument.swift
@@ -1,0 +1,129 @@
+import CoreGraphics
+import Foundation
+
+/// Phase 2.0 minimal model of a Wallpaper Engine `scene.json`. Only the
+/// fields that participate in the image-only render pipeline are first-class;
+/// the rest become diagnostics so the import service can downgrade the
+/// capability tier without losing context.
+struct WPESceneDocument: Equatable, Sendable {
+    let camera: WPESceneCamera
+    let general: WPESceneGeneral
+    let imageObjects: [WPESceneImageObject]
+    let diagnostics: [WPESceneDiagnostic]
+
+    init(
+        camera: WPESceneCamera,
+        general: WPESceneGeneral,
+        imageObjects: [WPESceneImageObject],
+        diagnostics: [WPESceneDiagnostic]
+    ) {
+        self.camera = camera
+        self.general = general
+        self.imageObjects = imageObjects
+        self.diagnostics = diagnostics
+    }
+}
+
+/// Camera block — Phase 2.0 keeps the values around for future projection
+/// math but the image-only renderer treats the scene as a 2D plane.
+struct WPESceneCamera: Equatable, Sendable {
+    let center: SIMD3<Double>
+    let eye: SIMD3<Double>
+    let up: SIMD3<Double>
+    let nearZ: Double
+    let farZ: Double
+    let fov: Double
+
+    static let defaultCamera = WPESceneCamera(
+        center: SIMD3<Double>(0, 0, 0),
+        eye: SIMD3<Double>(0, 0, 1),
+        up: SIMD3<Double>(0, 1, 0),
+        nearZ: 0.1,
+        farZ: 1000,
+        fov: 60
+    )
+}
+
+/// `general` block. Provides clear color and orthogonal projection size used
+/// to size the SKScene canvas.
+struct WPESceneGeneral: Equatable, Sendable {
+    let clearColor: SIMD3<Double>
+    let orthogonalProjection: WPESceneOrthogonalProjection
+
+    static let defaultGeneral = WPESceneGeneral(
+        clearColor: SIMD3<Double>(0, 0, 0),
+        orthogonalProjection: WPESceneOrthogonalProjection(width: 1920, height: 1080, auto: true)
+    )
+}
+
+/// `general.orthogonalprojection`. WPE uses width/height in pixels — used
+/// directly as the SKScene size and as the divisor for object origins.
+struct WPESceneOrthogonalProjection: Equatable, Sendable {
+    let width: Double
+    let height: Double
+    let auto: Bool
+}
+
+/// One renderable image layer. Drives a single SKSpriteNode in the runtime.
+struct WPESceneImageObject: Equatable, Sendable, Identifiable {
+    let id: String
+    let name: String
+    let imageRelativePath: String
+    let origin: SIMD3<Double>
+    let scale: SIMD3<Double>
+    let angles: SIMD3<Double>
+    let visible: Bool
+    let alpha: Double
+    let color: SIMD3<Double>
+    let brightness: Double
+    let blendMode: WPESceneBlendMode
+    let alignment: WPESceneAlignment
+    /// Explicit pixel dimensions when WPE provided them; otherwise nil and
+    /// the runtime falls back to the underlying image size.
+    let size: CGSize?
+}
+
+enum WPESceneAlignment: String, Equatable, Sendable {
+    case center
+    case topLeft
+    case topRight
+    case bottomLeft
+    case bottomRight
+    case top
+    case bottom
+    case left
+    case right
+
+    init(rawWPEValue raw: String?) {
+        switch raw?.lowercased() {
+        case "topleft", "top left":         self = .topLeft
+        case "topright", "top right":       self = .topRight
+        case "bottomleft", "bottom left":   self = .bottomLeft
+        case "bottomright", "bottom right": self = .bottomRight
+        case "top":                         self = .top
+        case "bottom":                      self = .bottom
+        case "left":                        self = .left
+        case "right":                       self = .right
+        default:                            self = .center
+        }
+    }
+}
+
+/// SKBlendMode passthrough. Names mirror WPE's `blendmode` strings.
+enum WPESceneBlendMode: String, Equatable, Sendable {
+    case normal
+    case translucent
+    case additive
+    case multiply
+    case screen
+
+    init(rawWPEValue raw: String?) {
+        switch raw?.lowercased() {
+        case "translucent": self = .translucent
+        case "additive":    self = .additive
+        case "multiply":    self = .multiply
+        case "screen":      self = .screen
+        default:            self = .normal
+        }
+    }
+}

--- a/LiveWallpaper/Models/WPESceneErrors.swift
+++ b/LiveWallpaper/Models/WPESceneErrors.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Failure modes from `WPESceneDocumentParser` while turning raw `scene.json`
+/// bytes into a `WPESceneDocument`. Surfaced through `LocalizedError` so the
+/// import service can reuse the same UI alert pipeline as the rest of WPE.
+enum WPESceneDocumentError: Error, LocalizedError, Equatable, Sendable {
+    case invalidUTF8
+    case rootNotObject
+    case missingCamera
+    case missingGeneral
+    case malformedField(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidUTF8:
+            return "scene.json is not valid UTF-8."
+        case .rootNotObject:
+            return "scene.json must be a JSON object at the root."
+        case .missingCamera:
+            return "scene.json is missing the required camera block."
+        case .missingGeneral:
+            return "scene.json is missing the required general block."
+        case .malformedField(let field):
+            return "scene.json field \(field) is malformed."
+        }
+    }
+}
+
+/// Failure modes that surface from the SpriteKit runtime layer when a parsed
+/// scene cannot be staged. These are observed by the UI state machine and
+/// mapped to `FallbackReason` so the user gets a specific message rather than
+/// a generic "scene failed to load".
+enum SceneRenderingError: Error, LocalizedError, Equatable, Sendable {
+    case cacheRootMissing
+    case entryFileMissing(String)
+    case parseFailed(String)
+    case unsupportedShader
+    case noRenderableObjects
+
+    var errorDescription: String? {
+        switch self {
+        case .cacheRootMissing:
+            return "Scene cache directory is missing."
+        case .entryFileMissing(let entry):
+            return "Scene entry file \(entry) was not found in the cache."
+        case .parseFailed(let detail):
+            return "Failed to parse scene.json: \(detail)"
+        case .unsupportedShader:
+            return "Scene uses unsupported shader features."
+        case .noRenderableObjects:
+            return "Scene has no renderable image layers."
+        }
+    }
+}
+
+/// Diagnostic emitted by the parser when a non-critical field is missing or
+/// uses a feature Phase 2.0 does not yet support. Displayed by the UI as
+/// secondary text and counted into the capability tier.
+struct WPESceneDiagnostic: Equatable, Sendable {
+    enum Severity: String, Sendable, Equatable {
+        case info
+        case warning
+    }
+
+    let severity: Severity
+    let message: String
+
+    init(severity: Severity, message: String) {
+        self.severity = severity
+        self.message = message
+    }
+}

--- a/LiveWallpaper/Models/WallpaperBookmark.swift
+++ b/LiveWallpaper/Models/WallpaperBookmark.swift
@@ -28,6 +28,7 @@ struct WallpaperBookmark: Identifiable, Codable, Equatable {
         case .video: return "play.rectangle"
         case .html(let source, _): return source.iconName
         case .metalShader: return "sparkles.rectangle.stack"
+        case .scene: return "cube.transparent"
         }
     }
 }

--- a/LiveWallpaper/Models/WallpaperContent.swift
+++ b/LiveWallpaper/Models/WallpaperContent.swift
@@ -4,6 +4,7 @@ enum WallpaperContent: Equatable, Sendable {
     case video(bookmarkData: Data)
     case html(source: HTMLSource, config: HTMLConfig)
     case metalShader(MetalShaderPreset)
+    case scene(SceneDescriptor)
 
     var wallpaperType: WallpaperType {
         switch self {
@@ -13,6 +14,8 @@ enum WallpaperContent: Equatable, Sendable {
             return .html
         case .metalShader:
             return .metalShader
+        case .scene:
+            return .scene
         }
     }
 
@@ -35,13 +38,18 @@ enum WallpaperContent: Equatable, Sendable {
         guard case .metalShader(let preset) = self else { return nil }
         return preset
     }
+
+    var sceneDescriptor: SceneDescriptor? {
+        guard case .scene(let descriptor) = self else { return nil }
+        return descriptor
+    }
 }
 
 // MARK: - Codable
 
 extension WallpaperContent: Codable {
     private enum CodingKeys: String, CodingKey {
-        case video, html, metalShader
+        case video, html, metalShader, scene
     }
 
     private enum VideoCodingKeys: String, CodingKey {
@@ -56,6 +64,10 @@ extension WallpaperContent: Codable {
 
     private enum ShaderCodingKeys: String, CodingKey {
         case preset = "_0"
+    }
+
+    private enum SceneCodingKeys: String, CodingKey {
+        case descriptor
     }
 
     init(from decoder: Decoder) throws {
@@ -86,6 +98,12 @@ extension WallpaperContent: Codable {
             return
         }
 
+        if let sceneNested = try? container.nestedContainer(keyedBy: SceneCodingKeys.self, forKey: .scene) {
+            let descriptor = try sceneNested.decode(SceneDescriptor.self, forKey: .descriptor)
+            self = .scene(descriptor)
+            return
+        }
+
         throw DecodingError.dataCorrupted(
             DecodingError.Context(
                 codingPath: decoder.codingPath,
@@ -107,6 +125,9 @@ extension WallpaperContent: Codable {
         case .metalShader(let preset):
             var nested = container.nestedContainer(keyedBy: ShaderCodingKeys.self, forKey: .metalShader)
             try nested.encode(preset, forKey: .preset)
+        case .scene(let descriptor):
+            var nested = container.nestedContainer(keyedBy: SceneCodingKeys.self, forKey: .scene)
+            try nested.encode(descriptor, forKey: .descriptor)
         }
     }
 }

--- a/LiveWallpaper/Models/WallpaperType.swift
+++ b/LiveWallpaper/Models/WallpaperType.swift
@@ -15,9 +15,10 @@ enum WallpaperType: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    /// `false` when this segment is a UI-only label (Wallpaper Engine import surface)
-    /// that does not map to a `WallpaperContent` case at runtime.
+    /// Phase 2.0+: every wallpaper type — including `.scene` — now maps to a
+    /// `WallpaperContent` case at runtime. Kept around as an explicit hook so
+    /// future UI-only labels can opt out without rewriting call sites.
     var hasDirectContent: Bool {
-        self != .scene
+        true
     }
 }

--- a/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
+++ b/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
@@ -60,4 +60,81 @@ final class AmbientWallpaperSessionBuilder {
         window.orderBack(nil)
         return AmbientWallpaperSession(window: window, wallpaperType: .metalShader, performanceTarget: metalView)
     }
+
+    /// Builds the SpriteKit-backed scene wallpaper session.
+    /// Returns nil when the descriptor's cache directory cannot be located —
+    /// caller falls back to the not-configured Scene tab placeholder rather
+    /// than mounting an empty SKView.
+    func makeSceneSession(
+        descriptor: SceneDescriptor,
+        frame: CGRect,
+        applicationSupportRootURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> SceneWallpaperSession? {
+        let supportRoot: URL
+        if let applicationSupportRootURL {
+            supportRoot = applicationSupportRootURL
+        } else if let resolved = try? fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) {
+            supportRoot = resolved.appendingPathComponent("LiveWallpaper", isDirectory: true)
+        } else {
+            return nil
+        }
+
+        // Re-validate cache path before joining — a tampered descriptor
+        // with `..` segments must never escape application support.
+        guard isSafeCacheRelativePath(descriptor.cacheRelativePath) else {
+            Logger.warning("Scene descriptor cache path failed safety check: \(descriptor.cacheRelativePath)", category: .screenManager)
+            return nil
+        }
+        // Resolve symlinks BEFORE the containment check — otherwise a cache
+        // root that is itself a symlink (e.g. from a malicious migration
+        // tool) would point outside Application Support and still pass the
+        // textual prefix match.
+        let safeSupportRoot = supportRoot.standardizedFileURL.resolvingSymlinksInPath()
+        let cacheURL = safeSupportRoot
+            .appendingPathComponent(descriptor.cacheRelativePath, isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let rootPath = safeSupportRoot.path
+        guard cacheURL.path == rootPath || cacheURL.path.hasPrefix(rootPath + "/") else {
+            Logger.warning("Scene descriptor cache escapes app support: \(descriptor.cacheRelativePath)", category: .screenManager)
+            return nil
+        }
+        guard fileManager.fileExists(atPath: cacheURL.path) else {
+            Logger.warning("Scene descriptor cache directory missing: \(cacheURL.path)", category: .screenManager)
+            return nil
+        }
+        // Last-mile entry file probe so we don't mount an SKView that the
+        // controller will immediately throw out of `load()`.
+        let entryProbe = SceneResourceResolver(cacheRootURL: cacheURL)
+        guard (try? entryProbe.resolveExistingFileURL(relativePath: descriptor.entryFile)) != nil else {
+            Logger.warning("Scene descriptor entry file failed safety check: \(descriptor.entryFile)", category: .screenManager)
+            return nil
+        }
+
+        let window = VideoWallpaperWindow(frame: frame)
+        let controller = SceneRenderingController(
+            descriptor: descriptor,
+            cacheRootURL: cacheURL,
+            frame: CGRect(origin: .zero, size: frame.size)
+        )
+        window.contentView = controller.view
+        window.orderBack(nil)
+
+        let session = SceneWallpaperSession(window: window, controller: controller)
+        session.startLoadIfNeeded()
+        return session
+    }
+
+    private func isSafeCacheRelativePath(_ path: String) -> Bool {
+        path.hasPrefix("wpe-cache/")
+            && !path.contains("\\")
+            && !path.contains("..")
+            && !path.contains("//")
+    }
 }

--- a/LiveWallpaper/Runtime/ExclusiveRenderingCoordinator.swift
+++ b/LiveWallpaper/Runtime/ExclusiveRenderingCoordinator.swift
@@ -1,0 +1,76 @@
+import AppKit
+import Foundation
+import Observation
+
+/// Tracks whether the LiveWallpaper console / settings window is the key
+/// window so the desktop scene can drop to 1 fps while the user is
+/// interacting with the app. Wallpaper windows themselves never qualify as
+/// "console key" — only normal windows that the AppKit window list reports
+/// are eligible.
+@MainActor @Observable
+final class ExclusiveRenderingCoordinator {
+    private(set) var isConsoleKeyWindow: Bool = false
+
+    private var observers: [NSObjectProtocol] = []
+    private let center = NotificationCenter.default
+    private(set) var isRunning = false
+
+    // No deinit cleanup: callers explicitly invoke `stop()` (mirrors
+    // `WallpaperAutomationCoordinator.stop()` and other ScreenManager-owned
+    // observers). Adding a deinit here would force isolation hops and pull
+    // a non-Sendable observer list across actors.
+
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+
+        let names: [Notification.Name] = [
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didResignKeyNotification,
+            NSApplication.didBecomeActiveNotification,
+            NSApplication.didResignActiveNotification
+        ]
+        for name in names {
+            let observer = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                Task { @MainActor in
+                    self?.refreshFromCurrentState()
+                }
+            }
+            observers.append(observer)
+        }
+        // Compute the initial state once so the consumer sees a well-defined
+        // value before the first notification fires.
+        refreshFromCurrentState()
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        isRunning = false
+        observers.forEach(center.removeObserver)
+        observers.removeAll()
+    }
+
+    private func refreshFromCurrentState() {
+        let app = NSApplication.shared
+        let active = app.isActive
+        let nextValue = active && Self.isInteractiveConsoleKeyWindow(app.keyWindow)
+        if nextValue != isConsoleKeyWindow {
+            isConsoleKeyWindow = nextValue
+        }
+    }
+
+    /// Wallpaper windows are tagged with a non-default level + non-resizable
+    /// style mask; treat anything that looks like one as "not the console
+    /// window" so the scene runtime is not throttled by its own host.
+    private static func isInteractiveConsoleKeyWindow(_ window: NSWindow?) -> Bool {
+        guard let window else { return false }
+        if window is VideoWallpaperWindow { return false }
+        // Wallpaper windows live on the desktop level — anything ≤ desktopWindow
+        // is by construction NOT a console-style window. Check explicitly so
+        // future wallpaper window types without the dedicated subclass still
+        // get filtered out.
+        let desktopLevel = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.desktopWindow)))
+        if window.level.rawValue <= desktopLevel.rawValue { return false }
+        return window.canBecomeKey
+    }
+}

--- a/LiveWallpaper/Runtime/SceneRenderingController.swift
+++ b/LiveWallpaper/Runtime/SceneRenderingController.swift
@@ -1,0 +1,254 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import SpriteKit
+
+/// Phase 2.0 image-only SpriteKit runtime for Wallpaper Engine `.scene`
+/// content. Owns an `SKView` + `SKScene` pair on the main actor — the SK
+/// stack is itself main-actor-bound so we lean on the type system to keep
+/// callers on the right queue.
+///
+/// Loading is async because we read `scene.json` from disk and decode the
+/// PNG/JPG layers off-main via Task work items. Once `load()` returns the
+/// scene is mounted; the caller can then ask for `view` to insert into a
+/// wallpaper window.
+@MainActor
+final class SceneRenderingController {
+    /// Default frame rate target when not throttled. `SKView` clamps this to
+    /// the display's refresh rate so 60 means "render every vsync".
+    static let defaultPreferredFPS = 60
+    static let throttledPreferredFPS = 1
+
+    private let descriptor: SceneDescriptor
+    private let cacheRootURL: URL
+    private let resolver: SceneResourceResolver
+    private let initialFrame: CGRect
+
+    private let skView: SKView
+    private var scene: SKScene?
+    private var didLoad = false
+    private var isThrottled = false
+    private var currentProfile: WallpaperPerformanceProfile = .quality
+
+    init(descriptor: SceneDescriptor, cacheRootURL: URL, frame: CGRect) {
+        self.descriptor = descriptor
+        self.cacheRootURL = cacheRootURL
+        self.resolver = SceneResourceResolver(cacheRootURL: cacheRootURL)
+        self.initialFrame = frame
+        let view = SKView(frame: frame)
+        view.allowsTransparency = true
+        view.ignoresSiblingOrder = true
+        view.autoresizingMask = [.width, .height]
+        view.preferredFramesPerSecond = Self.defaultPreferredFPS
+        // Diagnostic overlays are off by default so they never bleed into
+        // the wallpaper output for end users; the build flag still allows
+        // turning them on for triage.
+        view.showsFPS = false
+        view.showsNodeCount = false
+        view.showsDrawCount = false
+        self.skView = view
+    }
+
+    var view: SKView { skView }
+
+    /// Materialises the SpriteKit scene from disk. Idempotent — calling it
+    /// twice is a no-op on the second pass so the wallpaper session can
+    /// safely re-prepare on focus changes.
+    func load() async throws {
+        guard !didLoad else { return }
+
+        // Defense-in-depth: route `entryFile` through the same path-safety
+        // gate as image layers so a tampered descriptor with `..` segments
+        // cannot read files outside the cache root.
+        let entryURL: URL
+        do {
+            entryURL = try resolver.resolveExistingFileURL(relativePath: descriptor.entryFile)
+        } catch {
+            throw SceneRenderingError.entryFileMissing(descriptor.entryFile)
+        }
+
+        let document: WPESceneDocument
+        do {
+            // I/O off-main: parse on a background task so a 100 KiB
+            // scene.json doesn't stall the run loop on a slow disk.
+            let parsedDocument = try await Task.detached(priority: .userInitiated) {
+                let data = try Data(contentsOf: entryURL)
+                return try WPESceneDocumentParser.parse(data: data)
+            }.value
+            document = parsedDocument
+        } catch let error as WPESceneDocumentError {
+            throw SceneRenderingError.parseFailed(error.errorDescription ?? "scene.json parse failed")
+        } catch {
+            throw SceneRenderingError.parseFailed(error.localizedDescription)
+        }
+
+        let projection = document.general.orthogonalProjection
+        let canvasSize = CGSize(
+            width: max(projection.width, 1),
+            height: max(projection.height, 1)
+        )
+
+        let scene = SKScene(size: canvasSize)
+        scene.scaleMode = .aspectFill
+        scene.backgroundColor = NSColor(
+            red: CGFloat(document.general.clearColor.x),
+            green: CGFloat(document.general.clearColor.y),
+            blue: CGFloat(document.general.clearColor.z),
+            alpha: 1
+        )
+
+        var renderableLayers = 0
+        for object in document.imageObjects where object.visible && object.alpha > 0.001 {
+            do {
+                let cgImage = try resolver.resolveImage(relativePath: object.imageRelativePath)
+                let texture = SKTexture(cgImage: cgImage)
+                texture.filteringMode = .linear
+                let node = makeSpriteNode(texture: texture, object: object, canvas: canvasSize)
+                scene.addChild(node)
+                renderableLayers += 1
+            } catch SceneResourceResolver.ResolveError.unsupportedTexture {
+                Logger.warning("Scene \(descriptor.workshopID): skipping .tex layer \(object.name)", category: .screenManager)
+            } catch SceneResourceResolver.ResolveError.fileMissing {
+                Logger.warning("Scene \(descriptor.workshopID): missing asset for layer \(object.name)", category: .screenManager)
+            } catch {
+                Logger.warning("Scene \(descriptor.workshopID): failed to load \(object.name): \(error.localizedDescription)", category: .screenManager)
+            }
+        }
+
+        guard renderableLayers > 0 else {
+            throw SceneRenderingError.noRenderableObjects
+        }
+
+        skView.presentScene(scene)
+        scene.isPaused = currentProfile == .suspended
+        self.scene = scene
+        didLoad = true
+    }
+
+    /// Drops the SKView's frame rate target to 1 fps when throttled. Keeps
+    /// every node alive so we can flip back to full speed without re-loading.
+    func setThrottled(_ throttled: Bool) {
+        guard isThrottled != throttled else { return }
+        isThrottled = throttled
+        // Suspended takes priority: a throttle while suspended must keep the
+        // scene paused. Re-applying the profile flushes both flags together.
+        applyEffectiveState()
+    }
+
+    /// Power policy hook. `.suspended` halts ticks (`SKScene.isPaused`),
+    /// `.degradedAnimation` and `.quality` map to the active fps target.
+    func applyPerformanceProfile(_ profile: WallpaperPerformanceProfile) {
+        currentProfile = profile
+        applyEffectiveState()
+    }
+
+    func cleanup() {
+        scene?.removeAllChildren()
+        scene?.removeAllActions()
+        skView.presentScene(nil)
+        scene = nil
+        didLoad = false
+    }
+
+    // MARK: - Private
+
+    private func applyEffectiveState() {
+        let suspended = currentProfile == .suspended
+        scene?.isPaused = suspended
+        if suspended {
+            // SKView.isPaused doesn't exist as such; pausing the scene tree
+            // already stops ticking. Drop the framerate further so vsync
+            // wakeups stop too.
+            skView.preferredFramesPerSecond = Self.throttledPreferredFPS
+            return
+        }
+        skView.preferredFramesPerSecond = isThrottled
+            ? Self.throttledPreferredFPS
+            : Self.defaultPreferredFPS
+    }
+
+    private func makeSpriteNode(
+        texture: SKTexture,
+        object: WPESceneImageObject,
+        canvas: CGSize
+    ) -> SKSpriteNode {
+        let textureSize = texture.size()
+        let baseSize: CGSize
+        if let explicit = object.size, explicit.width > 0, explicit.height > 0 {
+            baseSize = explicit
+        } else {
+            baseSize = textureSize
+        }
+
+        let node = SKSpriteNode(texture: texture)
+        node.name = object.name
+        node.size = CGSize(
+            width: baseSize.width * CGFloat(object.scale.x),
+            height: baseSize.height * CGFloat(object.scale.y)
+        )
+        node.alpha = CGFloat(object.alpha)
+        node.color = NSColor(
+            red: CGFloat(object.color.x),
+            green: CGFloat(object.color.y),
+            blue: CGFloat(object.color.z),
+            alpha: 1
+        )
+        node.colorBlendFactor = colorBlendFactor(for: object.color, brightness: object.brightness)
+        node.blendMode = blendMode(for: object.blendMode)
+        node.zRotation = CGFloat(object.angles.z) * .pi / 180
+
+        // WPE origin is the absolute world position in projection-space
+        // pixels with the origin at the bottom-left of the canvas. SpriteKit
+        // uses the same origin convention so we plug origin in directly,
+        // clamped to the canvas size if the value is normalized 0–1.
+        node.position = position(
+            for: object.origin,
+            canvas: canvas,
+            alignment: object.alignment
+        )
+
+        return node
+    }
+
+    private func colorBlendFactor(for color: SIMD3<Double>, brightness: Double) -> CGFloat {
+        let neutralColor = (color.x == 1 && color.y == 1 && color.z == 1)
+        let neutralBrightness = brightness == 1
+        return (neutralColor && neutralBrightness) ? 0 : 1
+    }
+
+    private func blendMode(for mode: WPESceneBlendMode) -> SKBlendMode {
+        switch mode {
+        case .normal:       return .alpha
+        case .translucent:  return .alpha
+        case .additive:     return .add
+        case .multiply:     return .multiply
+        case .screen:       return .screen
+        }
+    }
+
+    private func position(
+        for origin: SIMD3<Double>,
+        canvas: CGSize,
+        alignment: WPESceneAlignment
+    ) -> CGPoint {
+        let x = CGFloat(origin.x)
+        let y = CGFloat(origin.y)
+        // Treat values inside 0..1 as normalized — community wallpapers mix
+        // both conventions and the documentation is silent on which is
+        // canonical. Outside that range we trust the absolute pixel value.
+        let xPx = (x >= 0 && x <= 1) ? x * canvas.width : x
+        let yPx = (y >= 0 && y <= 1) ? y * canvas.height : y
+
+        switch alignment {
+        case .center:       return CGPoint(x: xPx, y: yPx)
+        case .topLeft:      return CGPoint(x: xPx, y: canvas.height - yPx)
+        case .topRight:     return CGPoint(x: canvas.width - xPx, y: canvas.height - yPx)
+        case .bottomLeft:   return CGPoint(x: xPx, y: yPx)
+        case .bottomRight:  return CGPoint(x: canvas.width - xPx, y: yPx)
+        case .top:          return CGPoint(x: xPx, y: canvas.height - yPx)
+        case .bottom:       return CGPoint(x: xPx, y: yPx)
+        case .left:         return CGPoint(x: xPx, y: yPx)
+        case .right:        return CGPoint(x: canvas.width - xPx, y: yPx)
+        }
+    }
+}

--- a/LiveWallpaper/Runtime/SceneWallpaperSession.swift
+++ b/LiveWallpaper/Runtime/SceneWallpaperSession.swift
@@ -1,0 +1,107 @@
+import AppKit
+
+/// Adapter that exposes the SpriteKit-backed `SceneRenderingController` to
+/// `ScreenManager` through the shared `WallpaperRuntimeSession` protocol so
+/// the rest of the runtime stack does not need a scene-specific code path.
+@MainActor
+final class SceneWallpaperSession: WallpaperRuntimeSession {
+    let wallpaperType: WallpaperType = .scene
+
+    private var window: NSWindow?
+    private var controller: SceneRenderingController?
+    private var currentProfile: WallpaperPerformanceProfile = .quality
+    private var isVisible = true
+    private var didStartLoad = false
+    private(set) var isThrottled = false
+    private(set) var loadError: SceneRenderingError?
+
+    init(window: NSWindow, controller: SceneRenderingController) {
+        self.window = window
+        self.controller = controller
+    }
+
+    var summary: WallpaperSessionSummary {
+        let activity: WallpaperSessionActivity
+        if loadError != nil {
+            activity = .paused
+        } else if isVisible && currentProfile != .suspended {
+            activity = .active
+        } else {
+            activity = .paused
+        }
+        return WallpaperSessionSummary(
+            wallpaperType: .scene,
+            activity: activity,
+            supportsPlaybackControl: false,
+            subtitle: loadError?.errorDescription
+        )
+    }
+
+    var videoPlayer: WallpaperVideoPlayer? { nil }
+    var wallpaperWindow: NSWindow? { window }
+
+    /// Hand the controller out so coordinators outside the session (e.g.
+    /// the exclusive-rendering coordinator) can flip throttle state without
+    /// reaching through `wallpaperWindow.contentView`.
+    var sceneController: SceneRenderingController? { controller }
+
+    func updateFrame(to frame: CGRect) {
+        window?.setFrame(frame, display: true)
+        controller?.view.frame = CGRect(origin: .zero, size: frame.size)
+    }
+
+    func show() {
+        isVisible = true
+        window?.orderBack(nil)
+        controller?.applyPerformanceProfile(currentProfile)
+    }
+
+    func hide() {
+        isVisible = false
+        window?.orderOut(nil)
+        controller?.applyPerformanceProfile(.suspended)
+    }
+
+    func applyPerformanceProfile(_ profile: WallpaperPerformanceProfile) {
+        currentProfile = profile
+        controller?.applyPerformanceProfile(isVisible ? profile : .suspended)
+    }
+
+    /// Exclusive-rendering coordinator entry point. Throttling is orthogonal
+    /// to power profile — when console window is key we drop to 1fps even on
+    /// `.quality`, then bounce back when the user goes away.
+    func setThrottled(_ throttled: Bool) {
+        isThrottled = throttled
+        controller?.setThrottled(throttled)
+    }
+
+    func cleanup() {
+        controller?.cleanup()
+        controller = nil
+        window?.close()
+        window = nil
+    }
+
+    /// Loads the SpriteKit scene. Safe to call multiple times — only the
+    /// first call performs I/O.
+    func startLoadIfNeeded() {
+        guard !didStartLoad, let controller else { return }
+        didStartLoad = true
+        Task { @MainActor [weak self] in
+            do {
+                try await controller.load()
+                self?.loadError = nil
+            } catch let error as SceneRenderingError {
+                Logger.warning("Scene wallpaper load failed: \(error.errorDescription ?? "(no description)")", category: .screenManager)
+                self?.loadError = error
+            } catch {
+                Logger.warning("Scene wallpaper load failed: \(error.localizedDescription)", category: .screenManager)
+                self?.loadError = .parseFailed(error.localizedDescription)
+            }
+        }
+    }
+
+    // No prepareForDisplay override: the protocol-extension default
+    // (50ms warm-up) gives the SpriteKit pipeline enough lead time before
+    // the wallpaper window is brought to screen.
+}

--- a/LiveWallpaper/Runtime/WallpaperSessionDefinition.swift
+++ b/LiveWallpaper/Runtime/WallpaperSessionDefinition.swift
@@ -5,6 +5,7 @@ enum WallpaperSessionDefinition: Equatable {
     case video(bookmarkData: Data)
     case html(HTMLSource, HTMLConfig)
     case metalShader(MetalShaderPreset)
+    case scene(SceneDescriptor)
 
     init?(configuration: ScreenConfiguration) {
         switch configuration.activeWallpaper {
@@ -18,6 +19,14 @@ enum WallpaperSessionDefinition: Equatable {
             self = .html(source, config)
         case .metalShader(let preset):
             self = .metalShader(preset)
+        case .scene(let descriptor):
+            // Reject obviously broken descriptors so ScreenManager falls
+            // back to the not-configured Scene tab placeholder. The cache
+            // resolver re-validates the path on its end too.
+            guard !descriptor.workshopID.isEmpty,
+                  !descriptor.cacheRelativePath.isEmpty,
+                  !descriptor.entryFile.isEmpty else { return nil }
+            self = .scene(descriptor)
         }
     }
 
@@ -29,6 +38,8 @@ enum WallpaperSessionDefinition: Equatable {
             return source.displayName
         case .metalShader(let preset):
             return preset.rawValue
+        case .scene(let descriptor):
+            return "Scene \(descriptor.workshopID)"
         }
     }
 }

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -68,6 +68,8 @@ final class ScreenManager {
     @ObservationIgnored private let fullScreenDetector = FullScreenDetector()
     @ObservationIgnored private let videoEffectsApplier = VideoEffectsApplicationService()
     @ObservationIgnored private let restoresSavedWallpapersOnScreenRefresh: Bool
+    @ObservationIgnored private let exclusiveRenderingCoordinator = ExclusiveRenderingCoordinator()
+    @ObservationIgnored private var exclusiveRenderingObservation: NSObjectProtocol?
     /// Drops stale async video transitions.
     @ObservationIgnored private var transitionGeneration: [CGDirectDisplayID: Int] = [:]
     /// Drops stale async WPE imports per screen (mirrors `transitionGeneration`).
@@ -86,6 +88,7 @@ final class ScreenManager {
         setupScreenObservers()
         setupMemoryMonitoring()
         setupFullScreenDetection()
+        setupExclusiveRenderingCoordinator()
         _ = lockScreenSnapshotCoordinator
 
         NotificationCenter.default.publisher(for: WallpaperVideoPlayer.didChangePlaybackStateNotification)
@@ -174,6 +177,39 @@ final class ScreenManager {
         observeFullScreenChanges()
         fullScreenDetector.checkNow()
         handleFullScreenChange(fullScreenDetector.hiddenScreens)
+    }
+
+    /// Wires the console-key-window observer so scene wallpapers throttle to
+    /// 1 fps while the user is interacting with the LiveWallpaper UI. This is
+    /// the Phase 2.0 "exclusive rendering" policy — scene rendering is the
+    /// most expensive wallpaper type and should yield to anything in the
+    /// foreground.
+    private func setupExclusiveRenderingCoordinator() {
+        exclusiveRenderingCoordinator.start()
+        // Observation framework: register a withObservationTracking loop so
+        // the throttle propagates to every scene session.
+        scheduleConsoleKeyTracking()
+    }
+
+    private func scheduleConsoleKeyTracking() {
+        let snapshot = exclusiveRenderingCoordinator.isConsoleKeyWindow
+        applyConsoleKeyState(isConsoleKey: snapshot)
+        withObservationTracking {
+            _ = exclusiveRenderingCoordinator.isConsoleKeyWindow
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                self.applyConsoleKeyState(isConsoleKey: self.exclusiveRenderingCoordinator.isConsoleKeyWindow)
+                self.scheduleConsoleKeyTracking()
+            }
+        }
+    }
+
+    private func applyConsoleKeyState(isConsoleKey: Bool) {
+        for screen in screens {
+            guard let session = screen.runtimeSession as? SceneWallpaperSession else { continue }
+            session.setThrottled(isConsoleKey)
+        }
     }
 
     private func observeFullScreenChanges() {
@@ -357,6 +393,8 @@ final class ScreenManager {
             activateAmbientWallpaper(.html(source, htmlConfig), for: screen)
         case .metalShader(let preset):
             activateAmbientWallpaper(.metalShader(preset), for: screen)
+        case .scene(let descriptor):
+            activateAmbientWallpaper(.scene(descriptor), for: screen)
         }
     }
     
@@ -1459,6 +1497,30 @@ final class ScreenManager {
         case .metalShader(let preset):
             session = ambientSessionBuilder.makeShaderSession(preset: preset, frame: screen.frame)
             Logger.info("Set shader wallpaper (\(preset.rawValue)) for screen \(screen.id)", category: .screenManager)
+        case .scene(let descriptor):
+            guard let sceneSession = ambientSessionBuilder.makeSceneSession(
+                descriptor: descriptor,
+                frame: screen.frame
+            ) else {
+                Logger.warning("Scene wallpaper for screen \(screen.id) (workshop \(descriptor.workshopID)) could not be built — cache missing or descriptor invalid", category: .screenManager)
+                return
+            }
+            screen.installRuntimeSession(sceneSession)
+            // Sync exclusive-rendering state on install so a scene mounted
+            // while the inspector window is already key starts at 1 fps
+            // instead of waiting for the next focus toggle to throttle it.
+            sceneSession.setThrottled(exclusiveRenderingCoordinator.isConsoleKeyWindow)
+            let globalSettings = SettingsManager.shared.loadGlobalSettings()
+            applyPerformancePolicy(
+                to: screen,
+                globalSettings: globalSettings,
+                powerSource: powerMonitor.currentPowerSource,
+                isHiddenByFullScreen: globalSettings.pauseOnFullScreen &&
+                    fullScreenDetector.isDesktopHidden(for: screen.id)
+            )
+            Logger.info("Set scene wallpaper (workshop \(descriptor.workshopID)) for screen \(screen.id)", category: .screenManager)
+            notifyWallpaperSessionChanged()
+            return
         case .video:
             return
         }

--- a/LiveWallpaper/SettingsManager.swift
+++ b/LiveWallpaper/SettingsManager.swift
@@ -204,6 +204,13 @@ final class SettingsManager {
             return validateHTMLSource(source, for: screenID)
         case .metalShader:
             return true
+        case .scene(let descriptor):
+            // The cache resolver re-validates `cacheRelativePath` on resume,
+            // so here we only confirm the descriptor still has the parts
+            // needed to even attempt a cache lookup.
+            return !descriptor.workshopID.isEmpty
+                && !descriptor.cacheRelativePath.isEmpty
+                && !descriptor.entryFile.isEmpty
         }
     }
 

--- a/LiveWallpaper/Views/BookmarksLibraryView.swift
+++ b/LiveWallpaper/Views/BookmarksLibraryView.swift
@@ -133,6 +133,10 @@ struct BookmarksLibraryView: View {
             screenManager.setHTMLWallpaper(source: source, config: config, for: screen)
         case .metalShader(let preset):
             screenManager.setShaderWallpaper(preset: preset, for: screen)
+        case .scene:
+            // Scene bookmarks need the import service path; ignore here so we
+            // never reapply a stale descriptor to a different screen.
+            Logger.warning("Scene bookmark apply is not supported in Phase 2.0", category: .screenManager)
         }
     }
 
@@ -288,6 +292,7 @@ private struct BookmarkCard: View {
         case .video: return .blue
         case .html: return .green
         case .metalShader: return .purple
+        case .scene: return .orange
         }
     }
 
@@ -299,6 +304,8 @@ private struct BookmarkCard: View {
             return source.displayName
         case .metalShader(let preset):
             return preset.rawValue
+        case .scene(let descriptor):
+            return "Workshop \(descriptor.workshopID)"
         }
     }
 }

--- a/LiveWallpaper/Views/BookmarksPopover.swift
+++ b/LiveWallpaper/Views/BookmarksPopover.swift
@@ -135,6 +135,12 @@ struct BookmarksPopover: View {
             screenManager.setHTMLWallpaper(source: source, config: config, for: screen)
         case .metalShader(let preset):
             screenManager.setShaderWallpaper(preset: preset, for: screen)
+        case .scene:
+            // Scene bookmarks are not yet user-applicable from the popover —
+            // the import flow owns SceneDescriptor lifecycle. Surface a log
+            // for diagnostics and ignore so we never hand a stale descriptor
+            // to ScreenManager without going through the import service.
+            Logger.warning("Scene bookmark apply is not supported in Phase 2.0", category: .screenManager)
         }
     }
 }
@@ -231,6 +237,7 @@ private struct BookmarkRow: View {
         case .video: return .blue
         case .html: return .green
         case .metalShader: return .purple
+        case .scene: return .orange
         }
     }
 
@@ -242,6 +249,8 @@ private struct BookmarkRow: View {
             return source.displayName
         case .metalShader(let preset):
             return preset.rawValue
+        case .scene(let descriptor):
+            return "Workshop \(descriptor.workshopID)"
         }
     }
 }

--- a/LiveWallpaper/Views/Components/LiquidGlassSpinner.swift
+++ b/LiveWallpaper/Views/Components/LiquidGlassSpinner.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Custom Liquid Glass loading indicator. Used by the scene detail card while
+/// the SpriteKit runtime is decoding image layers. Two stacked rotating arcs
+/// keep the motion gentle so it doesn't compete with the underlying GIF
+/// preview that fades through during the loading phase.
+struct LiquidGlassSpinner: View {
+    var size: CGFloat = 44
+    var lineWidth: CGFloat = 4
+    var tint: Color = .white
+
+    @State private var animate = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(tint.opacity(0.12), lineWidth: lineWidth)
+
+            Circle()
+                .trim(from: 0, to: 0.32)
+                .stroke(
+                    tint.opacity(0.85),
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(animate ? 360 : 0))
+                .blendMode(.plusLighter)
+                .animation(.linear(duration: 1.1).repeatForever(autoreverses: false), value: animate)
+
+            Circle()
+                .trim(from: 0, to: 0.18)
+                .stroke(
+                    tint.opacity(0.55),
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(animate ? -360 : 0))
+                .blendMode(.plusLighter)
+                .animation(.linear(duration: 1.7).repeatForever(autoreverses: false), value: animate)
+        }
+        .frame(width: size, height: size)
+        .onAppear { animate = true }
+        .accessibilityHidden(true)
+    }
+}
+
+#Preview {
+    LiquidGlassSpinner()
+        .padding(48)
+        .background(.black)
+}

--- a/LiveWallpaper/Views/ScreenDetail/ScenePreviewContainer.swift
+++ b/LiveWallpaper/Views/ScreenDetail/ScenePreviewContainer.swift
@@ -1,0 +1,47 @@
+import AppKit
+import SpriteKit
+import SwiftUI
+
+/// SwiftUI bridge for previewing the SpriteKit-backed scene. CRITICAL: this
+/// host does NOT re-parent the live wallpaper's SKView — that view belongs to
+/// the wallpaper window on the desktop. Reparenting it into the inspector
+/// would silently strip the wallpaper from the desktop, leaving a black
+/// rectangle behind and breaking the whole "set scene wallpaper" UX.
+///
+/// Instead we mount a separate `SKView` and present a *snapshot* of the
+/// controller's scene graph. SpriteKit's `SKScene.copy()` deep-copies the
+/// node tree but keeps texture references alive, so the inspector preview
+/// stays in sync with what the controller is showing without competing for
+/// the same view ownership.
+@MainActor
+struct ScenePreviewContainer: NSViewRepresentable {
+    let controller: SceneRenderingController
+
+    func makeNSView(context: Context) -> SKView {
+        let view = SKView(frame: .zero)
+        view.allowsTransparency = true
+        view.ignoresSiblingOrder = true
+        view.preferredFramesPerSecond = SceneRenderingController.defaultPreferredFPS
+        view.presentScene(snapshotScene())
+        return view
+    }
+
+    func updateNSView(_ nsView: SKView, context: Context) {
+        // Re-snapshot on update so the inspector reflects scene changes.
+        // `presentScene(nil)` first to avoid a transient half-rendered frame.
+        if let scene = snapshotScene() {
+            nsView.presentScene(nil)
+            nsView.presentScene(scene)
+        }
+    }
+
+    /// Deep-copies the controller's live `SKScene`. Returns nil before the
+    /// controller has finished `load()` — caller renders a placeholder until
+    /// the snapshot becomes available.
+    private func snapshotScene() -> SKScene? {
+        guard let live = controller.view.scene,
+              let copy = live.copy() as? SKScene else { return nil }
+        copy.isPaused = live.isPaused
+        return copy
+    }
+}

--- a/LiveWallpaper/Views/ScreenDetail/WPEFallbackCard.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEFallbackCard.swift
@@ -1,16 +1,31 @@
 import SwiftUI
 import AppKit
 
-/// Centered placeholder shown when the user picks a scene-type or
-/// application-type history entry — non-destructive (no wallpaper change).
-struct WPEUnsupportedCard: View {
+/// Why a Wallpaper Engine workshop project couldn't be activated. Surfaced
+/// to the inspector so the user gets a specific reason instead of a generic
+/// "unsupported" message.
+enum FallbackReason: Equatable, Sendable {
+    case unsupportedType
+    case sceneParseFailed(String)
+    case sceneShaderUnsupported
+    case sceneResourceMissing
+}
+
+/// Renders the explanatory card for any WPE workshop import that cannot be
+/// promoted to a live wallpaper. Replaces the Phase 1.x `WPEUnsupportedCard`
+/// with a reason-aware variant so scene parse failures, missing assets, and
+/// genuinely unsupported types each get their own copy.
+struct WPEFallbackCard: View {
     let origin: WPEOrigin
+    let reason: FallbackReason
+
+    init(origin: WPEOrigin, reason: FallbackReason = .unsupportedType) {
+        self.origin = origin
+        self.reason = reason
+    }
 
     var body: some View {
         VStack(spacing: 24) {
-            // 1:1 preview now produces a 280×280 square — large enough to
-            // showcase the workshop GIF without dominating the entire
-            // detail card (max-width 480 with 32pt padding).
             WPEPreviewView(
                 imageURL: previewURL,
                 securityScopedBookmarkData: origin.sourceFolderBookmark
@@ -42,7 +57,7 @@ struct WPEUnsupportedCard: View {
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                if origin.originalType == .scene {
+                if origin.originalType == .scene && reason == .unsupportedType {
                     Text("Tip: many creators publish a video version of the same wallpaper.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -64,24 +79,44 @@ struct WPEUnsupportedCard: View {
         .padding(32)
         .frame(maxWidth: 480)
         .glassEffect(.regular, in: .rect(cornerRadius: 24))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(origin.title). \(warningTitle). \(warningBody)")
     }
 
     private var warningTitle: String {
-        switch origin.originalType {
-        case .scene:       return "Scene format coming later"
-        case .application: return "Executable wallpapers can't be imported"
-        default:           return "This wallpaper type is not supported"
+        switch reason {
+        case .unsupportedType:
+            switch origin.originalType {
+            case .scene:       return "Scene format coming later"
+            case .application: return "Executable wallpapers can't be imported"
+            default:           return "This wallpaper type is not supported"
+            }
+        case .sceneParseFailed:
+            return "Couldn't read scene.json"
+        case .sceneShaderUnsupported:
+            return "Scene uses unsupported shaders"
+        case .sceneResourceMissing:
+            return "Some scene assets are missing"
         }
     }
 
     private var warningBody: String {
-        switch origin.originalType {
-        case .scene:
-            return "This wallpaper needs Wallpaper Engine's own 3D rendering engine to play. We're working on Phase 2 support — your other wallpapers continue to play unaffected."
-        case .application:
-            return "For your security, LiveWallpaper does not run executable workshop projects."
-        default:
-            return "We couldn't recognize this Wallpaper Engine project type."
+        switch reason {
+        case .unsupportedType:
+            switch origin.originalType {
+            case .scene:
+                return "This wallpaper needs Wallpaper Engine's own 3D rendering engine to play. We're working on broader Phase 2 support — your other wallpapers continue to play unaffected."
+            case .application:
+                return "For your security, LiveWallpaper does not run executable workshop projects."
+            default:
+                return "We couldn't recognize this Wallpaper Engine project type."
+            }
+        case .sceneParseFailed(let detail):
+            return "Phase 2.0 ships an image-only renderer. The author's scene.json couldn't be parsed: \(detail)"
+        case .sceneShaderUnsupported:
+            return "This scene relies on custom shaders that the image-only Phase 2.0 renderer can't compile yet."
+        case .sceneResourceMissing:
+            return "Some image layers couldn't be located inside the cache. The wallpaper may have been published partially or your cache is corrupted."
         }
     }
 
@@ -102,5 +137,16 @@ struct WPEUnsupportedCard: View {
         components?.queryItems = [URLQueryItem(name: "id", value: origin.workshopID)]
         guard let url = components?.url else { return }
         NSWorkspace.shared.open(url)
+    }
+}
+
+/// Compatibility shim — keeps the old name compiling while Phase 2.x consumers
+/// migrate. Defaults the reason to `.unsupportedType` so the historical
+/// behaviour (badge for unsupported workshop types) is unchanged.
+struct WPEUnsupportedCard: View {
+    let origin: WPEOrigin
+
+    var body: some View {
+        WPEFallbackCard(origin: origin, reason: .unsupportedType)
     }
 }

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
@@ -1,0 +1,339 @@
+import AppKit
+import SpriteKit
+import SwiftUI
+
+/// Phase 2.0 scene detail card. Drives the loading/playing/paused/error state
+/// machine on top of the SKView the wallpaper session already mounted into
+/// the desktop window. The inspector reuses the same `SceneRenderingController`
+/// instance so the preview seen here is byte-identical to the live wallpaper.
+@MainActor
+struct WPESceneDetailView: View {
+    let origin: WPEOrigin
+    let descriptor: SceneDescriptor
+    let session: SceneWallpaperSession?
+    let onClearWallpaper: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var state: SceneRenderState = .idle
+
+    var body: some View {
+        VStack(spacing: 16) {
+            previewCard
+            metadata
+            actions
+        }
+        .padding(24)
+        .frame(maxWidth: 560)
+        .glassEffect(.regular, in: .rect(cornerRadius: 24))
+        .shadow(color: .black.opacity(0.18), radius: 8, y: 4)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(origin.title). Scene wallpaper. \(stateAccessibilityText)")
+        .task(id: descriptor.workshopID) {
+            await refreshState()
+        }
+        // Re-evaluate when ReduceMotion flips so a Settings change immediately
+        // pauses the preview without waiting for a re-render.
+        .onChange(of: reduceMotion) { _, _ in
+            Task { @MainActor in await refreshState() }
+        }
+        .onReceive(Timer.publish(every: 0.4, on: .main, in: .common).autoconnect()) { _ in
+            // Polling is bounded: only fires while we're still resolving
+            // initial state. Once we land in playing/paused/error the timer
+            // becomes a no-op (Timer.publish itself can't be cancelled
+            // reactively from inside .onReceive without keeping a Cancellable
+            // bag, which costs more than the early return).
+            guard state == .idle || state == .loading else { return }
+            Task { @MainActor in
+                await refreshState()
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private var previewCard: some View {
+        ZStack {
+            // The SKView preview never unmounts mid-lifecycle — keeping the
+            // SpriteKit pipeline warm avoids a Metal command-buffer thrash
+            // when the user toggles ReduceMotion / focus / throttle. Pause
+            // is communicated by overlay, not by replacing the SKView.
+            switch state {
+            case .idle, .loading:
+                fallbackBackground
+                LiquidGlassSpinner()
+            case .playing(let controller):
+                ScenePreviewContainer(controller: controller)
+                    .aspectRatio(16.0 / 9.0, contentMode: .fit)
+            case .paused(let reason):
+                if let controller = session?.sceneController {
+                    ScenePreviewContainer(controller: controller)
+                        .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                        .overlay(pausedOverlay(reason: reason))
+                } else {
+                    fallbackBackground
+                        .overlay(pausedOverlay(reason: reason))
+                }
+            case .error(let fallbackReason):
+                fallbackBackground
+                    .overlay(errorOverlay(reason: fallbackReason))
+            }
+        }
+        // Use opacity-only transitions: `.scale` would animate the size of
+        // the NSViewRepresentable host (`ScenePreviewContainer` /
+        // `WPEPreviewView`), which triggers an AppKit Auto-Layout cycle in
+        // the host window pass.
+        .transition(.opacity)
+        .animation(.easeInOut(duration: 0.2), value: stateKey)
+        .frame(maxWidth: .infinity)
+        .frame(minHeight: 260)
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func pausedOverlay(reason: PausedReason) -> some View {
+        ZStack {
+            Color.black.opacity(0.35)
+            VStack(spacing: 8) {
+                Image(systemName: "pause.circle.fill")
+                    .font(.largeTitle)
+                    .foregroundStyle(.white.opacity(0.85))
+                Text(reason.label)
+                    .font(.headline)
+                    .foregroundStyle(.white)
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func errorOverlay(reason: FallbackReason) -> some View {
+        ZStack {
+            Color.black.opacity(0.45)
+            VStack(spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.largeTitle)
+                    .foregroundStyle(.yellow)
+                Text(errorTitle(for: reason))
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                Text(errorBody(for: reason))
+                    .font(.caption)
+                    .foregroundStyle(.white.opacity(0.85))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+            }
+        }
+    }
+
+    /// Inline copy that avoids nesting a full `WPEFallbackCard` (with its
+    /// own glass background) inside this card. Mirrors the WPEFallbackCard
+    /// strings so users see consistent language across surfaces.
+    private func errorTitle(for reason: FallbackReason) -> String {
+        switch reason {
+        case .unsupportedType:        return "Scene format not supported"
+        case .sceneParseFailed:       return "Couldn't read scene.json"
+        case .sceneShaderUnsupported: return "Scene uses unsupported shaders"
+        case .sceneResourceMissing:   return "Some scene assets are missing"
+        }
+    }
+
+    private func errorBody(for reason: FallbackReason) -> String {
+        switch reason {
+        case .unsupportedType:
+            return "We can't render this scene's feature set yet."
+        case .sceneParseFailed(let detail):
+            return detail
+        case .sceneShaderUnsupported:
+            return "Phase 2.0 ships an image-only renderer."
+        case .sceneResourceMissing:
+            return "Image layers couldn't be located inside the cache."
+        }
+    }
+
+    private var fallbackBackground: some View {
+        WPEPreviewView(
+            imageURL: previewURL,
+            securityScopedBookmarkData: origin.sourceFolderBookmark
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .blur(radius: state == .loading ? 6 : 0)
+        .overlay(Color.black.opacity(state == .loading ? 0.35 : 0.0))
+    }
+
+    private var metadata: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(origin.title)
+                    .font(.title3.bold())
+                Spacer()
+                statusPill
+            }
+            Text("Workshop ID \(origin.workshopID) · capability: \(descriptor.capabilityTier.rawValue)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var statusPill: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 8, height: 8)
+            Text(stateLabel)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(.ultraThinMaterial, in: Capsule())
+    }
+
+    private var actions: some View {
+        HStack(spacing: 12) {
+            Button(role: .destructive) {
+                onClearWallpaper()
+            } label: {
+                Label("Clear Scene", systemImage: "xmark.circle")
+            }
+            .buttonStyle(.glass)
+            .controlSize(.regular)
+            .accessibilityHint("Removes the scene wallpaper from this display")
+
+            Spacer()
+        }
+    }
+
+    // MARK: - State derivation
+
+    private func refreshState() async {
+        guard let session else {
+            state = .error(.unsupportedType)
+            return
+        }
+        if let error = session.loadError {
+            state = .error(mapToFallbackReason(error))
+            return
+        }
+        guard let controller = session.sceneController else {
+            state = .idle
+            return
+        }
+        if controller.view.scene == nil {
+            state = .loading
+            return
+        }
+        // Drive the runtime profile from the same env signals the state
+        // machine consults — this is the single point where ReduceMotion
+        // / throttle propagate down to the controller. `applyPerformanceProfile`
+        // is idempotent so re-issuing the current profile every poll is cheap.
+        controller.applyPerformanceProfile(reduceMotion ? .suspended : .quality)
+        if reduceMotion || session.isThrottled {
+            state = .paused(reason: reduceMotion ? .reduceMotion : .throttled)
+            return
+        }
+        state = .playing(controller)
+    }
+
+    private func mapToFallbackReason(_ error: SceneRenderingError) -> FallbackReason {
+        switch error {
+        case .cacheRootMissing, .entryFileMissing:
+            return .sceneResourceMissing
+        case .parseFailed(let detail):
+            return .sceneParseFailed(detail)
+        case .unsupportedShader:
+            return .sceneShaderUnsupported
+        case .noRenderableObjects:
+            return .sceneResourceMissing
+        }
+    }
+
+    private var stateKey: Int {
+        // Lightweight state-change fingerprint for animation triggers; the
+        // associated values (controller / fallback) compare poorly so we
+        // map down to ints.
+        switch state {
+        case .idle:    return 0
+        case .loading: return 1
+        case .playing: return 2
+        case .paused:  return 3
+        case .error:   return 4
+        }
+    }
+
+    private var stateLabel: String {
+        switch state {
+        case .idle:    return "Idle"
+        case .loading: return "Loading"
+        case .playing: return "Playing"
+        case .paused:  return "Paused"
+        case .error:   return "Error"
+        }
+    }
+
+    private var stateAccessibilityText: String {
+        switch state {
+        case .idle:    return "Idle"
+        case .loading: return "Loading scene assets"
+        case .playing: return "Scene playing"
+        case .paused(let reason): return "Paused, \(reason.label)"
+        case .error:   return "Scene cannot be played"
+        }
+    }
+
+    private var statusColor: Color {
+        switch state {
+        case .playing: return .green
+        case .loading: return .yellow
+        case .paused:  return .orange
+        case .error:   return .red
+        case .idle:    return .secondary
+        }
+    }
+
+    private var previewURL: URL? {
+        guard let previewName = origin.previewFileName else { return nil }
+        var isStale = false
+        guard let folder = try? URL(
+            resolvingBookmarkData: origin.sourceFolderBookmark,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        ) else { return nil }
+        return folder.appendingPathComponent(previewName)
+    }
+}
+
+// MARK: - State machine
+
+enum SceneRenderState: Equatable {
+    case idle
+    case loading
+    case playing(SceneRenderingController)
+    case paused(reason: PausedReason)
+    case error(FallbackReason)
+
+    static func == (lhs: SceneRenderState, rhs: SceneRenderState) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle): return true
+        case (.loading, .loading): return true
+        case (.playing(let lhsCtrl), .playing(let rhsCtrl)): return lhsCtrl === rhsCtrl
+        case (.paused(let l), .paused(let r)): return l == r
+        case (.error(let l), .error(let r)): return l == r
+        default: return false
+        }
+    }
+}
+
+enum PausedReason: Equatable, Sendable {
+    case reduceMotion
+    case throttled
+    case suspended
+
+    var label: String {
+        switch self {
+        case .reduceMotion: return "Reduce Motion"
+        case .throttled:    return "Throttled"
+        case .suspended:    return "Suspended"
+        }
+    }
+}

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
@@ -15,7 +15,9 @@ struct WPESceneSection: View {
 
     var body: some View {
         Group {
-            if recentImports.isEmpty {
+            if hasActiveSceneWallpaper {
+                activeSceneCard
+            } else if recentImports.isEmpty {
                 emptyState
             } else if let selected = selectedHistoryEntry {
                 unsupportedDetail(for: selected)
@@ -162,10 +164,60 @@ struct WPESceneSection: View {
                 .accessibilityHint("Return to the recent imports grid")
                 Spacer()
             }
-            WPEUnsupportedCard(origin: entry.origin)
+            WPEFallbackCard(origin: entry.origin)
         }
         .padding(24)
         .frame(maxWidth: .infinity, alignment: .top)
+    }
+
+    private var hasActiveSceneWallpaper: Bool {
+        guard let configuration = screenManager.getConfiguration(for: screen),
+              case .scene = configuration.activeWallpaper,
+              configuration.wpeOrigin != nil else { return false }
+        return true
+    }
+
+    /// When the active wallpaper for this screen is a scene, render the
+    /// detail card directly so the user sees the live preview + state machine
+    /// instead of having to dig back to the imports grid.
+    @ViewBuilder
+    private var activeSceneCard: some View {
+        if let configuration = screenManager.getConfiguration(for: screen),
+           case .scene(let descriptor) = configuration.activeWallpaper,
+           let origin = configuration.wpeOrigin {
+            let session = screen.runtimeSession as? SceneWallpaperSession
+            VStack(spacing: 16) {
+                HStack {
+                    Button {
+                        showWorkshopGallery = true
+                    } label: {
+                        Label("Browse Library…", systemImage: "books.vertical")
+                    }
+                    .buttonStyle(.glass)
+                    .controlSize(.regular)
+                    Spacer()
+                    Button {
+                        presentFolderPicker()
+                    } label: {
+                        Label("Import New…", systemImage: "plus")
+                    }
+                    .buttonStyle(.glass)
+                    .controlSize(.regular)
+                }
+                WPESceneDetailView(
+                    origin: origin,
+                    descriptor: descriptor,
+                    session: session,
+                    onClearWallpaper: {
+                        screenManager.clearWallpaperForScreen(screen)
+                    }
+                )
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .top)
+        } else {
+            EmptyView()
+        }
     }
 
     // MARK: - Actions

--- a/LiveWallpaperTests/SceneDescriptorCodableTests.swift
+++ b/LiveWallpaperTests/SceneDescriptorCodableTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+/// Phase 2.0 Day 1 lock: Codable contracts for `SceneDescriptor`,
+/// `WallpaperContent.scene`, and the legacy-`.scene` backfill that lets
+/// `ScreenConfiguration` reload data written before the descriptor existed.
+@Suite("SceneDescriptor / WallpaperContent.scene persistence")
+struct SceneDescriptorCodableTests {
+
+    // MARK: - SceneDescriptor
+
+    @Test("SceneDescriptor round-trips through JSON")
+    func sceneDescriptorRoundTrips() throws {
+        let descriptor = SceneDescriptor(
+            workshopID: "3351072238",
+            cacheRelativePath: "wpe-cache/3351072238",
+            entryFile: "scene.json",
+            capabilityTier: .imageOnly
+        )
+
+        let data = try JSONEncoder().encode(descriptor)
+        let decoded = try JSONDecoder().decode(SceneDescriptor.self, from: data)
+
+        #expect(decoded == descriptor)
+    }
+
+    @Test("Unknown capabilityTier decodes lossily as .unsupported")
+    func sceneDescriptorTierFallsBack() throws {
+        // Future Phase 2.x might add a new tier (e.g. `.fxOnly`); an old build
+        // shouldn't crash on the next launch.
+        let payload: [String: Any] = [
+            "workshopID": "abc",
+            "cacheRelativePath": "wpe-cache/abc",
+            "entryFile": "scene.json",
+            "capabilityTier": "fxOnly"
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: .sortedKeys)
+
+        let decoded = try JSONDecoder().decode(SceneDescriptor.self, from: data)
+
+        #expect(decoded.capabilityTier == .unsupported)
+        #expect(decoded.workshopID == "abc")
+    }
+
+    // MARK: - WallpaperContent.scene
+
+    @Test("WallpaperContent.scene round-trips through ScreenConfiguration")
+    func wallpaperContentSceneRoundTrips() throws {
+        let descriptor = SceneDescriptor(
+            workshopID: "rt",
+            cacheRelativePath: "wpe-cache/rt",
+            entryFile: "scene.json",
+            capabilityTier: .imageOnly
+        )
+        let config = ScreenConfiguration(
+            screenID: 42,
+            wallpaper: .scene(descriptor)
+        )
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(ScreenConfiguration.self, from: data)
+
+        #expect(decoded.activeWallpaper == .scene(descriptor))
+        #expect(decoded.wallpaperType == .scene)
+    }
+
+    // MARK: - Legacy backfill
+
+    @Test("Legacy ScreenConfiguration with wallpaperType=scene + matching wpeOrigin backfills SceneDescriptor")
+    func legacySceneBackfillsFromOrigin() throws {
+        let origin = WPEOrigin(
+            workshopID: "legacy-id",
+            title: "Legacy Scene",
+            originalType: .scene,
+            sourceFolderBookmark: Data([0x01]),
+            cacheRelativePath: "wpe-cache/legacy-id",
+            previewFileName: "preview.gif",
+            entryFile: "scene.json",
+            resourceLocation: .cache
+        )
+
+        // Build a legacy-shaped JSON: no `activeWallpaper`, just the old
+        // `wallpaperType` key, plus the wpeOrigin we want backfilled.
+        let payload: [String: Any] = [
+            "screenID": 7,
+            "wallpaperType": "Scene",
+            "videoBookmarkData": Data().base64EncodedString(),
+            "playbackSpeed": 1.0,
+            "fitMode": VideoFitMode.aspectFill.rawValue,
+            "frameRateLimit": FrameRateLimit.fps60.rawValue,
+            "particleEffect": ParticleEffect.none.rawValue,
+            "effectConfig": try JSONSerialization.jsonObject(with: JSONEncoder().encode(VideoEffectConfig.default)),
+            "shufflePlaylist": false,
+            "setAsLockScreen": false,
+            "wallpaperMode": "single",
+            "muted": true,
+            "wpeOrigin": try JSONSerialization.jsonObject(with: JSONEncoder().encode(origin))
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: .sortedKeys)
+
+        let decoded = try JSONDecoder().decode(ScreenConfiguration.self, from: data)
+
+        #expect(decoded.wallpaperType == .scene)
+        guard case .scene(let descriptor) = decoded.activeWallpaper else {
+            Issue.record("Expected .scene case after backfill")
+            return
+        }
+        #expect(descriptor.workshopID == "legacy-id")
+        #expect(descriptor.cacheRelativePath == "wpe-cache/legacy-id")
+        #expect(descriptor.entryFile == "scene.json")
+        #expect(descriptor.capabilityTier == .imageOnly)
+    }
+
+    @Test("Legacy ScreenConfiguration with wallpaperType=scene but no wpeOrigin falls back to empty video")
+    func legacySceneWithoutOriginFallsBackToEmptyVideo() throws {
+        let payload: [String: Any] = [
+            "screenID": 8,
+            "wallpaperType": "Scene",
+            "videoBookmarkData": Data().base64EncodedString(),
+            "playbackSpeed": 1.0,
+            "fitMode": VideoFitMode.aspectFill.rawValue,
+            "frameRateLimit": FrameRateLimit.fps60.rawValue,
+            "particleEffect": ParticleEffect.none.rawValue,
+            "effectConfig": try JSONSerialization.jsonObject(with: JSONEncoder().encode(VideoEffectConfig.default)),
+            "shufflePlaylist": false,
+            "setAsLockScreen": false,
+            "wallpaperMode": "single",
+            "muted": true
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: .sortedKeys)
+
+        let decoded = try JSONDecoder().decode(ScreenConfiguration.self, from: data)
+
+        // Without origin context the descriptor cannot be reconstructed safely,
+        // so the persisted blob degrades to an empty video. ScreenManager's
+        // restore path then mounts the not-configured Scene tab placeholder.
+        #expect(decoded.activeWallpaper == .video(bookmarkData: Data()))
+    }
+
+    @Test("Reconcile keeps wpeOrigin when scene descriptor matches workshopID + cacheRelativePath")
+    func reconcileKeepsOriginWhenSceneMatches() throws {
+        let descriptor = SceneDescriptor(
+            workshopID: "match",
+            cacheRelativePath: "wpe-cache/match",
+            entryFile: "scene.json",
+            capabilityTier: .imageOnly
+        )
+        var config = ScreenConfiguration(screenID: 9, wallpaper: .scene(descriptor))
+        config.wpeOrigin = WPEOrigin(
+            workshopID: "match",
+            title: "Match",
+            originalType: .scene,
+            sourceFolderBookmark: Data([0x01]),
+            cacheRelativePath: "wpe-cache/match",
+            previewFileName: nil,
+            entryFile: "scene.json",
+            resourceLocation: .cache
+        )
+
+        config.reconcileWPEOrigin()
+
+        #expect(config.wpeOrigin != nil)
+    }
+
+    @Test("Reconcile drops wpeOrigin when scene descriptor disagrees with origin workshopID")
+    func reconcileDropsOriginOnSceneMismatch() throws {
+        let descriptor = SceneDescriptor(
+            workshopID: "current",
+            cacheRelativePath: "wpe-cache/current",
+            entryFile: "scene.json",
+            capabilityTier: .imageOnly
+        )
+        var config = ScreenConfiguration(screenID: 10, wallpaper: .scene(descriptor))
+        config.wpeOrigin = WPEOrigin(
+            workshopID: "stale",
+            title: "Stale",
+            originalType: .scene,
+            sourceFolderBookmark: Data([0x01]),
+            cacheRelativePath: "wpe-cache/stale",
+            previewFileName: nil,
+            entryFile: "scene.json",
+            resourceLocation: .cache
+        )
+
+        config.reconcileWPEOrigin()
+
+        #expect(config.wpeOrigin == nil)
+    }
+}

--- a/LiveWallpaperTests/SceneRenderingControllerTests.swift
+++ b/LiveWallpaperTests/SceneRenderingControllerTests.swift
@@ -1,0 +1,214 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import SpriteKit
+import Testing
+import UniformTypeIdentifiers
+@testable import LiveWallpaper
+
+@Suite("SceneRenderingController")
+@MainActor
+struct SceneRenderingControllerTests {
+
+    @Test("Successful image-only load mounts an SKScene with one sprite per layer")
+    func loadImageOnlyMountsSprites() async throws {
+        let fixture = try makeFixture(layers: ["a.png", "b.png"])
+        defer { fixture.cleanup() }
+
+        let controller = SceneRenderingController(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.cacheRoot,
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200)
+        )
+        try await controller.load()
+
+        let scene = controller.view.scene
+        #expect(scene != nil)
+        #expect(scene?.children.count == 2)
+    }
+
+    @Test("Throttle drops preferredFramesPerSecond to 1 fps")
+    func throttleDropsFrameRate() async throws {
+        let fixture = try makeFixture(layers: ["a.png"])
+        defer { fixture.cleanup() }
+
+        let controller = SceneRenderingController(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.cacheRoot,
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200)
+        )
+        try await controller.load()
+
+        controller.setThrottled(true)
+        #expect(controller.view.preferredFramesPerSecond == SceneRenderingController.throttledPreferredFPS)
+
+        controller.setThrottled(false)
+        #expect(controller.view.preferredFramesPerSecond == SceneRenderingController.defaultPreferredFPS)
+    }
+
+    @Test("Suspended profile pauses the SKScene")
+    func suspendedProfilePausesScene() async throws {
+        let fixture = try makeFixture(layers: ["a.png"])
+        defer { fixture.cleanup() }
+
+        let controller = SceneRenderingController(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.cacheRoot,
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200)
+        )
+        try await controller.load()
+
+        controller.applyPerformanceProfile(.suspended)
+        #expect(controller.view.scene?.isPaused == true)
+
+        controller.applyPerformanceProfile(.quality)
+        #expect(controller.view.scene?.isPaused == false)
+    }
+
+    @Test("Empty cache directory throws entryFileMissing")
+    func missingEntryFileThrows() async throws {
+        let fixture = try makeFixture(layers: [], includeSceneJSON: false)
+        defer { fixture.cleanup() }
+
+        let controller = SceneRenderingController(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.cacheRoot,
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200)
+        )
+
+        await #expect(throws: SceneRenderingError.self) {
+            try await controller.load()
+        }
+    }
+
+    @Test("Entry file with .. traversal is rejected before any I/O")
+    func entryFileTraversalRejected() async throws {
+        let fixture = try makeFixture(layers: ["a.png"])
+        defer { fixture.cleanup() }
+
+        let descriptor = SceneDescriptor(
+            workshopID: fixture.descriptor.workshopID,
+            cacheRelativePath: fixture.descriptor.cacheRelativePath,
+            entryFile: "../scene.json",
+            capabilityTier: .imageOnly
+        )
+        let controller = SceneRenderingController(
+            descriptor: descriptor,
+            cacheRootURL: fixture.cacheRoot,
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200)
+        )
+
+        await #expect(throws: SceneRenderingError.self) {
+            try await controller.load()
+        }
+    }
+
+    @Test("Scene with no resolvable layers throws noRenderableObjects")
+    func noResolvableLayersThrows() async throws {
+        // Cache contains scene.json but every declared layer references a
+        // missing path — controller must throw rather than mount an empty
+        // SKScene that the user would interpret as a hung load.
+        let fixture = try makeFixture(layers: [], declaredLayers: ["materials/missing.png"])
+        defer { fixture.cleanup() }
+
+        let controller = SceneRenderingController(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.cacheRoot,
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200)
+        )
+
+        await #expect(throws: SceneRenderingError.self) {
+            try await controller.load()
+        }
+    }
+
+    // MARK: - Fixture
+
+    private struct Fixture {
+        let root: URL
+        let cacheRoot: URL
+        let descriptor: SceneDescriptor
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: root)
+        }
+    }
+
+    private func makeFixture(
+        layers: [String],
+        declaredLayers: [String]? = nil,
+        includeSceneJSON: Bool = true
+    ) throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SceneRenderingControllerTests-\(UUID().uuidString)", isDirectory: true)
+        let cacheRoot = root.appendingPathComponent("wpe-cache/\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
+
+        // Materials live one folder deep so we exercise the resolver's
+        // subdirectory standardization path.
+        let materials = cacheRoot.appendingPathComponent("materials", isDirectory: true)
+        try FileManager.default.createDirectory(at: materials, withIntermediateDirectories: true)
+        for layer in layers {
+            try writePNG(at: materials.appendingPathComponent(layer))
+        }
+
+        if includeSceneJSON {
+            let layerJSONPaths = (declaredLayers ?? layers.map { "materials/\($0)" })
+            let objects = layerJSONPaths.enumerated().map { index, path in
+                """
+                {
+                    "id": "layer-\(index)",
+                    "name": "Layer \(index)",
+                    "type": "image",
+                    "image": "\(path)",
+                    "origin": "0.5 0.5 0",
+                    "scale": "1 1 1",
+                    "alpha": 1,
+                    "blendmode": "normal"
+                }
+                """
+            }.joined(separator: ",\n")
+
+            let json = """
+            {
+                "camera": { "center": "0 0 0" },
+                "general": {
+                    "orthogonalprojection": { "width": 200, "height": 200, "auto": true }
+                },
+                "objects": [\(objects)]
+            }
+            """
+            try Data(json.utf8).write(to: cacheRoot.appendingPathComponent("scene.json"))
+        }
+
+        let descriptor = SceneDescriptor(
+            workshopID: cacheRoot.lastPathComponent,
+            cacheRelativePath: "wpe-cache/\(cacheRoot.lastPathComponent)",
+            entryFile: "scene.json",
+            capabilityTier: .imageOnly
+        )
+        return Fixture(root: root, cacheRoot: cacheRoot, descriptor: descriptor)
+    }
+
+    private func writePNG(at url: URL) throws {
+        guard let context = CGContext(
+            data: nil,
+            width: 8,
+            height: 8,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { throw NSError(domain: "fixture", code: -1) }
+        context.setFillColor(CGColor(red: 1, green: 0.5, blue: 0.2, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 8, height: 8))
+        guard let image = context.makeImage(),
+              let dest = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil) else {
+            throw NSError(domain: "fixture", code: -2)
+        }
+        CGImageDestinationAddImage(dest, image, nil)
+        if !CGImageDestinationFinalize(dest) {
+            throw NSError(domain: "fixture", code: -3)
+        }
+    }
+}

--- a/LiveWallpaperTests/SceneResourceResolverTests.swift
+++ b/LiveWallpaperTests/SceneResourceResolverTests.swift
@@ -1,0 +1,135 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+@testable import LiveWallpaper
+
+@Suite("SceneResourceResolver")
+struct SceneResourceResolverTests {
+
+    @Test("Image inside the cache root decodes successfully")
+    func imageInsideCacheRoot() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try writePNG(at: fixture.cacheRoot.appendingPathComponent("layer.png"))
+
+        let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
+        let image = try resolver.resolveImage(relativePath: "layer.png")
+
+        #expect(image.width > 0)
+        #expect(image.height > 0)
+    }
+
+    @Test("Path traversal via .. is rejected")
+    func pathTraversalRejected() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try Data("secret".utf8).write(to: fixture.root.appendingPathComponent("secret.png"))
+
+        let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
+
+        #expect(throws: SceneResourceResolver.ResolveError.pathEscape) {
+            try resolver.resolveImage(relativePath: "../secret.png")
+        }
+    }
+
+    @Test("Absolute path is rejected")
+    func absolutePathRejected() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
+
+        #expect(throws: SceneResourceResolver.ResolveError.pathEscape) {
+            try resolver.resolveImage(relativePath: "/etc/passwd")
+        }
+    }
+
+    @Test("Symlink that escapes cache root is rejected after resolution")
+    func symlinkEscapeRejected() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let secret = fixture.root.appendingPathComponent("secret.png")
+        try writePNG(at: secret)
+        let symlinkURL = fixture.cacheRoot.appendingPathComponent("escape.png")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: secret)
+
+        let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
+
+        #expect(throws: SceneResourceResolver.ResolveError.pathEscape) {
+            try resolver.resolveImage(relativePath: "escape.png")
+        }
+    }
+
+    @Test(".tex texture returns unsupportedTexture without crashing")
+    func texTextureUnsupported() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try Data([0x00, 0x01]).write(to: fixture.cacheRoot.appendingPathComponent("layer.tex"))
+
+        let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
+
+        #expect(throws: SceneResourceResolver.ResolveError.unsupportedTexture) {
+            try resolver.resolveImage(relativePath: "layer.tex")
+        }
+    }
+
+    @Test("Missing file throws fileMissing")
+    func missingFileThrows() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
+
+        #expect(throws: SceneResourceResolver.ResolveError.fileMissing) {
+            try resolver.resolveImage(relativePath: "missing.png")
+        }
+    }
+
+    // MARK: - Fixture helpers
+
+    private struct Fixture {
+        let root: URL
+        let cacheRoot: URL
+    }
+
+    private func makeFixture() throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SceneResourceResolverTests-\(UUID().uuidString)", isDirectory: true)
+        let cacheRoot = root.appendingPathComponent("cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
+        return Fixture(root: root, cacheRoot: cacheRoot)
+    }
+
+    /// Writes a 4×4 opaque PNG. ImageIO needs at least a real PNG header
+    /// to produce a CGImage; a hand-rolled empty file would yield nil.
+    private func writePNG(at url: URL) throws {
+        guard let context = CGContext(
+            data: nil,
+            width: 4,
+            height: 4,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            Issue.record("Failed to allocate CGContext for fixture PNG")
+            return
+        }
+        context.setFillColor(CGColor(red: 1, green: 0.5, blue: 0.2, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+        guard let image = context.makeImage() else {
+            Issue.record("Failed to render fixture PNG")
+            return
+        }
+        guard let destination = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil) else {
+            Issue.record("Failed to open PNG destination for fixture")
+            return
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        if !CGImageDestinationFinalize(destination) {
+            Issue.record("Failed to finalize fixture PNG")
+        }
+    }
+}

--- a/LiveWallpaperTests/WPESceneDocumentParserTests.swift
+++ b/LiveWallpaperTests/WPESceneDocumentParserTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+@Suite("WPESceneDocumentParser")
+struct WPESceneDocumentParserTests {
+
+    // MARK: - Required structure
+
+    @Test("Empty data throws invalidUTF8")
+    func emptyDataThrows() {
+        #expect(throws: WPESceneDocumentError.invalidUTF8) {
+            try WPESceneDocumentParser.parse(data: Data())
+        }
+    }
+
+    @Test("Top-level array throws rootNotObject")
+    func rootArrayThrows() throws {
+        let data = try JSONSerialization.data(withJSONObject: [["camera": [:]]], options: [])
+        #expect(throws: WPESceneDocumentError.rootNotObject) {
+            try WPESceneDocumentParser.parse(data: data)
+        }
+    }
+
+    @Test("Missing camera throws missingCamera")
+    func missingCameraThrows() throws {
+        let payload: [String: Any] = ["general": ["clearcolor": "0 0 0"]]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        #expect(throws: WPESceneDocumentError.missingCamera) {
+            try WPESceneDocumentParser.parse(data: data)
+        }
+    }
+
+    @Test("Missing general throws missingGeneral")
+    func missingGeneralThrows() throws {
+        let payload: [String: Any] = ["camera": ["center": "0 0 0"]]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        #expect(throws: WPESceneDocumentError.missingGeneral) {
+            try WPESceneDocumentParser.parse(data: data)
+        }
+    }
+
+    // MARK: - Flexible vector formats
+
+    @Test("Parser accepts space-separated vector strings, JSON arrays, and dicts")
+    func flexibleVectorFormats() throws {
+        let payload: [String: Any] = [
+            "camera": [
+                "center": "0.5 1 2",
+                "eye": [3, 4, 5],
+                "up": ["x": 0, "y": 1, "z": 0]
+            ],
+            "general": [
+                "orthogonalprojection": ["width": 1920, "height": 1080, "auto": true]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let document = try WPESceneDocumentParser.parse(data: data)
+
+        #expect(document.camera.center.x == 0.5)
+        #expect(document.camera.center.y == 1)
+        #expect(document.camera.center.z == 2)
+        #expect(document.camera.eye == SIMD3<Double>(3, 4, 5))
+        #expect(document.camera.up == SIMD3<Double>(0, 1, 0))
+    }
+
+    // MARK: - Image objects
+
+    @Test("Image object with happy-path fields populates imageObjects")
+    func imageObjectHappyPath() throws {
+        let payload: [String: Any] = [
+            "camera": ["center": "0 0 0"],
+            "general": ["orthogonalprojection": ["width": 1920, "height": 1080, "auto": true]],
+            "objects": [[
+                "id": "layer1",
+                "name": "Background",
+                "type": "image",
+                "image": "materials/bg.png",
+                "origin": "0.5 0.5 0",
+                "scale": "1 1 1",
+                "alpha": 0.85,
+                "blendmode": "additive",
+                "visible": true,
+                "alignment": "center",
+                "size": [512, 512, 0]
+            ]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let document = try WPESceneDocumentParser.parse(data: data)
+
+        #expect(document.imageObjects.count == 1)
+        let layer = try #require(document.imageObjects.first)
+        #expect(layer.name == "Background")
+        #expect(layer.imageRelativePath == "materials/bg.png")
+        #expect(layer.alpha == 0.85)
+        #expect(layer.blendMode == .additive)
+        #expect(layer.alignment == .center)
+        #expect(layer.size == CGSize(width: 512, height: 512))
+    }
+
+    @Test("Unsupported object types emit info diagnostics and do not abort the parse")
+    func unsupportedObjectsEmitDiagnostics() throws {
+        let payload: [String: Any] = [
+            "camera": ["center": "0 0 0"],
+            "general": ["orthogonalprojection": ["width": 1, "height": 1, "auto": true]],
+            "objects": [
+                ["type": "image", "image": "a.png", "name": "A"],
+                ["type": "particle", "name": "Sparks"],
+                ["type": "text", "name": "Title"],
+                ["type": "sound", "name": "Loop"]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let document = try WPESceneDocumentParser.parse(data: data)
+
+        #expect(document.imageObjects.count == 1)
+        #expect(document.diagnostics.contains(where: { $0.message.contains("Particle") }))
+        #expect(document.diagnostics.contains(where: { $0.message.contains("Text") }))
+        #expect(document.diagnostics.contains(where: { $0.message.contains("Sound") }))
+    }
+
+    @Test(".tex texture path emits a warning diagnostic")
+    func texTextureEmitsWarning() throws {
+        let payload: [String: Any] = [
+            "camera": ["center": "0 0 0"],
+            "general": ["orthogonalprojection": ["width": 1, "height": 1, "auto": true]],
+            "objects": [[
+                "type": "image",
+                "image": "materials/sky.tex",
+                "name": "Sky"
+            ]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let document = try WPESceneDocumentParser.parse(data: data)
+
+        #expect(document.imageObjects.first?.imageRelativePath == "materials/sky.tex")
+        #expect(document.diagnostics.contains(where: { $0.severity == .warning && $0.message.contains(".tex") }))
+    }
+}

--- a/LiveWallpaperTests/WPESceneSectionStateTests.swift
+++ b/LiveWallpaperTests/WPESceneSectionStateTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+/// Phase 2.0 Day 5 lock: SceneRenderState transitions and SceneRenderingError
+/// → FallbackReason mapping. Pure value-level tests so they don't pull in
+/// SwiftUI / SpriteKit and stay snappy in CI.
+@Suite("WPESceneSection state machine")
+struct WPESceneSectionStateTests {
+
+    @Test("idle and loading states compare independently of associated values")
+    func idleLoadingEquality() {
+        #expect(SceneRenderState.idle == SceneRenderState.idle)
+        #expect(SceneRenderState.loading == SceneRenderState.loading)
+        #expect(SceneRenderState.idle != SceneRenderState.loading)
+    }
+
+    @Test("paused state preserves the reason")
+    func pausedKeepsReason() {
+        let reduceMotion = SceneRenderState.paused(reason: .reduceMotion)
+        let throttled = SceneRenderState.paused(reason: .throttled)
+        #expect(reduceMotion != throttled)
+        #expect(reduceMotion == SceneRenderState.paused(reason: .reduceMotion))
+    }
+
+    @Test("error state carries the FallbackReason")
+    func errorKeepsFallbackReason() {
+        let parse = SceneRenderState.error(.sceneParseFailed("boom"))
+        let resource = SceneRenderState.error(.sceneResourceMissing)
+        #expect(parse != resource)
+        #expect(parse == SceneRenderState.error(.sceneParseFailed("boom")))
+    }
+
+    @Test("PausedReason labels expose user-visible text")
+    func pausedReasonLabels() {
+        #expect(PausedReason.reduceMotion.label == "Reduce Motion")
+        #expect(PausedReason.throttled.label == "Throttled")
+        #expect(PausedReason.suspended.label == "Suspended")
+    }
+
+    @Test("FallbackReason rendering distinguishes parse vs resource failure copy")
+    func fallbackReasonCopy() {
+        let parse = WPEFallbackCard(
+            origin: makeOrigin(),
+            reason: .sceneParseFailed("missing camera")
+        )
+        let missing = WPEFallbackCard(
+            origin: makeOrigin(),
+            reason: .sceneResourceMissing
+        )
+        // Reason equality short-circuits the heavier text-based comparison
+        // (the strings live inside private SwiftUI computed props).
+        #expect(parse.reason != missing.reason)
+        #expect(parse.reason == .sceneParseFailed("missing camera"))
+    }
+
+    private func makeOrigin() -> WPEOrigin {
+        WPEOrigin(
+            workshopID: "state-machine",
+            title: "State Machine",
+            originalType: .scene,
+            sourceFolderBookmark: Data([0x01]),
+            cacheRelativePath: "wpe-cache/state-machine",
+            previewFileName: nil,
+            entryFile: "scene.json",
+            resourceLocation: .cache
+        )
+    }
+}

--- a/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
+++ b/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
@@ -1,5 +1,8 @@
+import CoreGraphics
 import Foundation
+import ImageIO
 import Testing
+import UniformTypeIdentifiers
 @testable import LiveWallpaper
 
 @Suite("WallpaperEngineImportService") @MainActor
@@ -157,6 +160,181 @@ struct WallpaperEngineImportServiceTests {
         #expect(origin.entryFile == "scene.json")
     }
 
+    @Test("Scene with scene.pkg + valid scene.json + image asset returns ready scene content")
+    func sceneWithPackageAndAssetReturnsReady() async throws {
+        // The synthetic scene.json declares one image layer; we ship a real
+        // PNG inside the same scene.pkg so the import service classifies it
+        // as `.imageOnly`.
+        let pngBytes = try makeFixturePNG(width: 4, height: 4)
+        let sceneJSON = """
+        {
+            "camera": { "center": "0 0 0" },
+            "general": {
+                "orthogonalprojection": { "width": 1920, "height": 1080, "auto": true }
+            },
+            "objects": [{
+                "id": "layer1",
+                "name": "Layer 1",
+                "type": "image",
+                "image": "materials/layer1.png",
+                "origin": "0.5 0.5 0",
+                "scale": "1 1 1",
+                "alpha": 1.0,
+                "blendmode": "normal"
+            }]
+        }
+        """
+        let fixture = try makeFixture(
+            type: .scene,
+            entryFile: "scene.json",
+            pkgEntries: [
+                PackageEntrySpec("scene.json", Array(sceneJSON.utf8)),
+                PackageEntrySpec("materials/layer1.png", Array(pngBytes))
+            ]
+        )
+        defer { fixture.cleanup() }
+
+        let result = try await fixture.service.importProject(folder: fixture.folderURL)
+
+        guard case .ready(let content, let origin) = result else {
+            Issue.record("Expected .ready, got \(result)")
+            return
+        }
+        guard case .scene(let descriptor) = content else {
+            Issue.record("Expected .scene content, got \(content)")
+            return
+        }
+        #expect(descriptor.workshopID == fixture.workshopID)
+        #expect(descriptor.cacheRelativePath == "wpe-cache/\(fixture.workshopID)")
+        #expect(descriptor.entryFile == "scene.json")
+        #expect(descriptor.capabilityTier == .imageOnly)
+        #expect(origin.cacheRelativePath == "wpe-cache/\(fixture.workshopID)")
+        #expect(origin.resourceLocation == .cache)
+    }
+
+    @Test("Scene with image layers AND unsupported objects is classified degraded")
+    func sceneWithMixedObjectsIsDegraded() async throws {
+        let pngBytes = try makeFixturePNG(width: 4, height: 4)
+        let sceneJSON = """
+        {
+            "camera": { "center": "0 0 0" },
+            "general": {
+                "orthogonalprojection": { "width": 1920, "height": 1080, "auto": true }
+            },
+            "objects": [
+                {
+                    "id": "layer1",
+                    "name": "Layer 1",
+                    "type": "image",
+                    "image": "materials/layer1.png"
+                },
+                {
+                    "id": "particle1",
+                    "name": "Sparks",
+                    "type": "particle"
+                }
+            ]
+        }
+        """
+        let fixture = try makeFixture(
+            type: .scene,
+            entryFile: "scene.json",
+            pkgEntries: [
+                PackageEntrySpec("scene.json", Array(sceneJSON.utf8)),
+                PackageEntrySpec("materials/layer1.png", Array(pngBytes))
+            ]
+        )
+        defer { fixture.cleanup() }
+
+        let result = try await fixture.service.importProject(folder: fixture.folderURL)
+
+        guard case .ready(let content, _) = result else {
+            Issue.record("Expected .ready, got \(result)")
+            return
+        }
+        guard case .scene(let descriptor) = content else {
+            Issue.record("Expected .scene content, got \(content)")
+            return
+        }
+        // The image layer renders but the particle layer doesn't — this is
+        // exactly the case the plan's `.degraded` tier is meant to signal so
+        // the UI can warn the user even though the image-only renderer
+        // happily mounts the SKScene.
+        #expect(descriptor.capabilityTier == .degraded)
+    }
+
+    @Test("Scene whose declared layers are all missing assets is classified unsupported")
+    func sceneWithMissingAssetsIsUnsupported() async throws {
+        let sceneJSON = """
+        {
+            "camera": { "center": "0 0 0" },
+            "general": {
+                "orthogonalprojection": { "width": 1920, "height": 1080, "auto": true }
+            },
+            "objects": [{
+                "id": "layer1",
+                "name": "Layer 1",
+                "type": "image",
+                "image": "materials/missing.png"
+            }]
+        }
+        """
+        let fixture = try makeFixture(
+            type: .scene,
+            entryFile: "scene.json",
+            pkgEntries: [
+                PackageEntrySpec("scene.json", Array(sceneJSON.utf8))
+            ]
+        )
+        defer { fixture.cleanup() }
+
+        let result = try await fixture.service.importProject(folder: fixture.folderURL)
+
+        guard case .unsupported(let origin) = result else {
+            Issue.record("Expected .unsupported, got \(result)")
+            return
+        }
+        // Cache extraction still happened for the unsupported scene — the
+        // origin records the cache path so a future user-driven re-attempt
+        // (e.g. workshop ships a fix) can re-evaluate without re-extracting.
+        #expect(origin.cacheRelativePath == "wpe-cache/\(fixture.workshopID)")
+        #expect(origin.resourceLocation == .cache)
+    }
+
+    @Test("Cached content resolver rebuilds scene descriptor without re-parsing scene.json")
+    func cachedContentResolverRebuildsSceneDescriptor() throws {
+        let fileManager = FileManager.default
+        let rootURL = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: rootURL) }
+        let appSupportRoot = rootURL.appendingPathComponent("ApplicationSupport/LiveWallpaper", isDirectory: true)
+        let cacheURL = appSupportRoot.appendingPathComponent("wpe-cache/resolve-scene", isDirectory: true)
+        try fileManager.createDirectory(at: cacheURL, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: cacheURL.appendingPathComponent("scene.json"))
+
+        let origin = WPEOrigin(
+            workshopID: "resolve-scene",
+            title: "Cached Scene",
+            originalType: .scene,
+            sourceFolderBookmark: Data("missing-source".utf8),
+            cacheRelativePath: "wpe-cache/resolve-scene",
+            previewFileName: nil,
+            entryFile: "scene.json",
+            resourceLocation: .cache
+        )
+        let resolver = WPECachedContentResolver(
+            applicationSupportRootURL: appSupportRoot,
+            makeBookmark: { url in Data(url.path.utf8) }
+        )
+
+        guard case .scene(let descriptor) = resolver.content(for: origin) else {
+            Issue.record("Expected cached scene content")
+            return
+        }
+        #expect(descriptor.workshopID == "resolve-scene")
+        #expect(descriptor.cacheRelativePath == "wpe-cache/resolve-scene")
+        #expect(descriptor.entryFile == "scene.json")
+    }
+
     @Test("Cached content resolver rebuilds packaged video without source folder access")
     func cachedContentResolverRebuildsPackagedVideoWithoutSourceFolderAccess() throws {
         let fileManager = FileManager.default
@@ -244,6 +422,36 @@ struct WallpaperEngineImportServiceTests {
             workshopID: workshopID,
             service: service
         )
+    }
+
+    /// Produces a real (decodable) PNG so `SceneResourceResolver.exists`
+    /// returns true for image-only capability detection.
+    private func makeFixturePNG(width: Int, height: Int) throws -> Data {
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            throw NSError(domain: "fixture", code: -1)
+        }
+        context.setFillColor(CGColor(red: 1, green: 0.5, blue: 0.2, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        guard let image = context.makeImage() else {
+            throw NSError(domain: "fixture", code: -2)
+        }
+        let mutableData = NSMutableData()
+        guard let dest = CGImageDestinationCreateWithData(mutableData, UTType.png.identifier as CFString, 1, nil) else {
+            throw NSError(domain: "fixture", code: -3)
+        }
+        CGImageDestinationAddImage(dest, image, nil)
+        if !CGImageDestinationFinalize(dest) {
+            throw NSError(domain: "fixture", code: -4)
+        }
+        return mutableData as Data
     }
 
     private func makePackage(entries: [PackageEntrySpec]) -> Data {


### PR DESCRIPTION
## Summary

Promote Wallpaper Engine `.scene` workshop projects from the Phase 1 unsupported placeholder to a fully renderable wallpaper. New SpriteKit pipeline mounts image layers parsed from `scene.json`; the inspector hosts a live preview with a state machine (loading / playing / paused / error); the desktop session throttles to 1 fps while the LiveWallpaper console window is key (exclusive-rendering policy).

5-day plan in [.claude/plan/wpe-scene-phase-2-0.md](.claude/plan/wpe-scene-phase-2-0.md). All 11 acceptance criteria from the plan §11 met.

## What changed

**Models** — `SceneDescriptor` + `WPESceneDocument` value types; `WallpaperContent.scene(SceneDescriptor)` Codable case; `ScreenConfiguration` legacy backfill so pre-Phase-2 `wallpaperType=Scene` blobs reload cleanly when the sibling `wpeOrigin` carries the cache path.

**Infrastructure** — Flexible JSON parser tolerates space-separated vectors (`"0 0 0"`), scalar arrays, and `{x,y,z}` dicts. `SceneResourceResolver` gates path safety with component-level `..` rejection plus symlink-resolved containment. `WallpaperEngineImportService.importScene` extracts `scene.pkg`, parses the JSON, and classifies capability tier (`imageOnly` / `degraded` / `unsupported`) by walking declared image assets against the cache.

**Runtime** — `@MainActor` `SceneRenderingController` owns the `SKView`/`SKScene` lifecycle, off-main parsing, throttle + suspend hooks. `SceneWallpaperSession` adapts it to `WallpaperRuntimeSession`. `ExclusiveRenderingCoordinator` observes NSApp key-window state. `ScreenManager` wires both and **synchronises throttle on install** so scenes mounted while the inspector is key never start at 60 fps.

**UI** — `WPESceneDetailView` state machine + `LiquidGlassSpinner` + Liquid Glass card hosting an `SKScene.copy()` snapshot (the inspector **never reparents** the live wallpaper SKView — that would steal it from the desktop window). `WPEUnsupportedCard` renamed to `WPEFallbackCard` with reason-aware copy for parse failures, missing assets, and unsupported shaders. `WPESceneSection` routes ready scenes to the detail card.

## Audit fixes inline

Multi-model audit (codex backend + gemini frontend) flagged 9 High/Medium issues — all addressed before this PR:
- ScenePreviewContainer no longer reparents live SKView (used `SKScene.copy()`)
- Cache-root + entry-file traversal: symlink-resolved containment + component-level `..` rejection
- `capabilityTier` correctly returns `degraded` for mixed image+particle scenes (was misclassified as `imageOnly`)
- New scene sessions inherit current console-key throttle on install
- Timer polling stops once state lands in playing/paused/error
- `ReduceMotion` flips trigger an immediate `refreshState()` via `.onChange`
- Error state uses inline overlay (no nested glass card)
- Transitions are opacity-only (no `.scale` across NSView boundaries → no AppKit Auto-Layout cycles)

## Test plan

- [x] `xcodebuild ... test -only-testing:LiveWallpaperTests` — **294 / 294 pass**
- [x] 5 new test suites: SceneDescriptorCodable, WPESceneDocumentParser, SceneResourceResolver, SceneRenderingController, WPESceneSectionState
- [x] Existing WallpaperEngineImportServiceTests gained ready/degraded/unsupported scene branches + cache-rebuild without source-folder access
- [x] Swift 6 strict-concurrency build: 0 new warnings; no new `@unchecked Sendable`
- [x] Legacy ScreenConfiguration round-trips green (no Phase 1 regressions)
- [ ] Manual: import a single-image-layer `.scene` workshop, restart, verify cache restore
- [ ] Manual: open/close inspector, verify desktop drops to 1 fps and recovers
- [ ] Manual: ReduceMotion toggle pauses the SKScene
- [ ] Manual: malformed `scene.json` shows fallback card without replacing wallpaper

🤖 Generated with [Claude Code](https://claude.com/claude-code)