### PR TITLE
fix(wpe): bring Phase 2A H1+H3 holdovers to main

### DIFF
--- a/LiveWallpaper/Infrastructure/WPEMetalTextureFormatMapper.swift
+++ b/LiveWallpaper/Infrastructure/WPEMetalTextureFormatMapper.swift
@@ -1,5 +1,14 @@
 import Metal
 
+/// Color-space intent for a Metal texture upload. Phase 2A H3 introduces this
+/// so the renderer can request sRGB-encoded pixel formats — matching the
+/// SpriteKit/CGImage fallback path — while data textures (masks, normal maps,
+/// future R8/RG8 channels) stay linear.
+enum WPEMetalColorSpace: Equatable, Sendable {
+    case sRGB
+    case linear
+}
+
 struct WPEMetalTextureCapabilities: Equatable, Sendable {
     let supportsBCTextureCompression: Bool
 
@@ -39,13 +48,24 @@ enum WPEMetalTextureLoaderError: Error, Equatable, LocalizedError, Sendable {
 }
 
 enum WPEMetalTextureFormatMapper {
+    /// Maps a WPE texture container format to the concrete `MTLPixelFormat` the
+    /// renderer should allocate. `colorSpace` defaults to `.sRGB` because WPE
+    /// Workshop content (PNG/JPG/BC) ships as sRGB-encoded perceptual color and
+    /// the SpriteKit fallback decodes through CGImage's sRGB pipeline.
+    /// Single-channel `R8` and two-channel `RG8` are forced to linear because
+    /// Metal does not expose sRGB variants for those formats.
     static func mapping(
         for format: WPETexFormat,
-        capabilities: WPEMetalTextureCapabilities
+        capabilities: WPEMetalTextureCapabilities,
+        colorSpace: WPEMetalColorSpace = .sRGB
     ) throws -> WPEMetalTextureFormatMapping {
         switch format {
         case .rgba8888:
-            return WPEMetalTextureFormatMapping(pixelFormat: .rgba8Unorm, bytesPerPixel: 4, bytesPerBlock: nil)
+            return WPEMetalTextureFormatMapping(
+                pixelFormat: colorSpace == .sRGB ? .rgba8Unorm_srgb : .rgba8Unorm,
+                bytesPerPixel: 4,
+                bytesPerBlock: nil
+            )
         case .r8:
             return WPEMetalTextureFormatMapping(pixelFormat: .r8Unorm, bytesPerPixel: 1, bytesPerBlock: nil)
         case .rg88:
@@ -54,22 +74,38 @@ enum WPEMetalTextureFormatMapper {
             guard capabilities.supportsBCTextureCompression else {
                 throw WPEMetalTextureLoaderError.unsupportedCompressedFormat(format)
             }
-            return WPEMetalTextureFormatMapping(pixelFormat: .bc1_rgba, bytesPerPixel: nil, bytesPerBlock: 8)
+            return WPEMetalTextureFormatMapping(
+                pixelFormat: colorSpace == .sRGB ? .bc1_rgba_srgb : .bc1_rgba,
+                bytesPerPixel: nil,
+                bytesPerBlock: 8
+            )
         case .dxt3:
             guard capabilities.supportsBCTextureCompression else {
                 throw WPEMetalTextureLoaderError.unsupportedCompressedFormat(format)
             }
-            return WPEMetalTextureFormatMapping(pixelFormat: .bc2_rgba, bytesPerPixel: nil, bytesPerBlock: 16)
+            return WPEMetalTextureFormatMapping(
+                pixelFormat: colorSpace == .sRGB ? .bc2_rgba_srgb : .bc2_rgba,
+                bytesPerPixel: nil,
+                bytesPerBlock: 16
+            )
         case .dxt5:
             guard capabilities.supportsBCTextureCompression else {
                 throw WPEMetalTextureLoaderError.unsupportedCompressedFormat(format)
             }
-            return WPEMetalTextureFormatMapping(pixelFormat: .bc3_rgba, bytesPerPixel: nil, bytesPerBlock: 16)
+            return WPEMetalTextureFormatMapping(
+                pixelFormat: colorSpace == .sRGB ? .bc3_rgba_srgb : .bc3_rgba,
+                bytesPerPixel: nil,
+                bytesPerBlock: 16
+            )
         case .bc7:
             guard capabilities.supportsBCTextureCompression else {
                 throw WPEMetalTextureLoaderError.unsupportedCompressedFormat(format)
             }
-            return WPEMetalTextureFormatMapping(pixelFormat: .bc7_rgbaUnorm, bytesPerPixel: nil, bytesPerBlock: 16)
+            return WPEMetalTextureFormatMapping(
+                pixelFormat: colorSpace == .sRGB ? .bc7_rgbaUnorm_srgb : .bc7_rgbaUnorm,
+                bytesPerPixel: nil,
+                bytesPerBlock: 16
+            )
         case .rgba1010102:
             throw WPEMetalTextureLoaderError.unsupportedFormat(format)
         }

--- a/LiveWallpaper/Infrastructure/WPEMetalTextureLoader.swift
+++ b/LiveWallpaper/Infrastructure/WPEMetalTextureLoader.swift
@@ -74,10 +74,15 @@ struct WPEMetalTextureLoader {
     func makeTexture(from cgImage: CGImage, label: String) throws -> MTLTexture {
         let loader = MTKTextureLoader(device: device)
         do {
+            // Phase 2A H3: explicitly request sRGB. WPE Workshop ships color
+            // imagery as sRGB-encoded PNG/JPG; relying on MTKTextureLoader to
+            // infer color space leaves untagged or device-RGB CGImages on the
+            // linear path, which would re-introduce the gamma divergence we
+            // are fixing. Forcing the option locks the contract.
             let texture = try loader.newTexture(
                 cgImage: cgImage,
                 options: [
-                    MTKTextureLoader.Option.SRGB: false,
+                    MTKTextureLoader.Option.SRGB: true,
                     MTKTextureLoader.Option.textureUsage: MTLTextureUsage.shaderRead.rawValue
                 ]
             )

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 import Metal
 import MetalKit
 
@@ -39,6 +40,13 @@ struct WPESolidUniforms {
 }
 
 final class WPEMetalRenderExecutor {
+    /// Phase 2A H3: every offscreen target and the on-screen swapchain share a
+    /// single sRGB pixel format so render pipelines built for the offscreen
+    /// pass can be reused by `present()` without re-creation, and so the
+    /// rendered gamma matches the SpriteKit/CGImage fallback on the same
+    /// scene fixture.
+    static let outputPixelFormat: MTLPixelFormat = .rgba8Unorm_srgb
+
     private let device: MTLDevice
     private let commandQueue: MTLCommandQueue
     private let library: MTLLibrary
@@ -204,7 +212,7 @@ final class WPEMetalRenderExecutor {
         let descriptor = MTLRenderPipelineDescriptor()
         descriptor.vertexFunction = vertex
         descriptor.fragmentFunction = fragment
-        descriptor.colorAttachments[0].pixelFormat = .rgba8Unorm
+        descriptor.colorAttachments[0].pixelFormat = Self.outputPixelFormat
 
         let state = try device.makeRenderPipelineState(descriptor: descriptor)
         pipelines[fragmentName] = state
@@ -213,7 +221,7 @@ final class WPEMetalRenderExecutor {
 
     private func makeOutputTexture(size: CGSize) throws -> MTLTexture {
         let descriptor = MTLTextureDescriptor.texture2DDescriptor(
-            pixelFormat: .rgba8Unorm,
+            pixelFormat: Self.outputPixelFormat,
             width: max(Int(size.width), 1),
             height: max(Int(size.height), 1),
             mipmapped: false
@@ -228,15 +236,29 @@ final class WPEMetalRenderExecutor {
     }
 
     private func colorVector(for pass: WPEPreparedRenderPass) -> SIMD4<Float> {
+        // WPE scene JSON authors `g_Color` in sRGB perceptual space ("0.5 0.5
+        // 0.5" → mid-gray on screen). The render target is sRGB-tagged, so the
+        // hardware applies linear→sRGB encode on store; we therefore must feed
+        // the shader linear-space RGB. Alpha stays unchanged — Metal does not
+        // gamma-encode the alpha channel on sRGB targets.
         let vector = pass.uniformValues["g_Color"]?.vectorValue
             ?? pass.pass.constants["g_Color"]?.vectorValue
             ?? [1, 1, 1, 1]
         return SIMD4<Float>(
-            Float(vector[safe: 0] ?? 1),
-            Float(vector[safe: 1] ?? 1),
-            Float(vector[safe: 2] ?? 1),
+            Self.sRGBToLinear(Float(vector[safe: 0] ?? 1)),
+            Self.sRGBToLinear(Float(vector[safe: 1] ?? 1)),
+            Self.sRGBToLinear(Float(vector[safe: 2] ?? 1)),
             Float(vector[safe: 3] ?? 1)
         )
+    }
+
+    /// Standard sRGB EOTF used by Metal's `_srgb` pixel formats.
+    private static func sRGBToLinear(_ value: Float) -> Float {
+        let clamped = min(max(value, 0), 1)
+        if clamped <= 0.04045 {
+            return clamped / 12.92
+        }
+        return Float(pow(Double((clamped + 0.055) / 1.055), 2.4))
     }
 
     private func resolve(reference: WPETextureReference, textures: [String: MTLTexture]) throws -> MTLTexture {

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -1,6 +1,13 @@
 import AppKit
 import MetalKit
 
+/// Wraps a texture-load failure with the requested asset path so the H1
+/// diagnostic mapper can blame the exact file, not the scene entry point.
+private struct WPEMetalTextureLoadContextError: Error {
+    let path: String
+    let underlying: any Error
+}
+
 @MainActor
 final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
     private let descriptor: SceneDescriptor
@@ -44,7 +51,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         super.init()
 
         mtkView.delegate = self
-        mtkView.colorPixelFormat = .rgba8Unorm
+        mtkView.colorPixelFormat = WPEMetalRenderExecutor.outputPixelFormat
         mtkView.clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
         mtkView.preferredFramesPerSecond = SceneRenderingController.defaultPreferredFPS
         mtkView.autoresizingMask = [.width, .height]
@@ -56,7 +63,20 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
 
     func load() async throws {
         guard !didLoad else { return }
+        do {
+            try await performLoad()
+            loadDiagnostics = nil
+        } catch {
+            // Surface a precise reason via `loadDiagnostics` so the detail
+            // view's honesty pass shows the actual failure (unsupported
+            // shader, missing texture, …) instead of "All declared layers
+            // decoded cleanly."
+            loadDiagnostics = diagnostic(for: error)
+            throw error
+        }
+    }
 
+    private func performLoad() async throws {
         onProgress?("Reading scene")
         let entryURL = try entryResolver.resolveExistingFileURL(relativePath: descriptor.entryFile)
         let document = try await Task.detached(priority: .userInitiated) {
@@ -101,6 +121,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         outputTexture = nil
         renderGraph = nil
         renderPipeline = nil
+        loadDiagnostics = nil
         try await load()
     }
 
@@ -168,7 +189,13 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         guard let path = externalTexturePath(for: reference), textures[path] == nil else {
             return
         }
-        textures[path] = try makeTexture(relativePath: path, label: "WPE texture \(path)")
+        do {
+            textures[path] = try makeTexture(relativePath: path, label: "WPE texture \(path)")
+        } catch {
+            // Carry the asset path through so `diagnostic(for:)` can blame the
+            // exact texture instead of falling back to the scene entry file.
+            throw WPEMetalTextureLoadContextError(path: path, underlying: error)
+        }
     }
 
     private func externalTexturePath(for reference: WPETextureReference) -> String? {
@@ -267,5 +294,64 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         let parts = relativePath.split(separator: "/", omittingEmptySubsequences: false)
         guard parts.count >= 3, parts[0] == ".." else { return nil }
         return (String(parts[1]), parts.dropFirst(2).joined(separator: "/"))
+    }
+
+    /// Maps any error raised during `performLoad()` onto the same
+    /// `SceneLoadDiagnostic` taxonomy `SceneRenderingController` populates, so
+    /// the SpriteKit and Metal backends report failures through one UI path.
+    /// `fallbackPath` carries an asset path through `WPEMetalTextureLoadContextError`
+    /// so missing-asset diagnostics blame the exact texture, not the scene
+    /// entry file. Layer attribution still uses `"scene"` — per-layer
+    /// granularity ships in Phase 2B.
+    private func diagnostic(for error: Error) -> SceneLoadDiagnostic {
+        diagnostic(for: error, fallbackPath: nil)
+    }
+
+    private func diagnostic(for error: Error, fallbackPath: String?) -> SceneLoadDiagnostic {
+        let layer = "scene"
+        switch error {
+        case let context as WPEMetalTextureLoadContextError:
+            return diagnostic(for: context.underlying, fallbackPath: context.path)
+        case let executorError as WPEMetalRenderExecutorError:
+            switch executorError {
+            case .unsupportedShader(let name):
+                return .materialUnresolved(layer: layer, reason: "Shader \"\(name)\" is not supported by the Metal renderer yet.")
+            case .unsupportedTarget:
+                return .materialUnresolved(layer: layer, reason: "This wallpaper uses an unsupported rendering target.")
+            case .missingTexture(let reference):
+                switch reference {
+                case .image(let path), .asset(let path), .fbo(let path):
+                    return .fileMissing(layer: layer, path: path)
+                case .previous:
+                    return .materialUnresolved(layer: layer, reason: "Previous-frame effects (motion blur, feedback) are not yet supported.")
+                }
+            case .noRenderablePasses:
+                return .materialUnresolved(layer: layer, reason: "Scene contains no renderable passes.")
+            case .commandQueueUnavailable, .libraryUnavailable, .pipelineUnavailable, .commandBufferFailed:
+                return .other(layer: layer, message: executorError.errorDescription ?? "Metal renderer failed.")
+            }
+        case let loaderError as WPEMetalTextureLoaderError:
+            switch loaderError {
+            case .unsupportedFormat, .unsupportedCompressedFormat, .malformedPayload, .textureAllocationFailed:
+                return .other(layer: layer, message: loaderError.errorDescription ?? "Texture upload failed.")
+            }
+        case let resolveError as SceneResourceResolver.ResolveError:
+            switch resolveError {
+            case .fileMissing:
+                return .fileMissing(layer: layer, path: fallbackPath ?? descriptor.entryFile)
+            case .pathEscape:
+                return .crossPackageReference(layer: layer, path: fallbackPath ?? descriptor.entryFile)
+            case .materialUnresolved(let reason):
+                return .materialUnresolved(layer: layer, reason: reason)
+            case .texture(let texError):
+                return .texture(layer: layer, error: texError)
+            case .unsupportedTexture:
+                return .legacyUnsupportedTexture(layer: layer)
+            case .decodeFailed:
+                return .other(layer: layer, message: "A texture or image file is corrupted and cannot be decoded.")
+            }
+        default:
+            return .other(layer: layer, message: error.localizedDescription)
+        }
     }
 }

--- a/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
+++ b/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
@@ -201,6 +201,77 @@ private func copyPass() -> WPERenderPass {
     )
 }
 
+private extension WPEMetalRenderExecutorTests {
+    @Test("Offscreen output is sRGB-tagged for SpriteKit gamma parity")
+    func outputTextureIsSRGB() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+        let pass = solidPass()
+        let pipeline = WPEPreparedRenderPipeline(layers: [
+            WPEPreparedRenderLayer(
+                graphLayer: graphLayer(pass: pass),
+                passes: [WPEPreparedRenderPass(
+                    pass: pass,
+                    shader: WPEShaderProgram(name: "solidcolor", vertexSource: "", fragmentSource: "", isBuiltin: true),
+                    textureBindings: [:],
+                    comboValues: [:],
+                    uniformValues: ["g_Color": .vector([1, 1, 1, 1])]
+                )]
+            )
+        ])
+
+        let output = try executor.render(pipeline: pipeline, size: CGSize(width: 4, height: 4), textures: [:])
+
+        #expect(output.pixelFormat == .rgba8Unorm_srgb)
+        #expect(WPEMetalRenderExecutor.outputPixelFormat == .rgba8Unorm_srgb)
+    }
+
+    @Test("solidcolor mid-tone uniform round-trips through sRGB target without gamma double-encoding")
+    func solidcolorMidToneSRGBRoundTrip() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+        let pass = WPERenderPass(
+            id: "midgray.0",
+            phase: .material,
+            shader: "solidcolor",
+            source: .previous,
+            target: .scene,
+            textures: [:],
+            binds: [:],
+            constants: ["g_Color": .vector([0.5, 0.5, 0.5, 1])],
+            combos: [:],
+            blending: "normal",
+            cullMode: "nocull",
+            depthTest: "disabled",
+            depthWrite: "disabled"
+        )
+        let pipeline = WPEPreparedRenderPipeline(layers: [
+            WPEPreparedRenderLayer(
+                graphLayer: graphLayer(pass: pass),
+                passes: [WPEPreparedRenderPass(
+                    pass: pass,
+                    shader: WPEShaderProgram(name: "solidcolor", vertexSource: "", fragmentSource: "", isBuiltin: true),
+                    textureBindings: [:],
+                    comboValues: [:],
+                    uniformValues: ["g_Color": .vector([0.5, 0.5, 0.5, 1])]
+                )]
+            )
+        ])
+
+        let output = try executor.render(pipeline: pipeline, size: CGSize(width: 4, height: 4), textures: [:])
+        let pixel = try readPixel(output, x: 2, y: 2)
+
+        // sRGB "0.5" round-trips back to byte 128 ±2 when uniforms are
+        // linearized before reaching the sRGB-tagged target. Without the
+        // sRGB→linear conversion the byte would read ~188 (gamma double-
+        // encoded). This test pins the H3 gamma fix.
+        #expect(abs(Int(pixel.r) - 128) <= 3)
+        #expect(abs(Int(pixel.g) - 128) <= 3)
+        #expect(abs(Int(pixel.b) - 128) <= 3)
+        #expect(pixel.a >= 250)
+    }
+}
+
 private func makeRGBAInputTexture(device: MTLDevice, bytes: Data) throws -> MTLTexture {
     let descriptor = MTLTextureDescriptor.texture2DDescriptor(
         pixelFormat: .rgba8Unorm,

--- a/LiveWallpaperTests/WPEMetalSceneRendererTests.swift
+++ b/LiveWallpaperTests/WPEMetalSceneRendererTests.swift
@@ -90,6 +90,61 @@ struct WPEMetalSceneRendererTests {
         #expect(pixel.g > pixel.r)
         #expect(pixel.g > pixel.b)
     }
+
+    @Test("Load failure populates loadDiagnostics with a SceneLoadDiagnostic")
+    func loadFailurePopulatesDiagnostics() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let descriptor = SceneDescriptor(
+            workshopID: UUID().uuidString,
+            cacheRelativePath: "wpe-cache/missing-\(UUID().uuidString)",
+            entryFile: "scene.json",
+            capabilityTier: .imageOnly
+        )
+        // Pointing the renderer at a directory that does not exist forces
+        // `entryResolver.resolveExistingFileURL` to throw `.fileMissing`,
+        // exercising the H1 diagnostic mapping path without depending on a
+        // real WPE scene fixture.
+        let nonExistentRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WPEMetalDiagnostics-\(UUID().uuidString)", isDirectory: true)
+
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: descriptor,
+            cacheRootURL: nonExistentRoot,
+            dependencyMounts: [],
+            frame: CGRect(x: 0, y: 0, width: 64, height: 64),
+            device: device
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await renderer.load()
+        }
+
+        let diagnostic = try #require(renderer.loadDiagnostics)
+        if case .fileMissing(_, let path) = diagnostic {
+            #expect(path == descriptor.entryFile)
+        } else {
+            Issue.record("Expected .fileMissing diagnostic, got \(diagnostic)")
+        }
+    }
+
+    @Test("Successful reload clears stale loadDiagnostics")
+    func reloadClearsStaleDiagnostics() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try MetalSceneFixture.solidColorScene()
+        defer { fixture.cleanup() }
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.root,
+            dependencyMounts: [],
+            frame: CGRect(x: 0, y: 0, width: 64, height: 64),
+            device: device
+        )
+
+        try await renderer.load()
+        try await renderer.reload()
+
+        #expect(renderer.loadDiagnostics == nil)
+    }
 }
 
 private struct MetalSceneFixture {
@@ -246,7 +301,11 @@ private struct MetalPixel {
 
 private extension MTLTexture {
     func readPixel(x: Int, y: Int) -> MetalPixel? {
-        guard pixelFormat == .rgba8Unorm,
+        // RGBA8 unorm and rgba8 unorm-sRGB share the same byte layout — the
+        // sRGB variant simply tags the texture so hardware applies gamma on
+        // sample/store. Both are fine for raw byte readback.
+        let supportedFormats: [MTLPixelFormat] = [.rgba8Unorm, .rgba8Unorm_srgb]
+        guard supportedFormats.contains(pixelFormat),
               x >= 0, x < width,
               y >= 0, y < height else {
             return nil

--- a/LiveWallpaperTests/WPEMetalTextureFormatMapperTests.swift
+++ b/LiveWallpaperTests/WPEMetalTextureFormatMapperTests.swift
@@ -5,23 +5,33 @@ import Testing
 @Suite("WPE Metal texture format mapper")
 struct WPEMetalTextureFormatMapperTests {
 
-    @Test("Maps CPU-decodable formats to direct Metal pixel formats")
-    func mapsUncompressedFormats() throws {
-        let capabilities = WPEMetalTextureCapabilities(supportsBCTextureCompression: false)
-
-        #expect(try WPEMetalTextureFormatMapper.mapping(for: .rgba8888, capabilities: capabilities).pixelFormat == .rgba8Unorm)
-        #expect(try WPEMetalTextureFormatMapper.mapping(for: .r8, capabilities: capabilities).pixelFormat == .r8Unorm)
-        #expect(try WPEMetalTextureFormatMapper.mapping(for: .rg88, capabilities: capabilities).pixelFormat == .rg8Unorm)
-    }
-
-    @Test("Maps BC formats to native compressed Metal formats when supported")
-    func mapsBCFormatsWhenSupported() throws {
+    @Test("Defaults to sRGB pixel formats for color textures")
+    func defaultsToSRGBForColorFormats() throws {
         let capabilities = WPEMetalTextureCapabilities(supportsBCTextureCompression: true)
 
-        #expect(try WPEMetalTextureFormatMapper.mapping(for: .dxt1, capabilities: capabilities).pixelFormat == .bc1_rgba)
-        #expect(try WPEMetalTextureFormatMapper.mapping(for: .dxt3, capabilities: capabilities).pixelFormat == .bc2_rgba)
-        #expect(try WPEMetalTextureFormatMapper.mapping(for: .dxt5, capabilities: capabilities).pixelFormat == .bc3_rgba)
-        #expect(try WPEMetalTextureFormatMapper.mapping(for: .bc7, capabilities: capabilities).pixelFormat == .bc7_rgbaUnorm)
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .rgba8888, capabilities: capabilities).pixelFormat == .rgba8Unorm_srgb)
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .dxt1, capabilities: capabilities).pixelFormat == .bc1_rgba_srgb)
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .dxt3, capabilities: capabilities).pixelFormat == .bc2_rgba_srgb)
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .dxt5, capabilities: capabilities).pixelFormat == .bc3_rgba_srgb)
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .bc7, capabilities: capabilities).pixelFormat == .bc7_rgbaUnorm_srgb)
+    }
+
+    @Test("Linear color space maps to non-sRGB variants")
+    func linearColorSpaceUsesUnormVariants() throws {
+        let capabilities = WPEMetalTextureCapabilities(supportsBCTextureCompression: true)
+
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .rgba8888, capabilities: capabilities, colorSpace: .linear).pixelFormat == .rgba8Unorm)
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .dxt1, capabilities: capabilities, colorSpace: .linear).pixelFormat == .bc1_rgba)
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .bc7, capabilities: capabilities, colorSpace: .linear).pixelFormat == .bc7_rgbaUnorm)
+    }
+
+    @Test("Single-channel data formats stay linear regardless of colorSpace")
+    func singleChannelStaysLinear() throws {
+        let capabilities = WPEMetalTextureCapabilities(supportsBCTextureCompression: false)
+
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .r8, capabilities: capabilities).pixelFormat == .r8Unorm)
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .rg88, capabilities: capabilities).pixelFormat == .rg8Unorm)
+        #expect(try WPEMetalTextureFormatMapper.mapping(for: .r8, capabilities: capabilities, colorSpace: .sRGB).pixelFormat == .r8Unorm)
     }
 
     @Test("Fails closed for BC formats when device support is absent")

--- a/LiveWallpaperTests/WPEMetalTextureLoaderTests.swift
+++ b/LiveWallpaperTests/WPEMetalTextureLoaderTests.swift
@@ -34,7 +34,9 @@ struct WPEMetalTextureLoaderTests {
 
         #expect(texture.width == 2)
         #expect(texture.height == 2)
-        #expect(texture.pixelFormat == .rgba8Unorm)
+        // Phase 2A H3: payloads default to sRGB so the gamma matches the
+        // SpriteKit/CGImage fallback. Linear uploads must be opted into.
+        #expect(texture.pixelFormat == .rgba8Unorm_srgb)
     }
 
     @Test("Rejects BC payload when current device cannot sample BC")


### PR DESCRIPTION
## Summary

Follow-up to bring [#17](https://github.com/Paradox07127/LiveWallpaper/pull/17) onto `main`. PR #17 was opened against `codex/wpe-phase2a-metal-renderer` as a stacked PR; merging it advanced the feature branch but did not reach `main`. This PR closes that gap with a single delta: the H1+H3 holdovers commit.

Delta from `main` (Phase 2A baseline at `0680a37`) → `codex/wpe-phase2a-metal-renderer` (`7dc6ec1`):

- `929dc6a` — `fix(wpe): Phase 2A H1+H3 holdovers — diagnostics + sRGB gamma parity`
- `7dc6ec1` — merge commit for PR #17

## What lands on main

- **H1**: `WPEMetalSceneRenderer.loadDiagnostics` is now populated on every load failure via the same `SceneLoadDiagnostic` taxonomy `SceneRenderingController` uses; texture load errors carry the failing asset path through `WPEMetalTextureLoadContextError`.
- **H3**: swapchain, offscreen output, and texture loader all align on `.rgba8Unorm_srgb`. `solidcolor` `g_Color` uniforms are sRGB→linearised so the hardware's sRGB encoding does not double-apply gamma.

Full audit + test rationale already documented on [#17](https://github.com/Paradox07127/LiveWallpaper/pull/17).

## Test plan

- [x] 28/28 Phase 2A targeted tests pass (verified pre-merge in #17)
- [ ] Reviewer confirms `git log` on main shows `929dc6a` after merge
- [ ] Reviewer confirms `loadDiagnostics` is no longer permanently `nil` on `WPEMetalSceneRenderer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)