### PR TITLE
feat(wpe): Phase 2.1 .tex decoder + UI honesty pass

### DIFF
--- a/LiveWallpaper/Infrastructure/SceneResourceResolver.swift
+++ b/LiveWallpaper/Infrastructure/SceneResourceResolver.swift
@@ -2,28 +2,30 @@ import CoreGraphics
 import Foundation
 import ImageIO
 
-/// Phase 2.0 resource resolver for `.scene` content. Reads images out of the
-/// extracted cache root using `ImageIO`. Path safety mirrors the WPE folder
-/// scheme handler — every relative path is standardized + symlink-resolved
-/// and rejected if it escapes the cache root.
+/// Resource resolver for `.scene` content. Reads PNG/JPG via ImageIO and
+/// `.tex` via the Phase 2.1 `WPETexDecoder`. Path safety mirrors the WPE
+/// folder scheme handler — every relative path is standardized + symlink-
+/// resolved and rejected if it escapes the cache root.
 ///
-/// `.tex` is a Wallpaper Engine binary texture format that Phase 2.0 does
-/// not parse yet. `resolveImage(...)` will throw `.unsupportedTexture` so
-/// the import service can flag the scene as `degraded`/`unsupported` and the
-/// runtime can render the scene minus that layer instead of crashing.
+/// Phase 2.1: `.tex` no longer auto-fails. The decoder routes by container
+/// version + format enum; only genuinely unsupported formats (RGBA1010102,
+/// unknown V6+ containers, animation frames) surface as precise errors.
 struct SceneResourceResolver: Sendable {
     enum ResolveError: Error, Equatable, Sendable {
         case pathEscape
         case fileMissing
         case decodeFailed
-        case unsupportedTexture
+        case unsupportedTexture                          // legacy alias
+        case texture(WPETexDecodeError)
     }
 
     let cacheRootURL: URL
+    private let decoder: WPETexDecoder
 
-    init(cacheRootURL: URL) {
+    init(cacheRootURL: URL, decoder: WPETexDecoder = WPETexDecoder()) {
         // Standardize once so subsequent prefix checks are stable.
         self.cacheRootURL = cacheRootURL.standardizedFileURL.resolvingSymlinksInPath()
+        self.decoder = decoder
     }
 
     /// Single point where the resolver touches the filesystem. Pulled out as
@@ -35,20 +37,34 @@ struct SceneResourceResolver: Sendable {
     /// Returns a CGImage decoded from the cache. The returned image is
     /// independent of the source file handle so the caller can hold it as
     /// long as needed.
+    ///
+    /// `.tex` files are routed through `WPETexDecoder`; PNG / JPG / GIF go
+    /// through ImageIO. Decode failures for `.tex` surface as
+    /// `.texture(WPETexDecodeError)` so the UI can map them to a precise
+    /// FallbackReason. Decode failures for other extensions stay on
+    /// `.decodeFailed` to match Phase 2.0 contracts.
     func resolveImage(relativePath: String) throws -> CGImage {
         guard !relativePath.isEmpty else { throw ResolveError.fileMissing }
         let target = try resolveURL(for: relativePath)
 
-        let lowered = target.pathExtension.lowercased()
-        if lowered == "tex" {
-            // Phase 2.0 stub: surface as unsupported so the caller picks a
-            // policy (skip layer / show fallback). 2.1 will add a real .tex
-            // first-frame extractor.
-            throw ResolveError.unsupportedTexture
-        }
-
         guard fileManager.fileExists(atPath: target.path) else {
             throw ResolveError.fileMissing
+        }
+
+        let lowered = target.pathExtension.lowercased()
+        if lowered == "tex" {
+            let payload: Data
+            do {
+                payload = try Data(contentsOf: target)
+            } catch {
+                throw ResolveError.fileMissing
+            }
+            switch decoder.decode(data: payload) {
+            case .success(let image):
+                return image
+            case .failure(let error):
+                throw ResolveError.texture(error)
+            }
         }
 
         guard let source = CGImageSourceCreateWithURL(target as CFURL, nil),
@@ -57,6 +73,48 @@ struct SceneResourceResolver: Sendable {
         }
         return image
     }
+
+    /// Cheap header-only probe used by `WallpaperEngineImportService` during
+    /// capability tier classification. We read only the first 64 bytes —
+    /// enough to cover TEXV (9) + TEXI magic (9) + every field the V3 info
+    /// block exposes (28 bytes) — so import scanning a 100 MB / 50-layer
+    /// scene.pkg doesn't churn memory mapping every payload.
+    func probeImage(relativePath: String) -> Result<WPETexInfo, ResolveError> {
+        guard !relativePath.isEmpty else { return .failure(.fileMissing) }
+        let target: URL
+        do {
+            target = try resolveURL(for: relativePath)
+        } catch let error as ResolveError {
+            return .failure(error)
+        } catch {
+            return .failure(.fileMissing)
+        }
+        guard fileManager.fileExists(atPath: target.path) else {
+            return .failure(.fileMissing)
+        }
+        let lowered = target.pathExtension.lowercased()
+        guard lowered == "tex" else {
+            return .failure(.unsupportedTexture)
+        }
+        let header: Data
+        do {
+            let handle = try FileHandle(forReadingFrom: target)
+            defer { try? handle.close() }
+            header = (try handle.read(upToCount: Self.texProbeByteLimit)) ?? Data()
+        } catch {
+            return .failure(.fileMissing)
+        }
+        switch decoder.probe(data: header) {
+        case .success(let info):
+            return .success(info)
+        case .failure(let error):
+            return .failure(.texture(error))
+        }
+    }
+
+    /// Worst-case header size: 9 (TEXV) + 9 (TEXI) + 7×4 (V3 fields) = 46.
+    /// Round up to 64 for safety.
+    private static let texProbeByteLimit = 64
 
     /// File existence probe used by tests + the import service to decide
     /// whether a scene's declared image layers are actually shipped.

--- a/LiveWallpaper/Infrastructure/WPETexByteReader.swift
+++ b/LiveWallpaper/Infrastructure/WPETexByteReader.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Lightweight cursor over an immutable `Data` slice. Used by the `.tex`
+/// decoder to read little-endian integers and 8-byte ASCII block magics
+/// without allocating intermediate `String` / `NSData` wrappers.
+///
+/// Block magics in WPE `.tex` files always come as a NUL-terminated 8-byte
+/// ASCII run (`TEXV0005\0`, `TEXI0001\0`, …). The reader strips the NUL
+/// terminator and returns the canonical 8-character form so the decoder
+/// can prefix-match (`hasPrefix("TEXV")`).
+struct WPETexByteReader {
+    let data: Data
+    private(set) var cursor: Int
+
+    init(data: Data, cursor: Int = 0) {
+        self.data = data
+        self.cursor = cursor
+    }
+
+    var remaining: Int { data.count - cursor }
+    var isAtEnd: Bool { cursor >= data.count }
+
+    mutating func readUInt32(blockName: String = "?") throws -> UInt32 {
+        try ensure(byteCount: 4, blockName: blockName)
+        let value = data.withUnsafeBytes { buffer -> UInt32 in
+            buffer.loadUnaligned(fromByteOffset: cursor, as: UInt32.self)
+        }
+        cursor += 4
+        return UInt32(littleEndian: value)
+    }
+
+    mutating func readInt32(blockName: String = "?") throws -> Int32 {
+        try ensure(byteCount: 4, blockName: blockName)
+        let value = data.withUnsafeBytes { buffer -> Int32 in
+            buffer.loadUnaligned(fromByteOffset: cursor, as: Int32.self)
+        }
+        cursor += 4
+        return Int32(littleEndian: value)
+    }
+
+    /// Reads a NUL-terminated 8-byte ASCII magic. Returns the trimmed
+    /// canonical form (e.g. `"TEXV0005"`). Empty / non-printable runs
+    /// surface as `truncatedBlock`.
+    mutating func readMagic() throws -> String {
+        try ensure(byteCount: 9, blockName: "magic")
+        let raw = data.subdata(in: cursor..<(cursor + 9))
+        cursor += 9
+        // Strip the trailing NUL and any padding so the prefix match works.
+        let trimmed = raw.prefix { $0 != 0 }
+        guard let asciiString = String(data: Data(trimmed), encoding: .ascii),
+              !asciiString.isEmpty else {
+            throw WPETexDecodeError.truncatedBlock(block: "magic", offset: cursor)
+        }
+        return asciiString
+    }
+
+    mutating func readBytes(count: Int, blockName: String) throws -> Data {
+        try ensure(byteCount: count, blockName: blockName)
+        let slice = data.subdata(in: cursor..<(cursor + count))
+        cursor += count
+        return slice
+    }
+
+    mutating func skip(_ count: Int, blockName: String = "?") throws {
+        try ensure(byteCount: count, blockName: blockName)
+        cursor += count
+    }
+
+    private func ensure(byteCount: Int, blockName: String) throws {
+        guard byteCount >= 0, cursor + byteCount <= data.count else {
+            throw WPETexDecodeError.truncatedBlock(block: blockName, offset: cursor)
+        }
+    }
+}

--- a/LiveWallpaper/Infrastructure/WPETexDecoder.swift
+++ b/LiveWallpaper/Infrastructure/WPETexDecoder.swift
@@ -1,0 +1,326 @@
+import CoreGraphics
+import Compression
+import Foundation
+
+/// Stateless `.tex` decoder. Parses `TEXVxxxx` containers emitted by the
+/// Wallpaper Engine publish pipeline and returns either the largest mipmap
+/// of the first frame as a `CGImage` or a precise `WPETexDecodeError` so
+/// the UI can surface the exact reason a layer failed (unsupported format
+/// vs. truncated bytes vs. unknown container version).
+///
+/// Format coverage in Phase 2.1:
+///   - CPU: RGBA8888, R8, RG88
+///   - GPU (Metal transcode, see `WPETexMetalTranscoder`): DXT1/3/5, BC7
+///   - Reject precisely: RGBA1010102, animation/sequence frames
+struct WPETexDecoder: Sendable {
+    init() {}
+
+    /// Cheap header probe — used by `WallpaperEngineImportService` during
+    /// capability tier classification. Reads only as far as the `TEXI`
+    /// block so we don't pay the full mipmap walk per layer at import time.
+    func probe(data: Data) -> Result<WPETexInfo, WPETexDecodeError> {
+        do {
+            return .success(try parseHeader(data: data))
+        } catch let error as WPETexDecodeError {
+            return .failure(error)
+        } catch {
+            return .failure(.decodeFailed(mipmap: 0, detail: error.localizedDescription))
+        }
+    }
+
+    /// Hot path. Reads container → info → bitmap, picks the largest mip,
+    /// dispatches to the appropriate pixel decoder, and returns a CGImage.
+    func decode(data: Data) -> Result<CGImage, WPETexDecodeError> {
+        do {
+            let parsed = try parse(data: data)
+            return .success(try makeCGImage(from: parsed))
+        } catch let error as WPETexDecodeError {
+            return .failure(error)
+        } catch {
+            return .failure(.decodeFailed(mipmap: 0, detail: error.localizedDescription))
+        }
+    }
+
+    // MARK: - Parsing
+
+    private struct ParsedTex {
+        let info: WPETexInfo
+        let bitmap: WPETexBitmapBlock
+        let hasAnimationFrames: Bool
+    }
+
+    private func parseHeader(data: Data) throws -> WPETexInfo {
+        var reader = WPETexByteReader(data: data)
+        let containerMagic = try reader.readMagic()
+        guard containerMagic.hasPrefix("TEXV") else {
+            throw WPETexDecodeError.unsupportedContainer(magic: containerMagic)
+        }
+        let containerVersion = parseTrailingVersion(containerMagic)
+
+        // The first sub-block must be TEXI; otherwise the file is malformed.
+        let infoMagic = try reader.readMagic()
+        guard infoMagic.hasPrefix("TEXI") else {
+            throw WPETexDecodeError.unsupportedBlock(magic: infoMagic)
+        }
+        return try parseInfoBlock(
+            versionedMagic: infoMagic,
+            containerVersion: containerVersion,
+            reader: &reader
+        )
+    }
+
+    private func parse(data: Data) throws -> ParsedTex {
+        var reader = WPETexByteReader(data: data)
+        let containerMagic = try reader.readMagic()
+        guard containerMagic.hasPrefix("TEXV") else {
+            throw WPETexDecodeError.unsupportedContainer(magic: containerMagic)
+        }
+        let containerVersion = parseTrailingVersion(containerMagic)
+
+        var info: WPETexInfo?
+        var bitmap: WPETexBitmapBlock?
+        var hasAnimation = false
+
+        while !reader.isAtEnd {
+            let blockMagic = try reader.readMagic()
+            switch blockMagic.prefix(4) {
+            case "TEXI":
+                info = try parseInfoBlock(
+                    versionedMagic: blockMagic,
+                    containerVersion: containerVersion,
+                    reader: &reader
+                )
+            case "TEXB":
+                guard let parsedInfo = info else {
+                    throw WPETexDecodeError.missingInfoBlock
+                }
+                bitmap = try parseBitmapBlock(
+                    versionedMagic: blockMagic,
+                    info: parsedInfo,
+                    reader: &reader
+                )
+                // Any bytes after TEXB (e.g. TEXS) we treat as animation.
+                if !reader.isAtEnd { hasAnimation = true }
+                break
+            case "TEXS":
+                hasAnimation = true
+                // Phase 2.1 returns the still first frame; we don't need
+                // the sequence payload for the image-only render path.
+                break
+            default:
+                throw WPETexDecodeError.unsupportedBlock(magic: blockMagic)
+            }
+            // Once we have both info + bitmap we can stop walking — the
+            // remaining frames go through Phase 2.x animation work.
+            if info != nil, bitmap != nil { break }
+        }
+
+        guard let parsedInfo = info else { throw WPETexDecodeError.missingInfoBlock }
+        guard let parsedBitmap = bitmap else { throw WPETexDecodeError.missingBitmapBlock }
+        return ParsedTex(info: parsedInfo, bitmap: parsedBitmap, hasAnimationFrames: hasAnimation)
+    }
+
+    // MARK: - TEXI
+
+    private func parseInfoBlock(
+        versionedMagic: String,
+        containerVersion: Int,
+        reader: inout WPETexByteReader
+    ) throws -> WPETexInfo {
+        let infoVersion = parseTrailingVersion(versionedMagic)
+
+        // Layout cross-checked against linux-wallpaperengine's `CTexture`
+        // and confirmed against the user's `TEXV0005`/`TEXI0001` samples:
+        //   format (uint32)
+        //   flags (uint32)
+        //   textureWidth  (uint32, padded to power of 2)
+        //   textureHeight (uint32)
+        //   imageWidth    (uint32, actual visible pixels)
+        //   imageHeight   (uint32)
+        //   [unkInt0 (uint32) — V3+ only]
+        // The image-vs-texture distinction matters: WPE pads compressed
+        // textures to power-of-two for GPU upload, but stores the visible
+        // sub-rect as `imageWidth/imageHeight`. We use the texture
+        // dimensions (full payload) so the bitmap mipmaps line up; the
+        // visible rect can be cropped at render time later.
+        let formatCode = Int(try reader.readInt32(blockName: "TEXI.format"))
+        let flags = try reader.readUInt32(blockName: "TEXI.flags")
+        let textureWidth = Int(try reader.readInt32(blockName: "TEXI.textureWidth"))
+        let textureHeight = Int(try reader.readInt32(blockName: "TEXI.textureHeight"))
+        let imageWidth = Int(try reader.readInt32(blockName: "TEXI.imageWidth"))
+        let imageHeight = Int(try reader.readInt32(blockName: "TEXI.imageHeight"))
+        _ = imageWidth; _ = imageHeight
+        // V3 adds a trailing `unkInt0`. We tolerate both shapes by peeking
+        // — TEXB starts with the 9-byte ASCII magic, so the very next
+        // bytes deciding whether to consume a uint32 is "if reader sees
+        // 'TEXB' next, skip; otherwise consume". TEXI0003 reliably has it.
+        if infoVersion >= 3 {
+            _ = try reader.readInt32(blockName: "TEXI.unkInt0")
+        }
+
+        let format = WPETexFormat(rawValue: formatCode)
+        let info = WPETexInfo(
+            containerVersion: containerVersion,
+            infoVersion: infoVersion,
+            width: max(textureWidth, 1),
+            height: max(textureHeight, 1),
+            textureFormatCode: formatCode,
+            format: format,
+            mipmapCount: 0,
+            flags: flags
+        )
+        guard info.dimensionsLooksValid else {
+            throw WPETexDecodeError.invalidDimensions(width: textureWidth, height: textureHeight)
+        }
+        return info
+    }
+
+    // MARK: - TEXB
+
+    private func parseBitmapBlock(
+        versionedMagic: String,
+        info: WPETexInfo,
+        reader: inout WPETexByteReader
+    ) throws -> WPETexBitmapBlock {
+        let bitmapVersion = parseTrailingVersion(versionedMagic)
+        let mipmapCount = Int(try reader.readInt32(blockName: "TEXB.mipCount"))
+        guard mipmapCount > 0 && mipmapCount <= 32 else {
+            throw WPETexDecodeError.mipmapOutOfBounds(index: mipmapCount)
+        }
+
+        var mipmaps: [WPETexMipmap] = []
+        mipmaps.reserveCapacity(mipmapCount)
+        for index in 0..<mipmapCount {
+            let mipWidth = Int(try reader.readInt32(blockName: "TEXB.mipWidth"))
+            let mipHeight = Int(try reader.readInt32(blockName: "TEXB.mipHeight"))
+            // V3 prepends a `compressed` flag UInt32; V2 / V1 omit it but
+            // store the byte count next either way.
+            var compressedFlag: UInt32 = 0
+            if bitmapVersion >= 3 {
+                compressedFlag = try reader.readUInt32(blockName: "TEXB.mipCompressed")
+            }
+            let storedSize = Int(try reader.readUInt32(blockName: "TEXB.mipSize"))
+            let payload = try reader.readBytes(count: storedSize, blockName: "TEXB.mipPayload")
+
+            mipmaps.append(WPETexMipmap(
+                index: index,
+                width: max(mipWidth, 1),
+                height: max(mipHeight, 1),
+                storedByteCount: storedSize,
+                payload: payload,
+                isCompressed: compressedFlag != 0
+            ))
+        }
+        return WPETexBitmapBlock(version: bitmapVersion, mipmaps: mipmaps)
+    }
+
+    // MARK: - Pixel dispatch
+
+    private func makeCGImage(from parsed: ParsedTex) throws -> CGImage {
+        guard let mip = parsed.bitmap.largestMipmap else {
+            throw WPETexDecodeError.missingBitmapBlock
+        }
+        guard let format = parsed.info.format else {
+            throw WPETexDecodeError.unsupportedFormat(code: parsed.info.textureFormatCode)
+        }
+
+        let expected = format.expectedByteCount(width: mip.width, height: mip.height)
+        let pixelBytes: Data = try inflateIfNeeded(
+            payload: mip.payload,
+            expectedByteCount: expected,
+            isCompressed: mip.isCompressed,
+            mipmap: mip.index
+        )
+
+        let decoded: DecodedRGBAImage
+        switch format {
+        case .rgba8888:
+            decoded = try WPETexPixelDecoder.decodeRGBA8888(
+                pixelBytes,
+                width: mip.width,
+                height: mip.height,
+                mipmap: mip.index
+            )
+        case .r8:
+            decoded = try WPETexPixelDecoder.decodeR8(
+                pixelBytes,
+                width: mip.width,
+                height: mip.height,
+                mipmap: mip.index
+            )
+        case .rg88:
+            decoded = try WPETexPixelDecoder.decodeRG88(
+                pixelBytes,
+                width: mip.width,
+                height: mip.height,
+                mipmap: mip.index
+            )
+        case .dxt1, .dxt3, .dxt5, .bc7:
+            decoded = try WPETexMetalTranscoder.transcode(
+                pixelBytes,
+                format: format,
+                width: mip.width,
+                height: mip.height,
+                mipmap: mip.index
+            )
+        case .rgba1010102:
+            // Phase 2.1 explicitly defers RGBA1010102; surface as
+            // unsupported so the UI shows a precise reason.
+            throw WPETexDecodeError.unsupportedFormat(code: format.rawValue)
+        }
+        return try decoded.makeCGImage()
+    }
+
+    /// Reconciles `payload` against `expectedByteCount`. Three cases:
+    /// 1. Exact match → return as-is.
+    /// 2. Mip flagged `compressed` (V3+) OR payload is shorter than
+    ///    expected → run LZ4 raw decompression.
+    /// 3. Otherwise (uncompressed flag, padded payload longer than
+    ///    expected) → take the leading prefix. WPE's V1/V2 bitmaps
+    ///    occasionally carry trailing slack bytes for alignment; treating
+    ///    that as a decode failure was the source of false negatives in
+    ///    early Phase 2.1 testing.
+    private func inflateIfNeeded(
+        payload: Data,
+        expectedByteCount: Int,
+        isCompressed: Bool,
+        mipmap: Int
+    ) throws -> Data {
+        if payload.count == expectedByteCount { return payload }
+        guard expectedByteCount > 0 else {
+            throw WPETexDecodeError.decompressionFailed(mipmap: mipmap)
+        }
+        if !isCompressed && payload.count > expectedByteCount {
+            return payload.prefix(expectedByteCount)
+        }
+
+        var output = Data(count: expectedByteCount)
+        let written = output.withUnsafeMutableBytes { (out: UnsafeMutableRawBufferPointer) -> Int in
+            payload.withUnsafeBytes { (input: UnsafeRawBufferPointer) -> Int in
+                guard let dst = out.bindMemory(to: UInt8.self).baseAddress,
+                      let src = input.bindMemory(to: UInt8.self).baseAddress else {
+                    return -1
+                }
+                return compression_decode_buffer(
+                    dst, expectedByteCount,
+                    src, payload.count,
+                    nil,
+                    COMPRESSION_LZ4_RAW
+                )
+            }
+        }
+        guard written == expectedByteCount else {
+            throw WPETexDecodeError.decompressionFailed(mipmap: mipmap)
+        }
+        return output
+    }
+
+    // MARK: - Helpers
+
+    /// "TEXV0005" → 5. Defaults to 0 when the suffix isn't a number so we
+    /// can flag genuinely unknown containers later.
+    private func parseTrailingVersion(_ magic: String) -> Int {
+        let digits = magic.suffix(4)
+        return Int(digits) ?? 0
+    }
+}

--- a/LiveWallpaper/Infrastructure/WPETexMetalTranscoder.swift
+++ b/LiveWallpaper/Infrastructure/WPETexMetalTranscoder.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Metal
+
+/// BC1/2/3/7 → RGBA8 transcode entry point. Phase 2.1 scaffolds the API
+/// but does NOT ship a real GPU transcode: a `blitEncoder.copy(...)`
+/// cannot transcode between pixel formats, so the original implementation
+/// produced black/garbage output. A correct transcode requires a render
+/// or compute pipeline that *samples* the BC source texture and writes
+/// the result into an `.rgba8Unorm` target — that's Phase 2.2 work.
+///
+/// Until then `transcode(...)` returns `.metalUnavailable(format:)` so
+/// the resolver maps the error to a precise `texUnsupportedFormat` UI
+/// reason. Empirically, the user's 9 imported scenes are 100%
+/// RGBA8888/RGBA1010102, so deferring BC has zero impact on coverage.
+///
+/// Modeled as an `enum` (no instance, no stored Metal state) so the
+/// type is trivially `Sendable` under Swift 6 strict concurrency without
+/// resorting to `@unchecked Sendable` on `MTLDevice` / `MTLCommandQueue`.
+enum WPETexMetalTranscoder {
+
+    /// Reports whether Phase 2.1 can transcode the given format. Always
+    /// `false` for BC family right now; honest answer for the import
+    /// service so it can mark the layer as unresolvable up front.
+    static func isAvailable(for format: WPETexFormat) -> Bool {
+        // Phase 2.2 will return `MTLCreateSystemDefaultDevice()?.supportsBCTextureCompression ?? false`
+        // once the render-pass-backed transcoder lands.
+        _ = format
+        return false
+    }
+
+    static func transcode(
+        _ bytes: Data,
+        format: WPETexFormat,
+        width: Int,
+        height: Int,
+        mipmap: Int
+    ) throws -> DecodedRGBAImage {
+        _ = (bytes, width, height, mipmap)
+        throw WPETexDecodeError.metalUnavailable(format: format)
+    }
+}

--- a/LiveWallpaper/Infrastructure/WPETexPixelDecoder.swift
+++ b/LiveWallpaper/Infrastructure/WPETexPixelDecoder.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// CPU pixel-decode paths for the uncompressed `.tex` formats. Block-
+/// compressed (BC) formats live in `WPETexMetalTranscoder`. Each function
+/// returns a `DecodedRGBAImage` with `kCGImageAlphaLast` byte order so the
+/// caller can hand it straight to `CGImage` / `SKTexture(cgImage:)`.
+enum WPETexPixelDecoder {
+
+    /// Validates the input length and returns the bytes verbatim — WPE's
+    /// `RGBA8888` is already in the in-memory layout we want.
+    static func decodeRGBA8888(
+        _ bytes: Data,
+        width: Int,
+        height: Int,
+        mipmap: Int
+    ) throws -> DecodedRGBAImage {
+        let expected = width * height * 4
+        guard bytes.count == expected else {
+            throw WPETexDecodeError.decodeFailed(
+                mipmap: mipmap,
+                detail: "RGBA8888 byte count mismatch: got \(bytes.count), expected \(expected)"
+            )
+        }
+        return DecodedRGBAImage(width: width, height: height, pixels: bytes)
+    }
+
+    /// Single-channel red expanded into RGBA(r,r,r,255). Used for masks /
+    /// luminance overlays that WPE stores compactly.
+    static func decodeR8(
+        _ bytes: Data,
+        width: Int,
+        height: Int,
+        mipmap: Int
+    ) throws -> DecodedRGBAImage {
+        let expected = width * height
+        guard bytes.count == expected else {
+            throw WPETexDecodeError.decodeFailed(
+                mipmap: mipmap,
+                detail: "R8 byte count mismatch: got \(bytes.count), expected \(expected)"
+            )
+        }
+        var rgba = Data(count: expected * 4)
+        rgba.withUnsafeMutableBytes { (out: UnsafeMutableRawBufferPointer) in
+            bytes.withUnsafeBytes { (input: UnsafeRawBufferPointer) in
+                let src = input.bindMemory(to: UInt8.self).baseAddress!
+                let dst = out.bindMemory(to: UInt8.self).baseAddress!
+                for i in 0..<expected {
+                    let r = src[i]
+                    dst[i * 4 + 0] = r
+                    dst[i * 4 + 1] = r
+                    dst[i * 4 + 2] = r
+                    dst[i * 4 + 3] = 255
+                }
+            }
+        }
+        return DecodedRGBAImage(width: width, height: height, pixels: rgba)
+    }
+
+    /// Two-channel red+green expanded into RGBA(r,g,0,255). Common for WPE
+    /// normal maps and gradient lookups.
+    static func decodeRG88(
+        _ bytes: Data,
+        width: Int,
+        height: Int,
+        mipmap: Int
+    ) throws -> DecodedRGBAImage {
+        let expected = width * height * 2
+        guard bytes.count == expected else {
+            throw WPETexDecodeError.decodeFailed(
+                mipmap: mipmap,
+                detail: "RG88 byte count mismatch: got \(bytes.count), expected \(expected)"
+            )
+        }
+        let pixelCount = width * height
+        var rgba = Data(count: pixelCount * 4)
+        rgba.withUnsafeMutableBytes { (out: UnsafeMutableRawBufferPointer) in
+            bytes.withUnsafeBytes { (input: UnsafeRawBufferPointer) in
+                let src = input.bindMemory(to: UInt8.self).baseAddress!
+                let dst = out.bindMemory(to: UInt8.self).baseAddress!
+                for i in 0..<pixelCount {
+                    dst[i * 4 + 0] = src[i * 2 + 0]
+                    dst[i * 4 + 1] = src[i * 2 + 1]
+                    dst[i * 4 + 2] = 0
+                    dst[i * 4 + 3] = 255
+                }
+            }
+        }
+        return DecodedRGBAImage(width: width, height: height, pixels: rgba)
+    }
+}

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -304,11 +304,10 @@ final class WallpaperEngineImportService {
         return .ready(.scene(descriptor), origin: origin)
     }
 
-    /// Walk `imageObjects` against the cache root: if every layer's asset is
-    /// present the scene is `.imageOnly`; if some are present and others are
-    /// missing we tag it `.degraded` so the UI shows a "missing assets"
-    /// notice; if none are renderable we surface as `.unsupported` and let
-    /// the import flow fall back to the placeholder card.
+    /// Walk `imageObjects` against the cache root: PNG/JPG go through file
+    /// existence; `.tex` go through the lightweight `WPETexDecoder.probe`
+    /// so a scene composed entirely of `.tex` (the modal Workshop case) is
+    /// classified accurately instead of always sliding into `.unsupported`.
     private func capabilityTier(for document: WPESceneDocument, cacheURL: URL) -> SceneCapabilityTier {
         guard !document.imageObjects.isEmpty else {
             return .unsupported
@@ -318,10 +317,23 @@ final class WallpaperEngineImportService {
         var unresolvable = 0
         for object in document.imageObjects {
             let path = object.imageRelativePath
-            // Treat .tex as unresolvable for tier purposes — the resolver
-            // throws unsupportedTexture, the runtime will skip the layer.
             if path.lowercased().hasSuffix(".tex") {
-                unresolvable += 1
+                // Header probe is cheap (≤ a few KB read) and avoids paying
+                // for the full mip-chain decode at import time.
+                switch resolver.probeImage(relativePath: path) {
+                case .success(let info):
+                    // A known-but-unsupported format (e.g. RGBA1010102 or
+                    // any BC variant in Phase 2.1) is not "resolvable" —
+                    // it would render as an empty layer. Use the explicit
+                    // `isPhase21Decodable` predicate instead of a nil check.
+                    if info.format?.isPhase21Decodable == true {
+                        resolvable += 1
+                    } else {
+                        unresolvable += 1
+                    }
+                case .failure:
+                    unresolvable += 1
+                }
                 continue
             }
             if resolver.exists(relativePath: path) {
@@ -333,11 +345,16 @@ final class WallpaperEngineImportService {
 
         if resolvable == 0 { return .unsupported }
         // Pure imageOnly only when EVERY layer resolves AND the parser saw no
-        // diagnostics at all. Info-level diagnostics include unsupported
-        // particle/text/sound objects — a scene that mixes a PNG layer with
-        // a particle emitter is degraded (the PNG renders, the particles
-        // don't), not fully imageOnly.
-        if unresolvable == 0 && document.diagnostics.isEmpty {
+        // *blocking* diagnostics. The parser emits info-level notes for
+        // every `.tex` layer ("falls back to first-frame stub"); those are
+        // expected for the modal Workshop scene and shouldn't downgrade the
+        // tier from imageOnly to degraded. We only count diagnostics that
+        // signal genuinely unsupported features (particles, text, sound,
+        // shaders) toward the `.degraded` decision.
+        let blockingDiagnostics = document.diagnostics.filter { diagnostic in
+            !diagnostic.message.contains(".tex texture")
+        }
+        if unresolvable == 0 && blockingDiagnostics.isEmpty {
             return .imageOnly
         }
         return .degraded

--- a/LiveWallpaper/Models/WPESceneErrors.swift
+++ b/LiveWallpaper/Models/WPESceneErrors.swift
@@ -36,6 +36,11 @@ enum SceneRenderingError: Error, LocalizedError, Equatable, Sendable {
     case parseFailed(String)
     case unsupportedShader
     case noRenderableObjects
+    /// Every layer hit a resource-level failure (decode / missing / unsupported
+    /// format / etc.). The associated diagnostic carries the *first* such
+    /// failure we encountered so the UI can surface a precise reason instead
+    /// of a generic "no renderable objects" message.
+    case resourceFailed(SceneLoadDiagnostic)
 
     var errorDescription: String? {
         switch self {
@@ -49,6 +54,46 @@ enum SceneRenderingError: Error, LocalizedError, Equatable, Sendable {
             return "Scene uses unsupported shader features."
         case .noRenderableObjects:
             return "Scene has no renderable image layers."
+        case .resourceFailed(let diagnostic):
+            return diagnostic.errorDescription
+        }
+    }
+}
+
+/// Per-layer failure recorded by `SceneRenderingController.load()`. Phase 2.1
+/// uses this to (a) decide whether the scene mounts in degraded mode (≥1
+/// layer renders) or fails outright, and (b) surface a concrete reason in
+/// the developer diagnostic panel and the fallback card.
+enum SceneLoadDiagnostic: Equatable, Sendable {
+    case texture(layer: String, error: WPETexDecodeError)
+    case legacyUnsupportedTexture(layer: String)
+    case fileMissing(layer: String, path: String)
+    case crossPackageReference(layer: String, path: String)
+    case other(layer: String, message: String)
+
+    var layerName: String {
+        switch self {
+        case .texture(let layer, _),
+             .legacyUnsupportedTexture(let layer),
+             .fileMissing(let layer, _),
+             .crossPackageReference(let layer, _),
+             .other(let layer, _):
+            return layer
+        }
+    }
+
+    var errorDescription: String {
+        switch self {
+        case .texture(let layer, let error):
+            return "Layer \(layer): \(error.errorDescription ?? "tex decode failed")"
+        case .legacyUnsupportedTexture(let layer):
+            return "Layer \(layer): legacy .tex layer skipped"
+        case .fileMissing(let layer, let path):
+            return "Layer \(layer): missing asset \(path)"
+        case .crossPackageReference(let layer, let path):
+            return "Layer \(layer): cross-package reference \(path) rejected"
+        case .other(let layer, let message):
+            return "Layer \(layer): \(message)"
         }
     }
 }

--- a/LiveWallpaper/Models/WPETexErrors.swift
+++ b/LiveWallpaper/Models/WPETexErrors.swift
@@ -1,0 +1,222 @@
+import CoreGraphics
+import Foundation
+
+/// Wallpaper Engine `.tex` container format codes. Source: community
+/// reverse-engineering work in `RePKG` and `linux-wallpaperengine` cross-
+/// referenced against the user's Steam Workshop samples (`TEXV0005` /
+/// `TEXI0001` / `TEXB0003` is the modal layout).
+enum WPETexFormat: Int, Sendable, Equatable {
+    case rgba8888 = 0
+    case dxt5 = 1   // BC3
+    case dxt3 = 2   // BC2
+    case dxt1 = 3   // BC1
+    case r8 = 4
+    case rg88 = 5
+    case rgba1010102 = 8
+    case bc7 = 13
+
+    /// Bytes per pixel for uncompressed formats; nil for block-compressed
+    /// (BC) formats where the unit is a 4×4 block.
+    var bytesPerPixel: Int? {
+        switch self {
+        case .rgba8888, .rgba1010102: return 4
+        case .r8: return 1
+        case .rg88: return 2
+        case .dxt1, .dxt3, .dxt5, .bc7: return nil
+        }
+    }
+
+    /// 16 for BC1; 32 for BC2/3/7. nil for uncompressed.
+    var bytesPerBlock: Int? {
+        switch self {
+        case .dxt1: return 8
+        case .dxt3, .dxt5, .bc7: return 16
+        default: return nil
+        }
+    }
+
+    /// Expected raw byte count for a given mip dimension (no compression
+    /// padding). Block-compressed mips round up to multiples of 4.
+    func expectedByteCount(width: Int, height: Int) -> Int {
+        if let bpp = bytesPerPixel {
+            return max(width, 1) * max(height, 1) * bpp
+        }
+        guard let bpb = bytesPerBlock else { return 0 }
+        let blocksW = max((width + 3) / 4, 1)
+        let blocksH = max((height + 3) / 4, 1)
+        return blocksW * blocksH * bpb
+    }
+
+    var debugLabel: String {
+        switch self {
+        case .rgba8888:    return "RGBA8888"
+        case .dxt5:        return "DXT5 (BC3)"
+        case .dxt3:        return "DXT3 (BC2)"
+        case .dxt1:        return "DXT1 (BC1)"
+        case .r8:          return "R8"
+        case .rg88:        return "RG88"
+        case .rgba1010102: return "RGBA1010102"
+        case .bc7:         return "BC7"
+        }
+    }
+
+    /// True when Phase 2.1 has a decode path that produces a CGImage.
+    /// Used by capability tier classification so a known-but-unsupported
+    /// format (e.g. RGBA1010102) is correctly counted as unresolvable
+    /// instead of optimistically tagged as renderable.
+    var isPhase21Decodable: Bool {
+        switch self {
+        case .rgba8888, .r8, .rg88:
+            return true
+        case .dxt1, .dxt3, .dxt5, .bc7:
+            // Phase 2.1 has a Metal pipeline scaffolded but a real BC →
+            // RGBA8 transcode requires a render/compute pass we have not
+            // shipped yet (a `blitEncoder.copy` cannot transcode formats).
+            // Until that lands, tag BC formats as not-yet-decodable so the
+            // import service classifies them as `.unsupportedFormat` with
+            // a precise UI message rather than rendering a black layer.
+            return false
+        case .rgba1010102:
+            return false
+        }
+    }
+}
+
+/// Failure modes from `WPETexDecoder`. Each case maps to a precise UI
+/// `FallbackReason` so the user sees "Format 13 (BC7) Metal-only" instead
+/// of "scene unsupported".
+enum WPETexDecodeError: Error, Equatable, Sendable, LocalizedError {
+    case unsupportedContainer(magic: String)
+    case unsupportedBlock(magic: String)
+    case missingInfoBlock
+    case missingBitmapBlock
+    case unsupportedFormat(code: Int)
+    case unsupportedAnimation
+    case invalidDimensions(width: Int, height: Int)
+    case truncatedBlock(block: String, offset: Int)
+    case mipmapOutOfBounds(index: Int)
+    case decompressionFailed(mipmap: Int)
+    case decodeFailed(mipmap: Int, detail: String)
+    case metalUnavailable(format: WPETexFormat)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedContainer(let magic):
+            return ".tex container '\(magic)' is unrecognised."
+        case .unsupportedBlock(let magic):
+            return ".tex block '\(magic)' is unrecognised."
+        case .missingInfoBlock:
+            return ".tex file is missing the TEXI info block."
+        case .missingBitmapBlock:
+            return ".tex file is missing the TEXB bitmap block."
+        case .unsupportedFormat(let code):
+            return ".tex format code \(code) is not yet supported."
+        case .unsupportedAnimation:
+            return ".tex animation/sequence frames are not supported."
+        case .invalidDimensions(let w, let h):
+            return ".tex declares invalid dimensions \(w)×\(h)."
+        case .truncatedBlock(let block, let offset):
+            return ".tex block '\(block)' truncated at offset \(offset)."
+        case .mipmapOutOfBounds(let index):
+            return ".tex mipmap index \(index) is out of bounds."
+        case .decompressionFailed(let mipmap):
+            return ".tex mipmap \(mipmap) decompression failed."
+        case .decodeFailed(let mipmap, let detail):
+            return ".tex mipmap \(mipmap) decode failed: \(detail)"
+        case .metalUnavailable(let format):
+            return "Cannot decode \(format.debugLabel) without Metal support on this machine."
+        }
+    }
+}
+
+// MARK: - Value types parsed out of the container
+
+/// `TEXI` block payload. Width / height are in pixels; `mipmapCount`
+/// counts the mip chain stored in the following `TEXB` block.
+struct WPETexInfo: Sendable, Equatable {
+    let containerVersion: Int
+    let infoVersion: Int
+    let width: Int
+    let height: Int
+    let textureFormatCode: Int
+    let format: WPETexFormat?
+    let mipmapCount: Int
+    let flags: UInt32
+
+    var dimensionsLooksValid: Bool {
+        width > 0 && height > 0
+            && width <= 16_384 && height <= 16_384
+    }
+}
+
+/// One mipmap entry pulled out of `TEXB`. `payload` is the raw stored bytes
+/// — may be larger than `expectedByteCount` (uncompressed) or smaller (LZ4-
+/// compressed). Decoder reconciles which case it is.
+struct WPETexMipmap: Sendable, Equatable {
+    let index: Int
+    let width: Int
+    let height: Int
+    let storedByteCount: Int
+    let payload: Data
+    /// Set when the bitmap header marked this mip as LZ4-compressed (`TEXB`
+    /// V3+ exposes the flag explicitly). Drives `WPETexDecoder.inflate`
+    /// behaviour: padded raw payloads with a trailing slack get truncated
+    /// to the expected byte count instead of misinterpreted as compressed.
+    let isCompressed: Bool
+}
+
+struct WPETexBitmapBlock: Sendable, Equatable {
+    let version: Int
+    let mipmaps: [WPETexMipmap]
+
+    var largestMipmap: WPETexMipmap? {
+        mipmaps.first
+    }
+}
+
+/// CPU-side RGBA8 image emitted by every decode path (CPU or Metal). A
+/// thin Sendable container so the actual `CGImage` can be created at the
+/// resolver boundary.
+struct DecodedRGBAImage: Sendable, Equatable {
+    let width: Int
+    let height: Int
+    let pixels: Data
+
+    init(width: Int, height: Int, pixels: Data) {
+        self.width = width
+        self.height = height
+        self.pixels = pixels
+    }
+}
+
+extension DecodedRGBAImage {
+    /// Builds a non-premultiplied RGBA8 `CGImage`. Uses
+    /// `kCGImageAlphaLast` so SpriteKit's `SKTexture(cgImage:)` reads the
+    /// alpha channel correctly without a swizzle pass.
+    func makeCGImage() throws -> CGImage {
+        let bitsPerComponent = 8
+        let bitsPerPixel = 32
+        let bytesPerRow = width * 4
+        guard let provider = CGDataProvider(data: pixels as CFData) else {
+            throw WPETexDecodeError.decodeFailed(mipmap: 0, detail: "CGDataProvider init failed")
+        }
+        let space = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.last.rawValue)
+        guard let image = CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: bitsPerComponent,
+            bitsPerPixel: bitsPerPixel,
+            bytesPerRow: bytesPerRow,
+            space: space,
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        ) else {
+            throw WPETexDecodeError.decodeFailed(mipmap: 0, detail: "CGImage init failed")
+        }
+        return image
+    }
+}

--- a/LiveWallpaper/Runtime/SceneRenderingController.swift
+++ b/LiveWallpaper/Runtime/SceneRenderingController.swift
@@ -29,6 +29,14 @@ final class SceneRenderingController {
     private var didLoad = false
     private var isThrottled = false
     private var currentProfile: WallpaperPerformanceProfile = .quality
+    /// First per-layer failure we observed during `load()`. Surfaced to the
+    /// detail view's diagnostic panel so power users can see *why* a layer
+    /// was skipped without diving into Console logs.
+    private(set) var loadDiagnostics: SceneLoadDiagnostic?
+    /// Per-layer progress callback driven by `load()`. The controller
+    /// invokes this on the main actor with strings like "3/12" so the
+    /// inspector card can surface them in `LiquidGlassSpinner`.
+    var onProgress: (@MainActor (String) -> Void)?
 
     init(descriptor: SceneDescriptor, cacheRootURL: URL, frame: CGRect) {
         self.descriptor = descriptor
@@ -98,7 +106,14 @@ final class SceneRenderingController {
         )
 
         var renderableLayers = 0
-        for object in document.imageObjects where object.visible && object.alpha > 0.001 {
+        var firstFailure: SceneLoadDiagnostic?
+        let visibleLayers = document.imageObjects.filter { $0.visible && $0.alpha > 0.001 }
+        let totalLayers = visibleLayers.count
+        var processed = 0
+
+        for object in visibleLayers {
+            processed += 1
+            onProgress?("Decoding \(processed)/\(totalLayers) textures…")
             do {
                 let cgImage = try resolver.resolveImage(relativePath: object.imageRelativePath)
                 let texture = SKTexture(cgImage: cgImage)
@@ -106,22 +121,36 @@ final class SceneRenderingController {
                 let node = makeSpriteNode(texture: texture, object: object, canvas: canvasSize)
                 scene.addChild(node)
                 renderableLayers += 1
+            } catch SceneResourceResolver.ResolveError.texture(let texError) {
+                Logger.warning("Scene \(descriptor.workshopID): tex decode failed for \(object.name) — \(texError.errorDescription ?? "?")", category: .screenManager)
+                firstFailure = firstFailure ?? .texture(layer: object.name, error: texError)
             } catch SceneResourceResolver.ResolveError.unsupportedTexture {
                 Logger.warning("Scene \(descriptor.workshopID): skipping .tex layer \(object.name)", category: .screenManager)
+                firstFailure = firstFailure ?? .legacyUnsupportedTexture(layer: object.name)
             } catch SceneResourceResolver.ResolveError.fileMissing {
                 Logger.warning("Scene \(descriptor.workshopID): missing asset for layer \(object.name)", category: .screenManager)
+                firstFailure = firstFailure ?? .fileMissing(layer: object.name, path: object.imageRelativePath)
             } catch SceneResourceResolver.ResolveError.pathEscape {
                 // Cross-package reference (e.g. `../<workshopid>/materials/foo.png`).
                 // Phase 2.0 has no multi-root resolver; skipping the layer
                 // keeps the scene partially renderable and the import
                 // service flagged the project as `.degraded` upstream.
                 Logger.warning("Scene \(descriptor.workshopID): cross-package reference rejected for \(object.name) — \(object.imageRelativePath)", category: .screenManager)
+                firstFailure = firstFailure ?? .crossPackageReference(layer: object.name, path: object.imageRelativePath)
             } catch {
                 Logger.warning("Scene \(descriptor.workshopID): failed to load \(object.name): \(error.localizedDescription)", category: .screenManager)
+                firstFailure = firstFailure ?? .other(layer: object.name, message: error.localizedDescription)
             }
         }
 
+        loadDiagnostics = firstFailure
+
         guard renderableLayers > 0 else {
+            // Surface the most specific failure we saw so the UI can map
+            // it to a precise FallbackReason instead of a generic message.
+            if let firstFailure {
+                throw SceneRenderingError.resourceFailed(firstFailure)
+            }
             throw SceneRenderingError.noRenderableObjects
         }
 
@@ -154,6 +183,23 @@ final class SceneRenderingController {
         skView.presentScene(nil)
         scene = nil
         didLoad = false
+        loadDiagnostics = nil
+    }
+
+    /// Tears the current SKScene down and re-runs `load()`. Used by the
+    /// inspector's Retry button — keeps the SKView itself alive (and on
+    /// the wallpaper window) so the user doesn't see a black flicker
+    /// while the new scene materialises.
+    func reload() async throws {
+        if didLoad {
+            scene?.removeAllChildren()
+            scene?.removeAllActions()
+            skView.presentScene(nil)
+            scene = nil
+            didLoad = false
+            loadDiagnostics = nil
+        }
+        try await load()
     }
 
     // MARK: - Private

--- a/LiveWallpaper/Runtime/SceneWallpaperSession.swift
+++ b/LiveWallpaper/Runtime/SceneWallpaperSession.swift
@@ -14,6 +14,10 @@ final class SceneWallpaperSession: WallpaperRuntimeSession {
     private var didStartLoad = false
     private(set) var isThrottled = false
     private(set) var loadError: SceneRenderingError?
+    /// Latest per-layer progress message reported by the controller.
+    /// Phase 2.1 surfaces this via `WPESceneDetailView` so the user sees
+    /// "Decoding 7/12 textures…" instead of an opaque spinner.
+    private(set) var loadProgress: String?
 
     init(window: NSWindow, controller: SceneRenderingController) {
         self.window = window
@@ -87,10 +91,12 @@ final class SceneWallpaperSession: WallpaperRuntimeSession {
     func startLoadIfNeeded() {
         guard !didStartLoad, let controller else { return }
         didStartLoad = true
+        installProgressHandler(on: controller)
         Task { @MainActor [weak self] in
             do {
                 try await controller.load()
                 self?.loadError = nil
+                self?.loadProgress = nil
             } catch let error as SceneRenderingError {
                 Logger.warning("Scene wallpaper load failed: \(error.errorDescription ?? "(no description)")", category: .screenManager)
                 self?.loadError = error
@@ -104,4 +110,32 @@ final class SceneWallpaperSession: WallpaperRuntimeSession {
     // No prepareForDisplay override: the protocol-extension default
     // (50ms warm-up) gives the SpriteKit pipeline enough lead time before
     // the wallpaper window is brought to screen.
+
+    /// Tears the controller's scene down and re-runs `load()`. Used by
+    /// the inspector's Retry button so the user has a recovery path
+    /// without manually clearing + re-importing the wallpaper. Clears
+    /// the previous `loadError` on success so the state machine can move
+    /// back to `.playing` instead of latching on the old failure.
+    func reload() async {
+        guard let controller else {
+            loadError = .cacheRootMissing
+            return
+        }
+        installProgressHandler(on: controller)
+        do {
+            try await controller.reload()
+            loadError = nil
+            loadProgress = nil
+        } catch let error as SceneRenderingError {
+            loadError = error
+        } catch {
+            loadError = .parseFailed(error.localizedDescription)
+        }
+    }
+
+    private func installProgressHandler(on controller: SceneRenderingController) {
+        controller.onProgress = { [weak self] progress in
+            self?.loadProgress = progress
+        }
+    }
 }

--- a/LiveWallpaper/Views/Components/LiquidGlassSpinner.swift
+++ b/LiveWallpaper/Views/Components/LiquidGlassSpinner.swift
@@ -8,37 +8,61 @@ struct LiquidGlassSpinner: View {
     var size: CGFloat = 44
     var lineWidth: CGFloat = 4
     var tint: Color = .white
+    /// Optional caption rendered just below the spinner ring. Used by
+    /// Phase 2.1's per-layer progress (e.g. "Decoding 3/12 textures…")
+    /// without forcing every caller to wrap the spinner in a VStack.
+    var progressText: String?
 
     @State private var animate = false
 
     var body: some View {
-        ZStack {
-            Circle()
-                .stroke(tint.opacity(0.12), lineWidth: lineWidth)
+        VStack(spacing: 12) {
+            ZStack {
+                Circle()
+                    .stroke(tint.opacity(0.12), lineWidth: lineWidth)
 
-            Circle()
-                .trim(from: 0, to: 0.32)
-                .stroke(
-                    tint.opacity(0.85),
-                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
-                )
-                .rotationEffect(.degrees(animate ? 360 : 0))
-                .blendMode(.plusLighter)
-                .animation(.linear(duration: 1.1).repeatForever(autoreverses: false), value: animate)
+                Circle()
+                    .trim(from: 0, to: 0.32)
+                    .stroke(
+                        tint.opacity(0.85),
+                        style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(animate ? 360 : 0))
+                    .blendMode(.plusLighter)
+                    .animation(.linear(duration: 1.1).repeatForever(autoreverses: false), value: animate)
 
-            Circle()
-                .trim(from: 0, to: 0.18)
-                .stroke(
-                    tint.opacity(0.55),
-                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
-                )
-                .rotationEffect(.degrees(animate ? -360 : 0))
-                .blendMode(.plusLighter)
-                .animation(.linear(duration: 1.7).repeatForever(autoreverses: false), value: animate)
+                Circle()
+                    .trim(from: 0, to: 0.18)
+                    .stroke(
+                        tint.opacity(0.55),
+                        style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(animate ? -360 : 0))
+                    .blendMode(.plusLighter)
+                    .animation(.linear(duration: 1.7).repeatForever(autoreverses: false), value: animate)
+            }
+            .frame(width: size, height: size)
+
+            if let progressText {
+                Text(progressText)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.92))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    // ultraThinMaterial pill keeps the caption visually
+                    // tied to the Liquid Glass aesthetic instead of
+                    // floating as plain white text on the blurred
+                    // wallpaper background.
+                    .background(.ultraThinMaterial, in: Capsule())
+                    .accessibilityLabel(progressText)
+            }
         }
-        .frame(width: size, height: size)
         .onAppear { animate = true }
-        .accessibilityHidden(true)
+        // Keep the ring itself silent so VoiceOver only announces the
+        // progress caption (when present) — avoids "loading, loading,
+        // loading…" chatter.
+        .accessibilityElement(children: progressText == nil ? .ignore : .contain)
     }
 }
 

--- a/LiveWallpaper/Views/ScreenDetail/WPEFallbackCard.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEFallbackCard.swift
@@ -5,10 +5,12 @@ import AppKit
 /// to the inspector so the user gets a specific reason instead of a generic
 /// "unsupported" message.
 enum FallbackReason: Equatable, Sendable {
+    // Phase 2.0
     case unsupportedType
     case sceneParseFailed(String)
     case sceneShaderUnsupported
     case sceneResourceMissing
+    // Phase 2.0.1
     /// Project declares Steam Workshop dependencies we couldn't satisfy
     /// from the local cache. Lists IDs the user must subscribe to in
     /// Steam before retrying the import.
@@ -16,6 +18,12 @@ enum FallbackReason: Equatable, Sendable {
     /// Project ships a Windows `.dll` plugin under `bin/`. Permanent on
     /// macOS — subscribing more workshop items will not help.
     case requiresWindowsPlugin
+    // Phase 2.1 — `.tex` decoder failures with precise codes so the user
+    // sees "Format 8 (RGBA1010102) not yet supported" instead of a vague
+    // "scene unsupported".
+    case texContainerUnsupported(magic: String)
+    case texUnsupportedFormat(code: Int)
+    case texDecodeFailed(detail: String)
 }
 
 /// Renders the explanatory card for any WPE workshop import that cannot be
@@ -42,6 +50,11 @@ struct WPEFallbackCard: View {
         return .unsupportedType
     }
 
+    /// True when the user can probably take an action (subscribe, retry,
+    /// re-download) and have the wallpaper start working. Drives both the
+    /// warning chip color and the Retry button visibility.
+    var canRetry: Bool { reason.isActionable }
+
     var body: some View {
         VStack(spacing: 24) {
             WPEPreviewView(
@@ -65,7 +78,11 @@ struct WPEFallbackCard: View {
                 HStack(spacing: 12) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.title2)
-                        .foregroundStyle(.orange)
+                        // Apple HIG warning semantic — `.yellow` matches
+                        // System Settings/Photos warning chips on macOS 26.
+                        // We keep the orange accent strictly for hard
+                        // permanent blockers (`.requiresWindowsPlugin`).
+                        .foregroundStyle(reason.severityTint)
                     Text(warningTitle)
                         .font(.headline)
                 }
@@ -199,6 +216,12 @@ struct WPEFallbackCard: View {
             return "Missing \(ids.count) Workshop \(ids.count == 1 ? "dependency" : "dependencies")"
         case .requiresWindowsPlugin:
             return "Windows plugin required"
+        case .texContainerUnsupported:
+            return "Texture container not supported yet"
+        case .texUnsupportedFormat:
+            return "Image format not supported yet"
+        case .texDecodeFailed:
+            return "Couldn't read texture file"
         }
     }
 
@@ -223,6 +246,19 @@ struct WPEFallbackCard: View {
             return "This wallpaper relies on other Workshop projects we don't have on disk yet. Subscribe to them in Steam, then re-import this folder."
         case .requiresWindowsPlugin:
             return "This wallpaper bundles a Windows `.dll` plugin (e.g. an audio visualizer or screensaver runtime). macOS can't load Windows native code, so the project is permanently unsupported here."
+        case .texContainerUnsupported(let magic):
+            return "This wallpaper uses a `.tex` container we don't decode yet (\(magic)). Phase 2.x will keep widening coverage as new versions appear."
+        case .texUnsupportedFormat(let code):
+            switch code {
+            case 8:
+                return "WPE format 8 (RGBA1010102) is rare and pending decoder support. Most other layers in this scene should still render."
+            case -1:
+                return "This format requires Metal-backed GPU decoding that this Mac doesn't support. Try rendering on a newer GPU."
+            default:
+                return "Wallpaper Engine format \(code) is not in the Phase 2.1 decoder. The renderer skips just this layer; the rest of the scene continues."
+            }
+        case .texDecodeFailed(let detail):
+            return "A texture failed to decode (\(detail)). Re-downloading the wallpaper in Steam usually fixes it."
         }
     }
 
@@ -264,5 +300,46 @@ struct WPEUnsupportedCard: View {
 
     var body: some View {
         WPEFallbackCard(origin: origin, reason: WPEFallbackCard.reason(for: origin))
+    }
+}
+
+extension FallbackReason {
+    /// Apple HIG warning semantics. `.yellow` for "needs attention but
+    /// recoverable", `.orange` for "permanent block, no action will help".
+    /// Keeping the two distinct lets users skim the inspector for the
+    /// difference between "subscribe to fix" vs "macOS can't run this".
+    var severityTint: Color {
+        switch self {
+        case .requiresWindowsPlugin:
+            return .orange
+        case .unsupportedType,
+             .sceneShaderUnsupported,
+             .texContainerUnsupported,
+             .texUnsupportedFormat:
+            return .orange
+        case .missingDependency,
+             .sceneParseFailed,
+             .sceneResourceMissing,
+             .texDecodeFailed:
+            return .yellow
+        }
+    }
+
+    /// Reason categories where the user can take a concrete action and
+    /// retry — drives the inline Retry button on the detail view.
+    var isActionable: Bool {
+        switch self {
+        case .missingDependency,
+             .sceneParseFailed,
+             .sceneResourceMissing,
+             .texDecodeFailed:
+            return true
+        case .unsupportedType,
+             .sceneShaderUnsupported,
+             .requiresWindowsPlugin,
+             .texContainerUnsupported,
+             .texUnsupportedFormat:
+            return false
+        }
     }
 }

--- a/LiveWallpaper/Views/ScreenDetail/WPEHistoryRow.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEHistoryRow.swift
@@ -29,6 +29,18 @@ struct WPEHistoryRow: View {
                             style: .continuous
                         )
                     )
+                    .overlay(alignment: .topTrailing) {
+                        if let badge = compatibilityBadge {
+                            Text(badge.label)
+                                .font(.system(size: 9, weight: .semibold))
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(badge.tint.opacity(0.85), in: Capsule())
+                                .foregroundStyle(.white)
+                                .padding(8)
+                                .accessibilityLabel(badge.accessibility)
+                        }
+                    }
 
                 VStack(alignment: .leading, spacing: 8) {
                     Text(entry.origin.title)
@@ -112,6 +124,33 @@ struct WPEHistoryRow: View {
         case .scene: return .orange
         case .application: return .red
         case .unknown: return .gray
+        }
+    }
+
+    /// Phase 2.1 thumbnail badge for honest expectation-setting BEFORE the
+    /// user taps Apply. Three tiers — clean (no badge), Experimental
+    /// (likely degraded), and Won't Run (Windows plugin / unknown).
+    /// We deliberately keep this conservative: PNG/JPG video and web
+    /// imports get no badge; scene + application + unknown carry one.
+    private var compatibilityBadge: (label: String, tint: Color, accessibility: String)? {
+        switch entry.origin.originalType {
+        case .video, .web:
+            return nil
+        case .application:
+            return ("Won't run", .orange, "Wallpaper requires a Windows executable; cannot run on macOS")
+        case .scene:
+            if entry.origin.requiresWindowsPlugin {
+                return ("Won't run", .orange, "Wallpaper bundles a Windows DLL plugin; cannot run on macOS")
+            }
+            if !entry.origin.missingDependencyIDs.isEmpty {
+                return ("Needs deps", .yellow, "Wallpaper depends on Workshop projects you haven't subscribed to")
+            }
+            // Phase 2.1: scenes are renderable when image-only; default
+            // tier is best-effort, so we tag them Experimental until the
+            // import service can persist a richer capability summary.
+            return ("Experimental", .yellow, "Scene wallpapers are rendered with the Phase 2.1 image-only engine")
+        case .unknown:
+            return ("Untested", .gray, "Wallpaper Engine project type is unknown")
         }
     }
 }

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
@@ -15,11 +15,16 @@ struct WPESceneDetailView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var state: SceneRenderState = .idle
+    /// Hidden developer disclosure toggled by Option-click on the metadata
+    /// row. Surfaces capability tier + first failure diagnostic so power
+    /// users can see *why* a layer was skipped without diving into Console.
+    @State private var showDiagnostics = false
 
     var body: some View {
         VStack(spacing: 16) {
             previewCard
             metadata
+            if showDiagnostics { diagnosticsPanel }
             actions
         }
         .padding(24)
@@ -42,7 +47,7 @@ struct WPESceneDetailView: View {
             // becomes a no-op (Timer.publish itself can't be cancelled
             // reactively from inside .onReceive without keeping a Cancellable
             // bag, which costs more than the early return).
-            guard state == .idle || state == .loading else { return }
+            guard state == .idle || state.isLoading else { return }
             Task { @MainActor in
                 await refreshState()
             }
@@ -59,9 +64,12 @@ struct WPESceneDetailView: View {
             // when the user toggles ReduceMotion / focus / throttle. Pause
             // is communicated by overlay, not by replacing the SKView.
             switch state {
-            case .idle, .loading:
+            case .idle:
                 fallbackBackground
                 LiquidGlassSpinner()
+            case .loading(let progress):
+                fallbackBackground
+                LiquidGlassSpinner(progressText: progress)
             case .playing(let controller):
                 ScenePreviewContainer(controller: controller)
                     .aspectRatio(16.0 / 9.0, contentMode: .fit)
@@ -136,6 +144,9 @@ struct WPESceneDetailView: View {
         case .missingDependency(let ids):
             return "Missing \(ids.count) Workshop \(ids.count == 1 ? "dependency" : "dependencies")"
         case .requiresWindowsPlugin:  return "Windows plugin required"
+        case .texContainerUnsupported: return "Unknown texture container"
+        case .texUnsupportedFormat:    return "Texture format not supported"
+        case .texDecodeFailed:         return "Texture decode failed"
         }
     }
 
@@ -160,6 +171,12 @@ struct WPESceneDetailView: View {
             return "Subscribe to \(head) and \(ids.count - 2) more in Steam, then re-import."
         case .requiresWindowsPlugin:
             return "macOS can't load Windows native plugins."
+        case .texContainerUnsupported(let magic):
+            return "Container \(magic) — Phase 2.x will add it."
+        case .texUnsupportedFormat(let code):
+            return "Format \(code) — not yet decoded."
+        case .texDecodeFailed(let detail):
+            return detail
         }
     }
 
@@ -169,8 +186,8 @@ struct WPESceneDetailView: View {
             securityScopedBookmarkData: origin.sourceFolderBookmark
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .blur(radius: state == .loading ? 6 : 0)
-        .overlay(Color.black.opacity(state == .loading ? 0.35 : 0.0))
+        .blur(radius: state.isLoading ? 6 : 0)
+        .overlay(Color.black.opacity(state.isLoading ? 0.35 : 0.0))
     }
 
     private var metadata: some View {
@@ -181,11 +198,61 @@ struct WPESceneDetailView: View {
                 Spacer()
                 statusPill
             }
-            Text("Workshop ID \(origin.workshopID) · capability: \(descriptor.capabilityTier.rawValue)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Text("Workshop ID \(origin.workshopID) · capability: \(descriptor.capabilityTier.rawValue)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                // Tiny info glyph hints that there's a developer panel
+                // hiding under Option-click. Without this affordance the
+                // panel was completely undiscoverable (gemini audit).
+                Image(systemName: "info.circle")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .help("Option-click for renderer diagnostics")
+                    .accessibilityHidden(true)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        // Option-click toggles the hidden developer diagnostic panel. We
+        // attach the gesture to the metadata row (rather than the whole
+        // card) so retry / clear buttons aren't intercepted. SwiftUI for
+        // macOS doesn't expose a typed modifier-aware tap gesture, so
+        // we sniff `NSEvent.modifierFlags` at click time — plain clicks
+        // become a no-op and only Option-clicks toggle the panel.
+        .onTapGesture {
+            guard NSEvent.modifierFlags.contains(.option) else { return }
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                showDiagnostics.toggle()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var diagnosticsPanel: some View {
+        // Build the VoiceOver label up-front so the panel announces both
+        // the title AND the active diagnostic in one pass — the previous
+        // implementation overrode `accessibilityLabel` on the parent and
+        // hid the error text from screen readers entirely (gemini audit).
+        let diagnosticText = session?.sceneController?.loadDiagnostics?.errorDescription
+            ?? "All declared layers decoded cleanly."
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Renderer Diagnostics")
+                .font(.caption.bold())
+            Text("Capability: \(descriptor.capabilityTier.rawValue) · Phase 2.1")
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+            Text(diagnosticText)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(4)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.black.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Renderer diagnostics: capability \(descriptor.capabilityTier.rawValue). \(diagnosticText)")
     }
 
     private var statusPill: some View {
@@ -203,6 +270,11 @@ struct WPESceneDetailView: View {
     }
 
     private var actions: some View {
+        // Apple HIG: destructive "Clear" sits leading; the constructive
+        // recovery action ("Retry") sits trailing and gets prominent
+        // styling so the recommended path is visually obvious. Without
+        // this swap, an Option-button-mash could land on the destructive
+        // button by accident.
         HStack(spacing: 12) {
             Button(role: .destructive) {
                 onClearWallpaper()
@@ -214,6 +286,21 @@ struct WPESceneDetailView: View {
             .accessibilityHint("Removes the scene wallpaper from this display")
 
             Spacer()
+
+            if case .error(let reason) = state, reason.isActionable {
+                Button {
+                    Task { @MainActor in
+                        state = .loading
+                        await session?.reload()
+                        await refreshState()
+                    }
+                } label: {
+                    Label("Retry", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+                .accessibilityHint("Re-decodes the scene with the current cache state")
+            }
         }
     }
 
@@ -233,7 +320,7 @@ struct WPESceneDetailView: View {
             return
         }
         if controller.view.scene == nil {
-            state = .loading
+            state = .loading(progress: session.loadProgress)
             return
         }
         // Drive the runtime profile from the same env signals the state
@@ -258,6 +345,35 @@ struct WPESceneDetailView: View {
             return .sceneShaderUnsupported
         case .noRenderableObjects:
             return .sceneResourceMissing
+        case .resourceFailed(let diagnostic):
+            return Self.fallbackReason(for: diagnostic)
+        }
+    }
+
+    /// Maps the most-specific per-layer failure into the corresponding
+    /// FallbackReason. Phase 2.1 surfaces .tex container/format errors with
+    /// their precise codes so the user understands why a layer was skipped.
+    static func fallbackReason(for diagnostic: SceneLoadDiagnostic) -> FallbackReason {
+        switch diagnostic {
+        case .texture(_, let error):
+            switch error {
+            case .unsupportedContainer(let magic):
+                return .texContainerUnsupported(magic: magic)
+            case .unsupportedFormat(let code):
+                return .texUnsupportedFormat(code: code)
+            case .metalUnavailable:
+                return .texUnsupportedFormat(code: -1)
+            case .unsupportedAnimation:
+                return .texDecodeFailed(detail: "animation/sequence frames")
+            default:
+                return .texDecodeFailed(detail: error.errorDescription ?? "decode failed")
+            }
+        case .legacyUnsupportedTexture:
+            return .texDecodeFailed(detail: "legacy .tex stub")
+        case .fileMissing, .crossPackageReference:
+            return .sceneResourceMissing
+        case .other(_, let message):
+            return .texDecodeFailed(detail: message)
         }
     }
 
@@ -321,15 +437,25 @@ struct WPESceneDetailView: View {
 
 enum SceneRenderState: Equatable {
     case idle
-    case loading
+    case loading(progress: String?)
     case playing(SceneRenderingController)
     case paused(reason: PausedReason)
     case error(FallbackReason)
 
+    /// Convenience for "loading without specific progress text" — keeps
+    /// the dozens of existing call sites that just wrote `.loading`
+    /// pinned to a single source of truth.
+    static var loading: SceneRenderState { .loading(progress: nil) }
+
+    var isLoading: Bool {
+        if case .loading = self { return true }
+        return false
+    }
+
     static func == (lhs: SceneRenderState, rhs: SceneRenderState) -> Bool {
         switch (lhs, rhs) {
         case (.idle, .idle): return true
-        case (.loading, .loading): return true
+        case (.loading(let l), .loading(let r)): return l == r
         case (.playing(let lhsCtrl), .playing(let rhsCtrl)): return lhsCtrl === rhsCtrl
         case (.paused(let l), .paused(let r)): return l == r
         case (.error(let l), .error(let r)): return l == r

--- a/LiveWallpaperTests/SceneResourceResolverTests.swift
+++ b/LiveWallpaperTests/SceneResourceResolverTests.swift
@@ -62,16 +62,33 @@ struct SceneResourceResolverTests {
         }
     }
 
-    @Test(".tex texture returns unsupportedTexture without crashing")
-    func texTextureUnsupported() throws {
+    @Test("Truncated .tex surfaces as a texture-specific resolve error")
+    func texTruncatedSurfacesTextureError() throws {
+        // Phase 2.1 routes `.tex` through `WPETexDecoder` instead of the
+        // Phase 2.0 stub. A 2-byte payload now produces a precise
+        // `truncatedBlock` decode error wrapped in
+        // `ResolveError.texture(...)` so the UI can show the failing
+        // block name and offset rather than a generic "unsupported".
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
         try Data([0x00, 0x01]).write(to: fixture.cacheRoot.appendingPathComponent("layer.tex"))
 
         let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
 
-        #expect(throws: SceneResourceResolver.ResolveError.unsupportedTexture) {
-            try resolver.resolveImage(relativePath: "layer.tex")
+        do {
+            _ = try resolver.resolveImage(relativePath: "layer.tex")
+            Issue.record("Expected resolveImage to throw on truncated .tex")
+        } catch SceneResourceResolver.ResolveError.texture(let texError) {
+            // Either truncatedBlock or unsupportedContainer is acceptable —
+            // both are precise failure modes. Reject vague decodeFailed.
+            switch texError {
+            case .truncatedBlock, .unsupportedContainer:
+                break
+            default:
+                Issue.record("Expected truncatedBlock/unsupportedContainer, got \(texError)")
+            }
+        } catch {
+            Issue.record("Expected ResolveError.texture, got \(error)")
         }
     }
 

--- a/LiveWallpaperTests/WPESceneSectionStateTests.swift
+++ b/LiveWallpaperTests/WPESceneSectionStateTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 @testable import LiveWallpaper
 
@@ -13,6 +14,59 @@ struct WPESceneSectionStateTests {
         #expect(SceneRenderState.idle == SceneRenderState.idle)
         #expect(SceneRenderState.loading == SceneRenderState.loading)
         #expect(SceneRenderState.idle != SceneRenderState.loading)
+    }
+
+    @Test("loading distinguishes nil vs progress text payloads")
+    func loadingPayloadDifferentiates() {
+        let plain = SceneRenderState.loading(progress: nil)
+        let labelled = SceneRenderState.loading(progress: "Decoding 3/12 textures…")
+        #expect(plain != labelled)
+        #expect(plain == SceneRenderState.loading)
+        #expect(plain.isLoading)
+        #expect(labelled.isLoading)
+    }
+
+    @MainActor
+    @Test("Texture decoder error → FallbackReason mapping is precise")
+    func textureFallbackMapping() {
+        let unsupportedFormat: SceneLoadDiagnostic = .texture(
+            layer: "background",
+            error: .unsupportedFormat(code: 8)
+        )
+        let unsupportedContainer: SceneLoadDiagnostic = .texture(
+            layer: "fg",
+            error: .unsupportedContainer(magic: "TEXV9999")
+        )
+        let truncated: SceneLoadDiagnostic = .texture(
+            layer: "fg",
+            error: .truncatedBlock(block: "TEXB", offset: 42)
+        )
+        #expect(WPESceneDetailView.fallbackReason(for: unsupportedFormat) == .texUnsupportedFormat(code: 8))
+        #expect(WPESceneDetailView.fallbackReason(for: unsupportedContainer) == .texContainerUnsupported(magic: "TEXV9999"))
+        if case .texDecodeFailed = WPESceneDetailView.fallbackReason(for: truncated) {
+            // OK
+        } else {
+            Issue.record("Truncated tex should map to .texDecodeFailed")
+        }
+    }
+
+    @Test("FallbackReason severity tint distinguishes warn vs hard block")
+    func severityTintIsHonest() {
+        #expect(FallbackReason.missingDependency(workshopIDs: ["1"]).severityTint == .yellow)
+        #expect(FallbackReason.sceneResourceMissing.severityTint == .yellow)
+        #expect(FallbackReason.texDecodeFailed(detail: "x").severityTint == .yellow)
+        #expect(FallbackReason.requiresWindowsPlugin.severityTint == .orange)
+        #expect(FallbackReason.texContainerUnsupported(magic: "X").severityTint == .orange)
+        #expect(FallbackReason.texUnsupportedFormat(code: 8).severityTint == .orange)
+    }
+
+    @Test("isActionable matches the Retry button visibility policy")
+    func isActionableMatchesRetry() {
+        #expect(FallbackReason.missingDependency(workshopIDs: []).isActionable)
+        #expect(FallbackReason.texDecodeFailed(detail: "x").isActionable)
+        #expect(!FallbackReason.requiresWindowsPlugin.isActionable)
+        #expect(!FallbackReason.texContainerUnsupported(magic: "X").isActionable)
+        #expect(!FallbackReason.texUnsupportedFormat(code: 8).isActionable)
     }
 
     @Test("paused state preserves the reason")

--- a/LiveWallpaperTests/WPETexDecoderTests.swift
+++ b/LiveWallpaperTests/WPETexDecoderTests.swift
@@ -1,0 +1,219 @@
+import Compression
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+@Suite("WPETexDecoder — container + RGBA8888")
+struct WPETexDecoderTests {
+
+    // MARK: - Container guards
+
+    @Test("Empty data fails with truncatedBlock at offset 0")
+    func emptyDataTruncated() {
+        let result = WPETexDecoder().decode(data: Data())
+        guard case .failure(.truncatedBlock(_, let offset)) = result else {
+            Issue.record("Expected truncatedBlock failure, got \(result)")
+            return
+        }
+        #expect(offset == 0)
+    }
+
+    @Test("Unknown container magic surfaces unsupportedContainer")
+    func unknownContainerMagic() {
+        var buffer = Data()
+        appendMagic(&buffer, magic: "FAKE9999")
+        let result = WPETexDecoder().decode(data: buffer)
+        guard case .failure(.unsupportedContainer(let magic)) = result else {
+            Issue.record("Expected unsupportedContainer, got \(result)")
+            return
+        }
+        #expect(magic.hasPrefix("FAKE"))
+    }
+
+    @Test("Container without TEXI block fails with missingInfoBlock")
+    func missingInfoBlock() {
+        var buffer = Data()
+        appendMagic(&buffer, magic: "TEXV0005")
+        // No follow-up blocks. End of stream → missingInfoBlock.
+        let result = WPETexDecoder().decode(data: buffer)
+        guard case .failure(.missingInfoBlock) = result else {
+            Issue.record("Expected missingInfoBlock, got \(result)")
+            return
+        }
+    }
+
+    @Test("Non-TEXI second block fails with unsupportedBlock")
+    func unsupportedSecondBlock() {
+        var buffer = Data()
+        appendMagic(&buffer, magic: "TEXV0005")
+        appendMagic(&buffer, magic: "WHAT0001")
+        let result = WPETexDecoder().decode(data: buffer)
+        guard case .failure(.unsupportedBlock(let magic)) = result else {
+            Issue.record("Expected unsupportedBlock, got \(result)")
+            return
+        }
+        #expect(magic.hasPrefix("WHAT"))
+    }
+
+    @Test("Probe of a complete RGBA8888 file yields valid info")
+    func probeReturnsInfo() {
+        let buffer = makeRGBA8888TestImage(width: 4, height: 4)
+        let result = WPETexDecoder().probe(data: buffer)
+        guard case .success(let info) = result else {
+            Issue.record("Expected probe success, got \(result)")
+            return
+        }
+        #expect(info.width == 4)
+        #expect(info.height == 4)
+        #expect(info.format == .rgba8888)
+        #expect(info.containerVersion == 5)
+    }
+
+    // MARK: - RGBA8888 round-trip
+
+    @Test("Decode of synthetic RGBA8888 returns a CGImage with correct dimensions")
+    func decodeRGBA8888RoundTrip() throws {
+        let buffer = makeRGBA8888TestImage(width: 4, height: 4)
+        let result = WPETexDecoder().decode(data: buffer)
+        guard case .success(let image) = result else {
+            Issue.record("Expected decode success, got \(result)")
+            return
+        }
+        #expect(image.width == 4)
+        #expect(image.height == 4)
+    }
+
+    @Test("Unknown format code surfaces unsupportedFormat with the offending code")
+    func unsupportedFormatCode() {
+        // Format 99 doesn't map to any WPETexFormat — the decoder must
+        // reject with the precise integer rather than a generic decode
+        // error so the UI can show "Format 99 not yet supported".
+        let buffer = makeImage(width: 2, height: 2, formatCode: 99, payload: Data(count: 16))
+        let result = WPETexDecoder().decode(data: buffer)
+        guard case .failure(.unsupportedFormat(let code)) = result else {
+            Issue.record("Expected unsupportedFormat, got \(result)")
+            return
+        }
+        #expect(code == 99)
+    }
+
+    @Test("LZ4-compressed mip payload decompresses to the expected uncompressed size")
+    func lz4InflateOnSizeMismatch() throws {
+        // Build an RGBA8888 mip and LZ4-compress its payload; the decoder
+        // should detect the size mismatch and fall back to LZ4 inflate.
+        let width = 4
+        let height = 4
+        let raw = Data((0..<(width * height * 4)).map { UInt8(($0 * 7) & 0xff) })
+        let compressed = try lz4RawCompress(raw)
+        // Don't bother synthesising a real lz4-compressed buffer if the
+        // platform refuses to compress; just guard the test with a check.
+        try #require(compressed.count != raw.count,
+                     "LZ4 must yield a different byte count to exercise the inflate fallback")
+
+        let buffer = makeImage(
+            width: width,
+            height: height,
+            formatCode: WPETexFormat.rgba8888.rawValue,
+            payload: compressed
+        )
+
+        let result = WPETexDecoder().decode(data: buffer)
+        guard case .success(let image) = result else {
+            Issue.record("Expected decode success after LZ4 inflate, got \(result)")
+            return
+        }
+        #expect(image.width == width)
+        #expect(image.height == height)
+    }
+
+    // MARK: - Fixture helpers
+
+    /// Synthesises a TEXV0005 / TEXI0001 / TEXB0003 buffer carrying a
+    /// uniform-colour RGBA8888 mipmap. Test-only — production code never
+    /// fabricates `.tex` files.
+    private func makeRGBA8888TestImage(width: Int, height: Int) -> Data {
+        // Solid orange so the decoded image is recognisable in debug.
+        let pixel: [UInt8] = [0xff, 0x80, 0x33, 0xff]
+        var raw = Data()
+        raw.reserveCapacity(width * height * 4)
+        for _ in 0..<(width * height) { raw.append(contentsOf: pixel) }
+        return makeImage(
+            width: width,
+            height: height,
+            formatCode: WPETexFormat.rgba8888.rawValue,
+            payload: raw
+        )
+    }
+
+    private func makeImage(
+        width: Int,
+        height: Int,
+        formatCode: Int,
+        payload: Data
+    ) -> Data {
+        // Mirrors the field order observed in the user's `TEXV0005` /
+        // `TEXI0001` samples (format → flags → textureW → textureH →
+        // imageW → imageH). We emit the V3 info block (extra unkInt0) so
+        // the decoder exercises the optional read.
+        var buffer = Data()
+        appendMagic(&buffer, magic: "TEXV0005")
+        appendMagic(&buffer, magic: "TEXI0003")
+        appendInt32(&buffer, Int32(formatCode))
+        appendUInt32(&buffer, 0)              // flags
+        appendInt32(&buffer, Int32(width))    // textureWidth
+        appendInt32(&buffer, Int32(height))   // textureHeight
+        appendInt32(&buffer, Int32(width))    // imageWidth
+        appendInt32(&buffer, Int32(height))   // imageHeight
+        appendInt32(&buffer, 0)               // unkInt0 (V3)
+
+        appendMagic(&buffer, magic: "TEXB0003")
+        appendInt32(&buffer, 1)               // mipmapCount
+        appendInt32(&buffer, Int32(width))
+        appendInt32(&buffer, Int32(height))
+        appendUInt32(&buffer, 0)              // compressed flag (false)
+        appendUInt32(&buffer, UInt32(payload.count))
+        buffer.append(payload)
+        return buffer
+    }
+
+    private func appendMagic(_ data: inout Data, magic: String) {
+        data.append(contentsOf: magic.utf8)
+        data.append(0x00) // NUL terminator
+    }
+
+    private func appendInt32(_ data: inout Data, _ value: Int32) {
+        var le = value.littleEndian
+        withUnsafeBytes(of: &le) { data.append(contentsOf: $0) }
+    }
+
+    private func appendUInt32(_ data: inout Data, _ value: UInt32) {
+        var le = value.littleEndian
+        withUnsafeBytes(of: &le) { data.append(contentsOf: $0) }
+    }
+
+    /// Compresses `data` using LZ4 raw. Mirrors what the decoder uses on
+    /// the inflate side. Throws when the platform refuses (e.g. data is
+    /// already smaller than the worst-case LZ4 frame size).
+    private func lz4RawCompress(_ data: Data) throws -> Data {
+        let dstCapacity = data.count + 64
+        var dst = Data(count: dstCapacity)
+        let written = dst.withUnsafeMutableBytes { (out: UnsafeMutableRawBufferPointer) -> Int in
+            data.withUnsafeBytes { (input: UnsafeRawBufferPointer) -> Int in
+                guard let dstPtr = out.bindMemory(to: UInt8.self).baseAddress,
+                      let srcPtr = input.bindMemory(to: UInt8.self).baseAddress else {
+                    return -1
+                }
+                return compression_encode_buffer(
+                    dstPtr, dstCapacity,
+                    srcPtr, data.count,
+                    nil,
+                    COMPRESSION_LZ4_RAW
+                )
+            }
+        }
+        guard written > 0 else {
+            throw NSError(domain: "lz4", code: -1)
+        }
+        return dst.prefix(written)
+    }
+}

--- a/LiveWallpaperTests/WPETexMetalTranscoderTests.swift
+++ b/LiveWallpaperTests/WPETexMetalTranscoderTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+@Suite("WPETexMetalTranscoder — BC compatibility gate")
+struct WPETexMetalTranscoderTests {
+
+    @Test("Phase 2.1 transcoder always reports BC formats as unavailable")
+    func bcFormatsReportUnavailable() {
+        // The Metal blit-based transcode in Day 2 was incorrect (a blit
+        // copy cannot transcode between pixel formats), so Phase 2.1
+        // ships with BC explicitly marked unavailable until the
+        // shader/compute pipeline arrives in Phase 2.2. The capability
+        // tier classifier reads `isAvailable(for:)`, so this test pins
+        // the contract that all four BC variants stay non-decodable.
+        #expect(!WPETexMetalTranscoder.isAvailable(for: .dxt1))
+        #expect(!WPETexMetalTranscoder.isAvailable(for: .dxt3))
+        #expect(!WPETexMetalTranscoder.isAvailable(for: .dxt5))
+        #expect(!WPETexMetalTranscoder.isAvailable(for: .bc7))
+    }
+
+    @Test("Calling transcode for a BC format throws metalUnavailable with the requested format")
+    func transcodeBCThrowsMetalUnavailable() throws {
+        for format in [WPETexFormat.dxt1, .dxt3, .dxt5, .bc7] {
+            do {
+                _ = try WPETexMetalTranscoder.transcode(
+                    Data(count: 16),
+                    format: format,
+                    width: 4,
+                    height: 4,
+                    mipmap: 0
+                )
+                Issue.record("Expected metalUnavailable for \(format.debugLabel)")
+            } catch WPETexDecodeError.metalUnavailable(let surfacedFormat) {
+                #expect(surfacedFormat == format)
+            } catch {
+                Issue.record("Expected metalUnavailable, got \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Promotes Wallpaper Engine `.scene` macOS coverage from **~0% → 8/9** of the user's real Steam Workshop samples by shipping a Swift-native `.tex` container decoder. The fallback UI now tells users *exactly* why a layer didn't render instead of "scene unsupported".

**Empirical baseline measured during planning**:
- 9 imported scenes; 8 are RGBA8888 (now decoded), 1 is RGBA1010102 (precise unsupported reason surfaced).
- TEXV0005 / TEXI0001 / TEXB0003 — field order verified against `linux-wallpaperengine` source: `format → flags → textureW → textureH → imageW → imageH`.

## What changed

**Decoder** (`LiveWallpaper/Models/WPETexErrors.swift`, `Infrastructure/WPETexByteReader.swift`, `WPETexDecoder.swift`, `WPETexPixelDecoder.swift`, `WPETexMetalTranscoder.swift`)
- Stateless `WPETexDecoder` — `probe()` reads ≤64 header bytes for capability tier classification; `decode()` returns `Result<CGImage, WPETexDecodeError>`.
- CPU paths (Sendable, off-main): RGBA8888, R8, RG88.
- LZ4 fallback distinguishes compressed vs. padded raw payloads via the TEXB V3 `compressed` flag.
- BC1/3/7 Metal transcoder scaffolded but explicitly `metalUnavailable`: a `blitEncoder.copy(...)` cannot transcode pixel formats; deferring to Phase 2.2 has zero impact on the user's current sample set.
- Full error taxonomy flows through `SceneResourceResolver.ResolveError.texture(...)` → `SceneRenderingError.resourceFailed(SceneLoadDiagnostic)` → `FallbackReason.tex*`.

**Resource resolver** (`SceneResourceResolver`, `WallpaperEngineImportService`)
- `.tex` resolves through the decoder; `.png/.jpg/.gif` still ImageIO.
- `probeImage` reads only 64 bytes — a 100 MB / 50-layer scene.pkg no longer churns memory during import.
- `capabilityTier` uses `WPETexFormat.isPhase21Decodable` so RGBA1010102 / BC are correctly counted as unresolvable.
- `.tex`-related parser info diagnostics no longer downgrade `.imageOnly` → `.degraded`.

**Runtime** (`SceneRenderingController`, `SceneWallpaperSession`)
- `load()` collects per-layer failures into `loadDiagnostics`, reports `onProgress` ("Decoding 3/12 textures…"), throws `resourceFailed(diagnostic)` when no layer renders.
- `reload()` keeps the SKView warm; `SceneWallpaperSession.reload()` clears `loadError` on success so the state machine returns to `.playing`.

**UI** (`WPEFallbackCard`, `WPESceneDetailView`, `LiquidGlassSpinner`, `WPEHistoryRow`)
- 3 new `FallbackReason` cases name the offending magic / format code.
- Severity tint per Apple HIG: `.yellow` recoverable / `.orange` permanent block.
- Retry promoted to trailing `.borderedProminent`; Clear stays leading destructive.
- Workshop Gallery thumbnail badges ("Experimental" / "Won't run" / "Needs deps" / "Untested") set expectations BEFORE import.
- `LiquidGlassSpinner` gains optional `progressText` rendered as `.ultraThinMaterial` capsule.
- `SceneRenderState.loading(progress:)` propagates per-layer counts.
- Option-click metadata toggles developer diagnostic panel; `info.circle` glyph hints at the gesture.

## Multi-model audit (codex + gemini) — 13 issues, all fixed inline

| Severity | Source | Issue | Fix |
|---|---|---|---|
| Critical | codex | BC blit can't transcode pixel formats | Mark BC `metalUnavailable` until Phase 2.2 shader path |
| Critical | codex | `MTLDevice`/`MTLCommandQueue` Sendable violation | Rebuild transcoder as `enum` — no stored Metal state |
| Critical | gemini | `accessibilityLabel` on diagnostics VStack hid error from VoiceOver | `.combine` with title + diagnostic |
| High | codex | `info.format != nil` misclassified RGBA1010102 as resolvable | `isPhase21Decodable` predicate |
| High | codex | `probeImage` read entire file | 64-byte FileHandle read |
| High | codex | Retry left `loadError` set → state stuck on `.error` | `session.reload()` clears it |
| High | gemini | Retry next to destructive Clear | Trailing prominent vs leading destructive |
| Medium | codex | LZ4 inflate failed on padded raw payloads | `isCompressed=false && payload>expected` → take prefix |
| Medium | codex | `.tex` warnings prevented imageOnly tier | Filter `.tex` warnings from blocking diagnostics |
| Medium | gemini | Option-click undiscoverable | `info.circle` glyph + tooltip |
| Low | gemini | Spinner caption clashed with Liquid Glass aesthetic | `.ultraThinMaterial` capsule |

## Test plan

- [x] `xcodebuild ... test -only-testing:LiveWallpaperTests` — **316 / 316 pass**
- [x] 8 new decoder tests (RGBA8888 round-trip, container/format/block edge cases, LZ4 inflate)
- [x] 2 Metal transcoder contract tests (BC always reports `metalUnavailable`)
- [x] 4 state-machine tests for `.loading(progress:)` and new `FallbackReason` mappings
- [x] Phase 2.0 + 2.0.1 regressions clean
- [x] Empirical: parsed all 9 user scene.pkg → 8 RGBA8888 + 1 RGBA1010102
- [ ] Manual: import a real scene → see textures rendering on the desktop
- [ ] Manual: VoiceOver navigates the diagnostics panel and reads the actual error
- [ ] Manual: Light/Dark/Reduce Transparency at 280×260 inspector size

🤖 Generated with [Claude Code](https://claude.com/claude-code)