### PR TITLE
fix(wpe): resolve scene material/model JSON indirection chain

### DIFF
--- a/LiveWallpaper/Infrastructure/SceneResourceResolver.swift
+++ b/LiveWallpaper/Infrastructure/SceneResourceResolver.swift
@@ -17,6 +17,14 @@ struct SceneResourceResolver: Sendable {
         case decodeFailed
         case unsupportedTexture                          // legacy alias
         case texture(WPETexDecodeError)
+        /// scene.json's `image` field pointed at a `.json` model/material
+        /// descriptor that we couldn't follow to a real texture file. The
+        /// descriptor either references a built-in WPE utility model
+        /// (`models/util/*.json`) we don't have a substitute for, or its
+        /// shape doesn't expose any `material`/`passes[].textures[]`
+        /// fields. Distinct case so the UI can say "scene relies on
+        /// engine-built layers" rather than "tex decode failed".
+        case materialUnresolved(reason: String)
     }
 
     let cacheRootURL: URL
@@ -45,7 +53,14 @@ struct SceneResourceResolver: Sendable {
     /// `.decodeFailed` to match Phase 2.0 contracts.
     func resolveImage(relativePath: String) throws -> CGImage {
         guard !relativePath.isEmpty else { throw ResolveError.fileMissing }
-        let target = try resolveURL(for: relativePath)
+        // WPE's `scene.json` does not point image layers at texture files
+        // directly. Instead it references a tiny `models/<name>.json`
+        // wrapper that names a `materials/<name>.json` descriptor, which
+        // in turn lists the actual `.tex` payload via `passes[0].textures[0]`.
+        // Resolve the chain up-front so the rest of this method only ever
+        // deals with the terminal asset path.
+        let resolvedPath = try resolveImageReference(relativePath: relativePath, depth: 0)
+        let target = try resolveURL(for: resolvedPath)
 
         guard fileManager.fileExists(atPath: target.path) else {
             throw ResolveError.fileMissing
@@ -72,6 +87,86 @@ struct SceneResourceResolver: Sendable {
             throw ResolveError.decodeFailed
         }
         return image
+    }
+
+    /// Walks WPE's image-reference chain until it produces a path to a
+    /// real asset (`.tex` / `.png` / `.jpg` / `.gif`). Recursion depth is
+    /// capped at 4 to defuse pathological self-referential descriptors —
+    /// real-world chains are at most 3 deep (model → material → texture).
+    ///
+    /// Recognised JSON shapes:
+    ///   - Model wrapper: `{ "material": "materials/X.json", … }`
+    ///   - Material descriptor: `{ "passes": [{ "textures": ["X"], … }] }`
+    /// Anything else (or a missing util model like `models/util/solidlayer.json`)
+    /// surfaces as `materialUnresolved` so the UI can show a precise hint.
+    private func resolveImageReference(relativePath: String, depth: Int) throws -> String {
+        let lowered = (relativePath as NSString).pathExtension.lowercased()
+        if lowered != "json" {
+            return relativePath
+        }
+        if depth >= 4 {
+            throw ResolveError.materialUnresolved(reason: "Reference depth exceeded for \(relativePath)")
+        }
+
+        let url = try resolveURL(for: relativePath)
+        guard fileManager.fileExists(atPath: url.path) else {
+            // WPE ships several built-in utility models (e.g.
+            // `models/util/solidlayer.json`) that the engine substitutes
+            // at runtime. We don't have access to them; surface a precise
+            // reason rather than a generic missing-file error.
+            if relativePath.contains("models/util/") {
+                throw ResolveError.materialUnresolved(reason: "Built-in WPE layer \(relativePath) is not available on macOS")
+            }
+            throw ResolveError.fileMissing
+        }
+
+        let payload: Data
+        do {
+            payload = try Data(contentsOf: url)
+        } catch {
+            throw ResolveError.fileMissing
+        }
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: payload, options: [.fragmentsAllowed])
+        } catch {
+            throw ResolveError.materialUnresolved(reason: "Couldn't parse \(relativePath) as JSON")
+        }
+        guard let dict = parsed as? [String: Any] else {
+            throw ResolveError.materialUnresolved(reason: "\(relativePath) is not a JSON object")
+        }
+
+        if let materialPath = dict["material"] as? String, !materialPath.isEmpty {
+            return try resolveImageReference(relativePath: materialPath, depth: depth + 1)
+        }
+
+        if let textureName = firstTextureName(in: dict) {
+            // WPE convention: the textures array carries identifiers
+            // without extension or directory. The asset always lives at
+            // `materials/<name>.tex` next to the descriptor.
+            return "materials/\(textureName).tex"
+        }
+
+        throw ResolveError.materialUnresolved(reason: "\(relativePath) has no `material` or `passes[].textures[]`")
+    }
+
+    /// Drills into a material descriptor's `passes[0].textures[0]` and
+    /// returns its bare identifier. Materials sometimes wrap textures in
+    /// dictionaries (`{"name": "foo", "size": [...]}`); accept both the
+    /// flat string form and a `name` key under the dict form.
+    private func firstTextureName(in dict: [String: Any]) -> String? {
+        guard let passes = dict["passes"] as? [[String: Any]] else { return nil }
+        for pass in passes {
+            guard let textures = pass["textures"] as? [Any] else { continue }
+            for entry in textures {
+                if let name = entry as? String, !name.isEmpty { return name }
+                if let nested = entry as? [String: Any],
+                   let name = nested["name"] as? String, !name.isEmpty {
+                    return name
+                }
+            }
+        }
+        return nil
     }
 
     /// Cheap header-only probe used by `WallpaperEngineImportService` during

--- a/LiveWallpaper/Models/WPESceneErrors.swift
+++ b/LiveWallpaper/Models/WPESceneErrors.swift
@@ -69,6 +69,10 @@ enum SceneLoadDiagnostic: Equatable, Sendable {
     case legacyUnsupportedTexture(layer: String)
     case fileMissing(layer: String, path: String)
     case crossPackageReference(layer: String, path: String)
+    /// scene.json points at a `.json` model/material descriptor we
+    /// can't follow to a real texture. Used for both built-in WPE util
+    /// layers (`models/util/*.json`) and malformed material chains.
+    case materialUnresolved(layer: String, reason: String)
     case other(layer: String, message: String)
 
     var layerName: String {
@@ -77,6 +81,7 @@ enum SceneLoadDiagnostic: Equatable, Sendable {
              .legacyUnsupportedTexture(let layer),
              .fileMissing(let layer, _),
              .crossPackageReference(let layer, _),
+             .materialUnresolved(let layer, _),
              .other(let layer, _):
             return layer
         }
@@ -92,6 +97,8 @@ enum SceneLoadDiagnostic: Equatable, Sendable {
             return "Layer \(layer): missing asset \(path)"
         case .crossPackageReference(let layer, let path):
             return "Layer \(layer): cross-package reference \(path) rejected"
+        case .materialUnresolved(let layer, let reason):
+            return "Layer \(layer): \(reason)"
         case .other(let layer, let message):
             return "Layer \(layer): \(message)"
         }

--- a/LiveWallpaper/Runtime/SceneRenderingController.swift
+++ b/LiveWallpaper/Runtime/SceneRenderingController.swift
@@ -124,6 +124,9 @@ final class SceneRenderingController {
             } catch SceneResourceResolver.ResolveError.texture(let texError) {
                 Logger.warning("Scene \(descriptor.workshopID): tex decode failed for \(object.name) — \(texError.errorDescription ?? "?")", category: .screenManager)
                 firstFailure = firstFailure ?? .texture(layer: object.name, error: texError)
+            } catch SceneResourceResolver.ResolveError.materialUnresolved(let reason) {
+                Logger.warning("Scene \(descriptor.workshopID): material chain unresolved for \(object.name) — \(reason)", category: .screenManager)
+                firstFailure = firstFailure ?? .materialUnresolved(layer: object.name, reason: reason)
             } catch SceneResourceResolver.ResolveError.unsupportedTexture {
                 Logger.warning("Scene \(descriptor.workshopID): skipping .tex layer \(object.name)", category: .screenManager)
                 firstFailure = firstFailure ?? .legacyUnsupportedTexture(layer: object.name)

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
@@ -372,6 +372,8 @@ struct WPESceneDetailView: View {
             return .texDecodeFailed(detail: "legacy .tex stub")
         case .fileMissing, .crossPackageReference:
             return .sceneResourceMissing
+        case .materialUnresolved(_, let reason):
+            return .texDecodeFailed(detail: reason)
         case .other(_, let message):
             return .texDecodeFailed(detail: message)
         }

--- a/LiveWallpaperTests/SceneResourceResolverTests.swift
+++ b/LiveWallpaperTests/SceneResourceResolverTests.swift
@@ -92,6 +92,73 @@ struct SceneResourceResolverTests {
         }
     }
 
+    @Test("Model wrapper JSON resolves to materials/<name>.tex via material chain")
+    func materialChainResolves() throws {
+        // Synthesise the WPE chain: scene.json points at a model wrapper
+        // (`models/foo.json`) → which references a material descriptor
+        // (`materials/foo.json`) → which lists the texture name `foo` →
+        // which becomes `materials/foo.tex`. The resolver must follow the
+        // chain transparently and return the decoded image.
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let modelsDir = fixture.cacheRoot.appendingPathComponent("models", isDirectory: true)
+        let materialsDir = fixture.cacheRoot.appendingPathComponent("materials", isDirectory: true)
+        try FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: materialsDir, withIntermediateDirectories: true)
+
+        try Data("""
+        { "autosize": true, "material": "materials/foo.json" }
+        """.utf8).write(to: modelsDir.appendingPathComponent("foo.json"))
+        try Data("""
+        { "passes": [{ "textures": ["foo"], "shader": "genericimage4" }] }
+        """.utf8).write(to: materialsDir.appendingPathComponent("foo.json"))
+        try writeRGBA8888Tex(at: materialsDir.appendingPathComponent("foo.tex"))
+
+        let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
+        let image = try resolver.resolveImage(relativePath: "models/foo.json")
+
+        #expect(image.width == 4)
+        #expect(image.height == 4)
+    }
+
+    @Test("Built-in util model surfaces materialUnresolved with a friendly hint")
+    func builtinUtilModelSurfacesPrecisely() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
+
+        do {
+            _ = try resolver.resolveImage(relativePath: "models/util/solidlayer.json")
+            Issue.record("Expected materialUnresolved")
+        } catch SceneResourceResolver.ResolveError.materialUnresolved(let reason) {
+            #expect(reason.contains("Built-in"))
+        } catch {
+            Issue.record("Expected materialUnresolved, got \(error)")
+        }
+    }
+
+    @Test("JSON wrapper without material/passes fields surfaces materialUnresolved")
+    func malformedDescriptorSurfacesUnresolved() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let modelsDir = fixture.cacheRoot.appendingPathComponent("models", isDirectory: true)
+        try FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
+        try Data("""
+        { "autosize": true, "puppet": "models/foo_puppet.mdl" }
+        """.utf8).write(to: modelsDir.appendingPathComponent("foo.json"))
+
+        let resolver = SceneResourceResolver(cacheRootURL: fixture.cacheRoot)
+        do {
+            _ = try resolver.resolveImage(relativePath: "models/foo.json")
+            Issue.record("Expected materialUnresolved")
+        } catch SceneResourceResolver.ResolveError.materialUnresolved {
+            // OK
+        } catch {
+            Issue.record("Expected materialUnresolved, got \(error)")
+        }
+    }
+
     @Test("Missing file throws fileMissing")
     func missingFileThrows() throws {
         let fixture = try makeFixture()
@@ -117,6 +184,43 @@ struct SceneResourceResolverTests {
         let cacheRoot = root.appendingPathComponent("cache", isDirectory: true)
         try FileManager.default.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
         return Fixture(root: root, cacheRoot: cacheRoot)
+    }
+
+    /// Writes a synthetic 4×4 RGBA8888 `.tex` file matching the layout
+    /// the decoder expects (TEXV0005 / TEXI0003 / TEXB0003). Used by the
+    /// material-chain test so a real `CGImage` comes out the other end.
+    private func writeRGBA8888Tex(at url: URL) throws {
+        var data = Data()
+        func appendMagic(_ s: String) {
+            data.append(contentsOf: s.utf8)
+            data.append(0x00)
+        }
+        func appendInt32(_ v: Int32) {
+            var le = v.littleEndian
+            withUnsafeBytes(of: &le) { data.append(contentsOf: $0) }
+        }
+        func appendUInt32(_ v: UInt32) {
+            var le = v.littleEndian
+            withUnsafeBytes(of: &le) { data.append(contentsOf: $0) }
+        }
+        appendMagic("TEXV0005")
+        appendMagic("TEXI0003")
+        appendInt32(0)            // format = RGBA8888
+        appendUInt32(0)           // flags
+        appendInt32(4)            // textureWidth
+        appendInt32(4)            // textureHeight
+        appendInt32(4)            // imageWidth
+        appendInt32(4)            // imageHeight
+        appendInt32(0)            // unkInt0 (V3)
+        appendMagic("TEXB0003")
+        appendInt32(1)            // mipmapCount
+        appendInt32(4)            // mip width
+        appendInt32(4)            // mip height
+        appendUInt32(0)           // not compressed
+        let pixels = Data(repeating: 0xFF, count: 4 * 4 * 4)
+        appendUInt32(UInt32(pixels.count))
+        data.append(pixels)
+        try data.write(to: url)
     }
 
     /// Writes a 4×4 opaque PNG. ImageIO needs at least a real PNG header


### PR DESCRIPTION
## Summary

**Real-world failure** from the user's 3351072238 scene log:

```
createImageAtIndex 3 could not find plugin for image source [111 bytes] 7B 0D 0A 09 22 61 75 74... '{..."aut'
⚠️ Scene 3351072238: failed to load 伊蕾娜: ResolveError error 3
```

The bytes `7B 0D 0A 09 22 61 75 74` decode to `{\r\n\t"aut...` — ImageIO was being handed **JSON** content. Phase 2.1's resolver assumed `scene.json`'s `image` field points at a real asset; in reality WPE uses a three-step indirection:

```
scene.json        { "image": "models/伊蕾娜.json" }
    ↓
models/X.json     { "material": "materials/伊蕾娜.json", "puppet": ... }
    ↓
materials/X.json  { "passes": [{ "textures": ["伊蕾娜"] }] }
    ↓
materials/伊蕾娜.tex  ← actual RGBA8888 payload
```

Every layer was being rejected because the JSON wrapper hit ImageIO unchanged.

## Fix

**`SceneResourceResolver`** now walks the chain in `resolveImageReference` with a depth-4 cap (real-world chains are 3-deep). Two recognised JSON shapes:
- Model wrapper: `{ "material": "materials/X.json" }` → recurse
- Material descriptor: `{ "passes": [{ "textures": ["X"] }] }` → resolve to `materials/X.tex`

**`ResolveError.materialUnresolved(reason:)`** distinguishes built-in WPE util layers (`models/util/solidlayer.json`, `composelayer.json` — supplied by the engine, never shipped in `scene.pkg`) from malformed descriptors.

**`SceneLoadDiagnostic.materialUnresolved(layer:reason:)`** carries the precise hint up to the inspector card and developer diagnostics panel.

## Verification

Dry-run new resolver against the user's actual `3351072238/scene.pkg`:

```
Resolved 16 / 18 layers to a real materials/<name>.tex:
  ✓ 伊蕾娜              → materials/伊蕾娜.tex
  ✓ 妃咲 60帧           → materials/妃咲 60帧.tex
  ✓ 三角 倒/三角/etc    → materials/三角 倒.tex / 三角.tex
  ✓ 新建画布2          → materials/新建画布2.tex
  ✓ 网盘                → materials/网盘.tex
  …
Unresolved 2 / 18:
  ✗ 背景蒙版            models/util/composelayer.json  [Built-in WPE layer not available on macOS]
  ✗ 纯色                models/util/solidlayer.json    [Built-in WPE layer not available on macOS]
```

The 2 remaining are correct: WPE's engine-built composer/solid layers are not packaged.

## Test plan

- [x] `xcodebuild ... test -only-testing:LiveWallpaperTests` — **319 / 319 pass**
- [x] 3 new resolver tests: chain-resolves, util-layer-friendly-hint, malformed-descriptor
- [x] No regressions to Phase 2.1 decoder or UI tests
- [ ] Manual: re-run the same 3351072238 scene → 16 layers should now render on the desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)