### PR TITLE
feat(wpe): Phase 2B scene runtime hardening — clock, parallax, snapshot

### DIFF
--- a/LiveWallpaper/Infrastructure/WPEMetalTextureLoader.swift
+++ b/LiveWallpaper/Infrastructure/WPEMetalTextureLoader.swift
@@ -5,13 +5,77 @@ import MetalKit
 struct WPEMetalTextureLoader {
     private let device: MTLDevice
     private let capabilities: WPEMetalTextureCapabilities
+    private let uploadQueue: WPEMetalTextureUploadQueue
 
-    init(device: MTLDevice, capabilities: WPEMetalTextureCapabilities? = nil) {
+    init(
+        device: MTLDevice,
+        capabilities: WPEMetalTextureCapabilities? = nil,
+        uploadQueue: WPEMetalTextureUploadQueue = .shared
+    ) {
         self.device = device
         self.capabilities = capabilities ?? WPEMetalTextureCapabilities(device: device)
+        self.uploadQueue = uploadQueue
     }
 
-    func makeTexture(from payload: WPETexTexturePayload, label: String) throws -> MTLTexture {
+    func makeTexture(from payload: WPETexTexturePayload, label: String) async throws -> MTLTexture {
+        let device = self.device
+        let capabilities = self.capabilities
+        return try await uploadQueue.perform {
+            try Self.makeTextureSynchronously(
+                from: payload,
+                label: label,
+                device: device,
+                capabilities: capabilities
+            )
+        }
+    }
+
+    func makeTexture(from image: DecodedRGBAImage, label: String) async throws -> MTLTexture {
+        let payload = WPETexTexturePayload(
+            info: WPETexInfo(
+                containerVersion: 0,
+                infoVersion: 0,
+                width: image.width,
+                height: image.height,
+                textureFormatCode: WPETexFormat.rgba8888.rawValue,
+                format: .rgba8888,
+                mipmapCount: 1,
+                flags: 0
+            ),
+            mipmaps: [WPETexTextureMipmap(index: 0, width: image.width, height: image.height, bytes: image.pixels)],
+            hasAnimationFrames: false
+        )
+        return try await makeTexture(from: payload, label: label)
+    }
+
+    func makeTexture(from cgImage: CGImage, label: String) async throws -> MTLTexture {
+        let device = self.device
+        return try await uploadQueue.perform {
+            // Phase 2A H3: explicitly request sRGB so untagged CGImages do not
+            // fall back to the linear path and re-introduce gamma divergence.
+            let loader = MTKTextureLoader(device: device)
+            do {
+                let texture = try loader.newTexture(
+                    cgImage: cgImage,
+                    options: [
+                        MTKTextureLoader.Option.SRGB: true,
+                        MTKTextureLoader.Option.textureUsage: MTLTextureUsage.shaderRead.rawValue
+                    ]
+                )
+                texture.label = label
+                return texture
+            } catch {
+                throw WPEMetalTextureLoaderError.malformedPayload(error.localizedDescription)
+            }
+        }
+    }
+
+    private static func makeTextureSynchronously(
+        from payload: WPETexTexturePayload,
+        label: String,
+        device: MTLDevice,
+        capabilities: WPEMetalTextureCapabilities
+    ) throws -> MTLTexture {
         guard let format = payload.info.format else {
             throw WPEMetalTextureLoaderError.malformedPayload("unknown texture format \(payload.info.textureFormatCode)")
         }
@@ -40,7 +104,7 @@ struct WPEMetalTextureLoader {
                 "mip bytes \(mip.bytes.count) smaller than expected \(expected)"
             )
         }
-        let bytesPerRow = try Self.bytesPerRow(width: mip.width, mapping: mapping)
+        let bytesPerRow = try bytesPerRow(width: mip.width, mapping: mapping)
 
         mip.bytes.withUnsafeBytes { raw in
             texture.replace(
@@ -51,46 +115,6 @@ struct WPEMetalTextureLoader {
             )
         }
         return texture
-    }
-
-    func makeTexture(from image: DecodedRGBAImage, label: String) throws -> MTLTexture {
-        let payload = WPETexTexturePayload(
-            info: WPETexInfo(
-                containerVersion: 0,
-                infoVersion: 0,
-                width: image.width,
-                height: image.height,
-                textureFormatCode: WPETexFormat.rgba8888.rawValue,
-                format: .rgba8888,
-                mipmapCount: 1,
-                flags: 0
-            ),
-            mipmaps: [WPETexTextureMipmap(index: 0, width: image.width, height: image.height, bytes: image.pixels)],
-            hasAnimationFrames: false
-        )
-        return try makeTexture(from: payload, label: label)
-    }
-
-    func makeTexture(from cgImage: CGImage, label: String) throws -> MTLTexture {
-        let loader = MTKTextureLoader(device: device)
-        do {
-            // Phase 2A H3: explicitly request sRGB. WPE Workshop ships color
-            // imagery as sRGB-encoded PNG/JPG; relying on MTKTextureLoader to
-            // infer color space leaves untagged or device-RGB CGImages on the
-            // linear path, which would re-introduce the gamma divergence we
-            // are fixing. Forcing the option locks the contract.
-            let texture = try loader.newTexture(
-                cgImage: cgImage,
-                options: [
-                    MTKTextureLoader.Option.SRGB: true,
-                    MTKTextureLoader.Option.textureUsage: MTLTextureUsage.shaderRead.rawValue
-                ]
-            )
-            texture.label = label
-            return texture
-        } catch {
-            throw WPEMetalTextureLoaderError.malformedPayload(error.localizedDescription)
-        }
     }
 
     private static func bytesPerRow(width: Int, mapping: WPEMetalTextureFormatMapping) throws -> Int {

--- a/LiveWallpaper/Infrastructure/WPEMetalTextureSnapshotter.swift
+++ b/LiveWallpaper/Infrastructure/WPEMetalTextureSnapshotter.swift
@@ -1,0 +1,78 @@
+import AppKit
+import Metal
+
+/// Background readback helper that converts the Metal renderer's offscreen
+/// `MTLTexture` into an `NSImage` for `WPESceneDetailView`. Phase 2A's
+/// renderer left the Metal backend without a thumbnail; the detail view
+/// then fell into `.previewUnavailable`. Phase 2B Task 5 wires this
+/// snapshotter through `WPESceneRenderer.previewSnapshot`.
+///
+/// The readback runs on a dedicated utility-QoS queue so a 4K mip-chain
+/// readback never blocks the main thread on a multi-display setup; the
+/// snapshotter is `@unchecked Sendable` because every closure it owns is
+/// either pure or hops onto the main actor explicitly via the calling
+/// renderer.
+final class WPEMetalTextureSnapshotter: @unchecked Sendable {
+    static let shared = WPEMetalTextureSnapshotter()
+
+    private let queue: DispatchQueue
+
+    init(label: String = "com.livewallpaper.wpe-metal.snapshot-readback") {
+        self.queue = DispatchQueue(label: label, qos: .utility)
+    }
+
+    /// Synchronous readback. Phase 2B Task 5 uses this from `performLoad()`
+    /// on the main actor — the load is async so an extra blocking call here
+    /// is bounded by the `getBytes` cost (a few milliseconds for 4K), and
+    /// keeping the API non-async sidesteps Swift 6's `MTLTexture` sendable
+    /// check. Per-frame readback (Phase 2C) will need a sendable wrapper.
+    func snapshot(from texture: MTLTexture) -> NSImage? {
+        Self.makeImage(from: texture)
+    }
+
+    private static func makeImage(from texture: MTLTexture) -> NSImage? {
+        guard texture.width > 0, texture.height > 0 else {
+            return nil
+        }
+        guard texture.pixelFormat == .rgba8Unorm || texture.pixelFormat == .rgba8Unorm_srgb else {
+            return nil
+        }
+
+        let bytesPerPixel = 4
+        let bytesPerRow = texture.width * bytesPerPixel
+        var bytes = [UInt8](repeating: 0, count: bytesPerRow * texture.height)
+        texture.getBytes(
+            &bytes,
+            bytesPerRow: bytesPerRow,
+            from: MTLRegionMake2D(0, 0, texture.width, texture.height),
+            mipmapLevel: 0
+        )
+
+        guard let provider = CGDataProvider(data: Data(bytes) as CFData) else {
+            return nil
+        }
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+
+        guard let cgImage = CGImage(
+            width: texture.width,
+            height: texture.height,
+            bitsPerComponent: 8,
+            bitsPerPixel: 32,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: true,
+            intent: .defaultIntent
+        ) else {
+            return nil
+        }
+
+        return NSImage(
+            cgImage: cgImage,
+            size: CGSize(width: texture.width, height: texture.height)
+        )
+    }
+}

--- a/LiveWallpaper/Infrastructure/WPEMetalTextureUploadQueue.swift
+++ b/LiveWallpaper/Infrastructure/WPEMetalTextureUploadQueue.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Bounded off-main upload lane for Metal texture work. WPE scenes routinely
+/// ship 4K BC mip chains; running `MTLTexture.replace(...)` on the calling
+/// actor blocks the main thread for tens of milliseconds per mip and stalls
+/// SwiftUI updates on multi-display setups. This queue dispatches uploads to
+/// a concurrent `DispatchQueue` while a `DispatchSemaphore` caps how many
+/// run in parallel — overcommitting the GPU's IO surface produces no real
+/// speedup and just contends for system RAM.
+final class WPEMetalTextureUploadQueue: @unchecked Sendable {
+    /// Process-wide upload lane shared by every renderer instance. Capped at
+    /// half the active core count (min 1, max 2) so a 6-display setup never
+    /// stalls the GPU on a single mip; the bound is purely heuristic and can
+    /// be revisited once Phase 2D ships full uniform binding instrumentation.
+    static let shared = WPEMetalTextureUploadQueue(
+        label: "com.livewallpaper.wpe-metal.texture-upload",
+        maxConcurrentUploads: max(1, min(2, ProcessInfo.processInfo.activeProcessorCount / 2))
+    )
+
+    private let queue: DispatchQueue
+    private let semaphore: DispatchSemaphore
+    private let didStartUpload: (@Sendable (Bool) -> Void)?
+
+    init(
+        label: String,
+        maxConcurrentUploads: Int,
+        didStartUpload: (@Sendable (Bool) -> Void)? = nil
+    ) {
+        self.queue = DispatchQueue(label: label, qos: .userInitiated, attributes: .concurrent)
+        self.semaphore = DispatchSemaphore(value: max(maxConcurrentUploads, 1))
+        self.didStartUpload = didStartUpload
+    }
+
+    func perform<T>(
+        _ operation: @escaping @Sendable () throws -> T
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            queue.async {
+                self.semaphore.wait()
+                defer { self.semaphore.signal() }
+                self.didStartUpload?(Thread.isMainThread)
+                do {
+                    continuation.resume(returning: try operation())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
@@ -95,7 +95,8 @@ struct WPERenderGraphBuilder: Sendable {
             compositeA: compositeA,
             compositeB: compositeB,
             localFBOs: context.localFBOs,
-            passes: context.finalizedPasses()
+            passes: context.finalizedPasses(),
+            parallaxDepth: object.parallaxDepth
         )
     }
 

--- a/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
@@ -212,6 +212,10 @@ enum WPESceneDocumentParser {
             diagnostics.append(.init(severity: .warning, message: "Image \(name) uses .tex texture — falls back to first-frame stub if available"))
         }
 
+        // WPE writes the field as `parallaxDepth` in newer scenes and the
+        // legacy lowercase `parallaxdepth` in older Workshop content.
+        let parallaxDepth = parseDouble(dict["parallaxDepth"]) ?? parseDouble(dict["parallaxdepth"]) ?? 0
+
         return WPESceneImageObject(
             id: id,
             name: name,
@@ -228,7 +232,8 @@ enum WPESceneDocumentParser {
             alignment: alignment,
             size: size,
             effects: effects,
-            animationLayers: animationLayers
+            animationLayers: animationLayers,
+            parallaxDepth: parallaxDepth
         )
     }
 

--- a/LiveWallpaper/Models/WPERenderGraph.swift
+++ b/LiveWallpaper/Models/WPERenderGraph.swift
@@ -21,6 +21,32 @@ struct WPERenderLayer: Equatable, Sendable, Identifiable {
     let compositeB: String
     let localFBOs: [WPERenderFBO]
     let passes: [WPERenderPass]
+    /// Mirrors `WPESceneImageObject.parallaxDepth`. Phase 2B uses this as
+    /// the bound for the built-in mouse-parallax UV offset; later phases
+    /// will route it into custom shaders via the prepared uniform table.
+    let parallaxDepth: Double
+
+    init(
+        objectID: String,
+        objectName: String,
+        imagePath: String,
+        materialPath: String?,
+        compositeA: String,
+        compositeB: String,
+        localFBOs: [WPERenderFBO],
+        passes: [WPERenderPass],
+        parallaxDepth: Double = 0
+    ) {
+        self.objectID = objectID
+        self.objectName = objectName
+        self.imagePath = imagePath
+        self.materialPath = materialPath
+        self.compositeA = compositeA
+        self.compositeB = compositeB
+        self.localFBOs = localFBOs
+        self.passes = passes
+        self.parallaxDepth = parallaxDepth
+    }
 }
 
 struct WPERenderFBO: Equatable, Sendable {

--- a/LiveWallpaper/Models/WPERenderPipeline.swift
+++ b/LiveWallpaper/Models/WPERenderPipeline.swift
@@ -33,6 +33,48 @@ struct WPEShaderProgram: Equatable, Sendable {
     let isBuiltin: Bool
 }
 
+extension WPEPreparedRenderPipeline {
+    /// Phase 2B: returns a copy of the pipeline with per-frame Metal runtime
+    /// + camera uniforms merged into every pass's `uniformValues`. Material
+    /// uniforms (e.g. `g_Color`) win on key collision so existing tests stay
+    /// green; runtime keys (`g_Time`, `g_Daytime`, `g_Brightness`,
+    /// `g_PointerPosition`, `g_ViewProjectionMatrix`) only fill in slots the
+    /// pass did not already define.
+    func addingMetalRuntimeUniforms(
+        _ runtimeUniforms: WPEMetalRuntimeUniforms,
+        camera: WPEMetalCameraUniforms
+    ) -> WPEPreparedRenderPipeline {
+        WPEPreparedRenderPipeline(
+            layers: layers.map { layer in
+                WPEPreparedRenderLayer(
+                    graphLayer: layer.graphLayer,
+                    passes: layer.passes.map { pass in
+                        var values = pass.uniformValues
+                        // Runtime uniforms (`g_Time`, `g_Daytime`,
+                        // `g_Brightness`, `g_PointerPosition`,
+                        // `g_ViewProjectionMatrix`) are reserved names. Always
+                        // overwrite so a stale per-load default never wins
+                        // over the live frame value.
+                        for (key, value) in runtimeUniforms.uniformValues {
+                            values[key] = value
+                        }
+                        for (key, value) in camera.uniformValues {
+                            values[key] = value
+                        }
+                        return WPEPreparedRenderPass(
+                            pass: pass.pass,
+                            shader: pass.shader,
+                            textureBindings: pass.textureBindings,
+                            comboValues: pass.comboValues,
+                            uniformValues: values
+                        )
+                    }
+                )
+            }
+        )
+    }
+}
+
 enum WPERenderPipelineError: Error, Equatable, LocalizedError, Sendable {
     case shaderMissing(name: String, stage: String, path: String)
     case includeMissing(path: String, requestedBy: String)

--- a/LiveWallpaper/Models/WPESceneDocument.swift
+++ b/LiveWallpaper/Models/WPESceneDocument.swift
@@ -86,6 +86,48 @@ struct WPESceneImageObject: Equatable, Sendable, Identifiable {
     let size: CGSize?
     let effects: [WPESceneImageEffect]
     let animationLayers: [WPESceneAnimationLayer]
+    /// Mouse-parallax depth (0 = locked to scene). Phase 2B applies a
+    /// conservative UV offset bounded to ±0.05 in built-in copy passes; full
+    /// camera-parallax fidelity is deferred until shader translation lands.
+    let parallaxDepth: Double
+
+    init(
+        id: String,
+        name: String,
+        imageRelativePath: String,
+        materialRelativePath: String?,
+        origin: SIMD3<Double>,
+        scale: SIMD3<Double>,
+        angles: SIMD3<Double>,
+        visible: Bool,
+        alpha: Double,
+        color: SIMD3<Double>,
+        brightness: Double,
+        blendMode: WPESceneBlendMode,
+        alignment: WPESceneAlignment,
+        size: CGSize?,
+        effects: [WPESceneImageEffect],
+        animationLayers: [WPESceneAnimationLayer],
+        parallaxDepth: Double = 0
+    ) {
+        self.id = id
+        self.name = name
+        self.imageRelativePath = imageRelativePath
+        self.materialRelativePath = materialRelativePath
+        self.origin = origin
+        self.scale = scale
+        self.angles = angles
+        self.visible = visible
+        self.alpha = alpha
+        self.color = color
+        self.brightness = brightness
+        self.blendMode = blendMode
+        self.alignment = alignment
+        self.size = size
+        self.effects = effects
+        self.animationLayers = animationLayers
+        self.parallaxDepth = parallaxDepth
+    }
 }
 
 struct WPESceneImageEffect: Equatable, Sendable, Identifiable {

--- a/LiveWallpaper/Models/WPESceneErrors.swift
+++ b/LiveWallpaper/Models/WPESceneErrors.swift
@@ -87,20 +87,25 @@ enum SceneLoadDiagnostic: Equatable, Sendable {
         }
     }
 
+    /// User-facing copy. Phase 2B Task 6 rewrote these strings per the
+    /// UX & Frontend Spec in `2026-05-05-wpe-phase2b-scene-runtime-hardening.md`
+    /// — the messages name the failing layer in plain language and avoid
+    /// engineering jargon ("texture", "shader") that confused users in the
+    /// detail view's diagnostic card.
     var errorDescription: String {
         switch self {
-        case .texture(let layer, let error):
-            return "Layer \(layer): \(error.errorDescription ?? "tex decode failed")"
+        case .texture(let layer, _):
+            return "The image for '\(layer)' couldn't be loaded."
         case .legacyUnsupportedTexture(let layer):
-            return "Layer \(layer): legacy .tex layer skipped"
-        case .fileMissing(let layer, let path):
-            return "Layer \(layer): missing asset \(path)"
-        case .crossPackageReference(let layer, let path):
-            return "Layer \(layer): cross-package reference \(path) rejected"
-        case .materialUnresolved(let layer, let reason):
-            return "Layer \(layer): \(reason)"
+            return "The image format used by '\(layer)' is no longer supported."
+        case .fileMissing(let layer, _):
+            return "A file required by the '\(layer)' layer is missing."
+        case .crossPackageReference(let layer, _):
+            return "The layer '\(layer)' requires files from an external package, which is not supported."
+        case .materialUnresolved(let layer, _):
+            return "A rendering feature needed by '\(layer)' is not supported yet."
         case .other(let layer, let message):
-            return "Layer \(layer): \(message)"
+            return "The layer '\(layer)' encountered an issue: \(message)."
         }
     }
 }

--- a/LiveWallpaper/Runtime/SceneRenderingController.swift
+++ b/LiveWallpaper/Runtime/SceneRenderingController.swift
@@ -78,6 +78,22 @@ final class SceneRenderingController: WPESceneRenderer {
     var nsView: NSView { skView }
     var hasPresentedFrame: Bool { skView.scene != nil }
 
+    /// SpriteKit snapshot via AppKit's offscreen bitmap cache. Returns `nil`
+    /// when the SKView has zero bounds (early load) so consumers can choose a
+    /// loading placeholder instead of an opaque blank image.
+    var previewSnapshot: NSImage? {
+        guard skView.bounds.width > 0, skView.bounds.height > 0 else {
+            return nil
+        }
+        guard let representation = skView.bitmapImageRepForCachingDisplay(in: skView.bounds) else {
+            return nil
+        }
+        skView.cacheDisplay(in: skView.bounds, to: representation)
+        let image = NSImage(size: skView.bounds.size)
+        image.addRepresentation(representation)
+        return image
+    }
+
     /// Materialises the SpriteKit scene from disk. Idempotent — calling it
     /// twice is a no-op on the second pass so the wallpaper session can
     /// safely re-prepare on focus changes.

--- a/LiveWallpaper/Runtime/SceneWallpaperSession.swift
+++ b/LiveWallpaper/Runtime/SceneWallpaperSession.swift
@@ -108,7 +108,16 @@ final class SceneWallpaperSession: WallpaperRuntimeSession {
                 self?.loadError = error
             } catch {
                 Logger.warning("Scene wallpaper load failed: \(error.localizedDescription)", category: .screenManager)
-                self?.loadError = .parseFailed(error.localizedDescription)
+                // Phase 2B: Metal renderer maps load failures onto
+                // `loadDiagnostics` before rethrowing the raw error type;
+                // surface that taxonomy here so the detail view shows the
+                // precise `SceneLoadDiagnostic` reason instead of a generic
+                // "parse failed" message.
+                if let diagnostic = renderer.loadDiagnostics {
+                    self?.loadError = .resourceFailed(diagnostic)
+                } else {
+                    self?.loadError = .parseFailed(error.localizedDescription)
+                }
             }
         }
     }
@@ -135,7 +144,11 @@ final class SceneWallpaperSession: WallpaperRuntimeSession {
         } catch let error as SceneRenderingError {
             loadError = error
         } catch {
-            loadError = .parseFailed(error.localizedDescription)
+            if let diagnostic = renderer.loadDiagnostics {
+                loadError = .resourceFailed(diagnostic)
+            } else {
+                loadError = .parseFailed(error.localizedDescription)
+            }
         }
     }
 

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -39,6 +39,11 @@ struct WPESolidUniforms {
     var color: SIMD4<Float>
 }
 
+struct WPECopyUniforms {
+    var uvOffset: SIMD2<Float>
+    var padding: SIMD2<Float> = SIMD2<Float>(0, 0)
+}
+
 final class WPEMetalRenderExecutor {
     /// Phase 2A H3: every offscreen target and the on-screen swapchain share a
     /// single sRGB pixel format so render pipelines built for the offscreen
@@ -67,8 +72,11 @@ final class WPEMetalRenderExecutor {
     func render(
         pipeline: WPEPreparedRenderPipeline,
         size: CGSize,
-        textures: [String: MTLTexture]
+        textures: [String: MTLTexture],
+        runtimeUniforms: WPEMetalRuntimeUniforms = .zero,
+        cameraUniforms: WPEMetalCameraUniforms = .identity
     ) throws -> MTLTexture {
+        let preparedPipeline = pipeline.addingMetalRuntimeUniforms(runtimeUniforms, camera: cameraUniforms)
         let output = try makeOutputTexture(size: size)
         guard let commandBuffer = commandQueue.makeCommandBuffer() else {
             throw WPEMetalRenderExecutorError.commandBufferFailed
@@ -76,10 +84,12 @@ final class WPEMetalRenderExecutor {
 
         var shouldClear = true
         var didEncode = false
-        for layer in pipeline.layers {
+        for layer in preparedPipeline.layers {
             if layer.passes.isEmpty {
                 try encodeCopy(
                     reference: .image(layer.graphLayer.imagePath),
+                    layer: layer.graphLayer,
+                    runtimeUniforms: runtimeUniforms,
                     output: output,
                     textures: textures,
                     commandBuffer: commandBuffer,
@@ -92,6 +102,7 @@ final class WPEMetalRenderExecutor {
             for pass in layer.passes {
                 try encode(
                     pass: pass,
+                    layer: layer.graphLayer,
                     output: output,
                     textures: textures,
                     commandBuffer: commandBuffer,
@@ -131,6 +142,8 @@ final class WPEMetalRenderExecutor {
         }
         encoder.setRenderPipelineState(try renderPipeline(fragmentName: "wpe_copy_fragment"))
         encoder.setFragmentTexture(source, index: 0)
+        var uniforms = WPECopyUniforms(uvOffset: SIMD2<Float>(0, 0))
+        encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPECopyUniforms>.stride, index: 0)
         encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
         encoder.endEncoding()
 
@@ -141,6 +154,7 @@ final class WPEMetalRenderExecutor {
 
     private func encode(
         pass: WPEPreparedRenderPass,
+        layer: WPERenderLayer,
         output: MTLTexture,
         textures: [String: MTLTexture],
         commandBuffer: MTLCommandBuffer,
@@ -169,7 +183,9 @@ final class WPEMetalRenderExecutor {
             encoder.setRenderPipelineState(try renderPipeline(fragmentName: "wpe_copy_fragment"))
             let reference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
             let texture = try resolve(reference: reference, textures: textures)
+            var uniforms = copyUniforms(for: pass, layer: layer)
             encoder.setFragmentTexture(texture, index: 0)
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPECopyUniforms>.stride, index: 0)
         } else {
             throw WPEMetalRenderExecutorError.unsupportedShader(pass.pass.shader)
         }
@@ -179,6 +195,8 @@ final class WPEMetalRenderExecutor {
 
     private func encodeCopy(
         reference: WPETextureReference,
+        layer: WPERenderLayer,
+        runtimeUniforms: WPEMetalRuntimeUniforms,
         output: MTLTexture,
         textures: [String: MTLTexture],
         commandBuffer: MTLCommandBuffer,
@@ -197,7 +215,51 @@ final class WPEMetalRenderExecutor {
 
         encoder.setRenderPipelineState(try renderPipeline(fragmentName: "wpe_copy_fragment"))
         encoder.setFragmentTexture(try resolve(reference: reference, textures: textures), index: 0)
+        var uniforms = WPECopyUniforms(
+            uvOffset: Self.parallaxUVOffset(
+                pointerPosition: runtimeUniforms.pointerPosition,
+                parallaxDepth: layer.parallaxDepth
+            )
+        )
+        encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPECopyUniforms>.stride, index: 0)
         encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+    }
+
+    /// Conservative WPE mouse-parallax model. The shader receives a UV
+    /// offset bounded to ±0.05 so a layer with depth 0.1 and the cursor at
+    /// the screen edge shifts samples by 5% — enough to feel parallax
+    /// without exposing texture borders. Phase 2D's GLSL translator will
+    /// replace this with the full WPE camera-parallax math.
+    static func parallaxUVOffset(
+        pointerPosition: SIMD2<Double>,
+        parallaxDepth: Double
+    ) -> SIMD2<Float> {
+        guard parallaxDepth != 0 else {
+            return SIMD2<Float>(0, 0)
+        }
+        let delta = SIMD2<Double>(
+            pointerPosition.x - 0.5,
+            pointerPosition.y - 0.5
+        )
+        let offset = delta * parallaxDepth * 0.1
+        return SIMD2<Float>(
+            Float(min(max(offset.x, -0.05), 0.05)),
+            Float(min(max(offset.y, -0.05), 0.05))
+        )
+    }
+
+    private func copyUniforms(for pass: WPEPreparedRenderPass, layer: WPERenderLayer) -> WPECopyUniforms {
+        let vector = pass.uniformValues["g_PointerPosition"]?.vectorValue ?? [0.5, 0.5]
+        let pointer = SIMD2<Double>(
+            vector[safe: 0] ?? 0.5,
+            vector[safe: 1] ?? 0.5
+        )
+        return WPECopyUniforms(
+            uvOffset: Self.parallaxUVOffset(
+                pointerPosition: pointer,
+                parallaxDepth: layer.parallaxDepth
+            )
+        )
     }
 
     private func renderPipeline(fragmentName: String) throws -> MTLRenderPipelineState {

--- a/LiveWallpaper/Runtime/WPEMetalRuntimeUniforms.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRuntimeUniforms.swift
@@ -1,0 +1,194 @@
+import AppKit
+import Foundation
+import QuartzCore
+
+/// Per-frame WPE runtime uniforms produced by `WPEMetalFrameClock` and merged
+/// into prepared pass uniforms before the Metal executor runs. Built-in
+/// shaders ignore the entries they do not bind, so this layer can ship before
+/// the Phase 2D custom-shader translator consumes them.
+struct WPEMetalRuntimeUniforms: Equatable, Sendable {
+    let time: Double
+    let daytime: Double
+    let brightness: Double
+    let pointerPosition: SIMD2<Double>
+
+    static let zero = WPEMetalRuntimeUniforms(
+        time: 0,
+        daytime: 0,
+        brightness: 1,
+        pointerPosition: SIMD2<Double>(0.5, 0.5)
+    )
+
+    var uniformValues: [String: WPESceneShaderConstantValue] {
+        [
+            "g_Time": .number(time),
+            "g_Daytime": .number(daytime),
+            "g_Brightness": .number(brightness),
+            "g_PointerPosition": .vector([pointerPosition.x, pointerPosition.y])
+        ]
+    }
+}
+
+/// Deterministic clock for Metal frame uniforms. The closure-based
+/// `currentMediaTime` and `currentDate` make the type trivial to drive from
+/// fixtures while the default initializer falls back to `CACurrentMediaTime`
+/// and `Date()` for production.
+struct WPEMetalFrameClock: Sendable {
+    let loadTime: CFTimeInterval
+
+    private let currentMediaTime: @Sendable () -> CFTimeInterval
+    private let currentDate: @Sendable () -> Date
+    private let calendar: Calendar
+
+    init(
+        loadTime: CFTimeInterval = CACurrentMediaTime(),
+        currentMediaTime: @escaping @Sendable () -> CFTimeInterval = { CACurrentMediaTime() },
+        currentDate: @escaping @Sendable () -> Date = { Date() },
+        calendar: Calendar = .current
+    ) {
+        self.loadTime = loadTime
+        self.currentMediaTime = currentMediaTime
+        self.currentDate = currentDate
+        self.calendar = calendar
+    }
+
+    func runtimeUniforms(
+        profile: WallpaperPerformanceProfile,
+        pointerPosition: SIMD2<Double>
+    ) -> WPEMetalRuntimeUniforms {
+        let elapsed = max(currentMediaTime() - loadTime, 0)
+        let date = currentDate()
+        let components = calendar.dateComponents([.hour, .minute, .second], from: date)
+        let seconds = Double((components.hour ?? 0) * 3600 + (components.minute ?? 0) * 60 + (components.second ?? 0))
+        let daytime = min(max(seconds / 86_400, 0), 1)
+
+        return WPEMetalRuntimeUniforms(
+            time: elapsed,
+            daytime: daytime,
+            brightness: profile.metalBrightnessUniformValue,
+            pointerPosition: pointerPosition.clampedToUnitSquare
+        )
+    }
+}
+
+/// Pointer position sampler. `live` reads `NSEvent.mouseLocation` and maps it
+/// to the renderer view's UV space; `fixed` is for fixtures that need a
+/// known pointer position regardless of the cursor.
+@MainActor
+struct WPEMetalPointerSampler: Sendable {
+    let sample: @MainActor @Sendable (NSView) -> SIMD2<Double>
+
+    static let live = WPEMetalPointerSampler { view in
+        normalizedSceneUV(mouseLocation: NSEvent.mouseLocation, in: view)
+    }
+
+    static func fixed(_ uv: SIMD2<Double>) -> WPEMetalPointerSampler {
+        WPEMetalPointerSampler { _ in uv.clampedToUnitSquare }
+    }
+
+    static func normalizedSceneUV(mouseLocation: CGPoint, in view: NSView) -> SIMD2<Double> {
+        guard view.bounds.width > 0, view.bounds.height > 0 else {
+            return SIMD2<Double>(0.5, 0.5)
+        }
+
+        let localPoint: CGPoint
+        if let window = view.window {
+            let windowPoint = window.convertPoint(fromScreen: mouseLocation)
+            localPoint = view.convert(windowPoint, from: nil)
+        } else {
+            localPoint = view.convert(mouseLocation, from: nil)
+        }
+
+        let x = Double(localPoint.x / view.bounds.width)
+        let y = 1.0 - Double(localPoint.y / view.bounds.height)
+        return SIMD2<Double>(x, y).clampedToUnitSquare
+    }
+}
+
+/// Camera/projection uniforms produced from `general.orthogonalprojection` +
+/// the scene camera. Mirrors the WPE convention of a top-left origin so UV
+/// math stays consistent with the existing CGImage/SpriteKit paths.
+struct WPEMetalCameraUniforms: Equatable, Sendable {
+    let renderSize: CGSize
+    let viewProjectionMatrix: [Double]
+
+    static let identity = WPEMetalCameraUniforms(
+        renderSize: CGSize(width: 1, height: 1),
+        viewProjectionMatrix: [
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1
+        ]
+    )
+
+    init(
+        orthogonalProjection: WPESceneOrthogonalProjection,
+        sceneCamera: WPESceneCamera
+    ) {
+        let width = max(orthogonalProjection.width, 1)
+        let height = max(orthogonalProjection.height, 1)
+        renderSize = CGSize(width: width, height: height)
+        viewProjectionMatrix = Self.topLeftOrthographicMatrix(
+            width: Double(width),
+            height: Double(height),
+            nearZ: sceneCamera.nearZ,
+            farZ: sceneCamera.farZ
+        )
+    }
+
+    private init(renderSize: CGSize, viewProjectionMatrix: [Double]) {
+        self.renderSize = renderSize
+        self.viewProjectionMatrix = viewProjectionMatrix
+    }
+
+    var uniformValues: [String: WPESceneShaderConstantValue] {
+        [
+            "g_ViewProjectionMatrix": .vector(viewProjectionMatrix)
+        ]
+    }
+
+    private static func topLeftOrthographicMatrix(
+        width: Double,
+        height: Double,
+        nearZ: Double,
+        farZ: Double
+    ) -> [Double] {
+        let left = 0.0
+        let right = width
+        let top = 0.0
+        let bottom = height
+        let near = nearZ
+        let far = farZ == nearZ ? nearZ + 1 : farZ
+
+        return [
+            2.0 / (right - left), 0, 0, 0,
+            0, 2.0 / (top - bottom), 0, 0,
+            0, 0, 1.0 / (near - far), 0,
+            (left + right) / (left - right),
+            (top + bottom) / (bottom - top),
+            near / (near - far),
+            1
+        ]
+    }
+}
+
+extension WallpaperPerformanceProfile {
+    var metalBrightnessUniformValue: Double {
+        switch self {
+        case .quality:
+            return 1
+        case .suspended:
+            return 0
+        }
+    }
+}
+
+private extension SIMD2 where Scalar == Double {
+    var clampedToUnitSquare: SIMD2<Double> {
+        SIMD2<Double>(
+            min(max(x, 0), 1),
+            min(max(y, 0), 1)
+        )
+    }
+}

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -1,9 +1,12 @@
 import AppKit
 import MetalKit
 
-/// Wraps a texture-load failure with the requested asset path so the H1
-/// diagnostic mapper can blame the exact file, not the scene entry point.
+/// Wraps a texture-load failure with the requested asset path AND the WPE
+/// object/layer name that referenced it so the H1 diagnostic mapper can
+/// blame the exact file and surface the failing layer instead of falling
+/// back to the scene entry point.
 private struct WPEMetalTextureLoadContextError: Error {
+    let layerName: String
     let path: String
     let underlying: any Error
 }
@@ -19,6 +22,13 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
     private let executor: WPEMetalRenderExecutor
     private let textureLoader: WPEMetalTextureLoader
     private var outputTexture: MTLTexture?
+    private var loadedTextures: [String: MTLTexture] = [:]
+    private var sceneRenderSize: CGSize = CGSize(width: 1, height: 1)
+    private var cameraUniforms: WPEMetalCameraUniforms = .identity
+    private var frameClock: WPEMetalFrameClock
+    private let pointerSampler: WPEMetalPointerSampler
+    private let snapshotter: WPEMetalTextureSnapshotter
+    private var cachedSnapshot: NSImage?
     private var didLoad = false
     private var isThrottled = false
     private var currentProfile: WallpaperPerformanceProfile = .quality
@@ -27,7 +37,13 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
     private(set) var loadDiagnostics: SceneLoadDiagnostic?
     private(set) var renderGraph: WPERenderGraph?
     private(set) var renderPipeline: WPEPreparedRenderPipeline?
+    private(set) var lastRuntimeUniforms: WPEMetalRuntimeUniforms?
     var renderedTexture: MTLTexture? { outputTexture }
+    /// CGImage readback of the most recent rendered frame; populated at the
+    /// end of `performLoad()` so `WPESceneDetailView` can show a thumbnail
+    /// instead of falling into `.previewUnavailable`. Refreshed by `reload()`
+    /// and cleared by `cleanup()`.
+    var previewSnapshot: NSImage? { cachedSnapshot }
     var onProgress: (@MainActor (String) -> Void)?
 
     init(
@@ -35,7 +51,10 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         cacheRootURL: URL,
         dependencyMounts: [WPEAssetMount],
         frame: CGRect,
-        device: MTLDevice
+        device: MTLDevice,
+        frameClock: WPEMetalFrameClock = WPEMetalFrameClock(),
+        pointerSampler: WPEMetalPointerSampler = .live,
+        snapshotter: WPEMetalTextureSnapshotter = .shared
     ) throws {
         self.descriptor = descriptor
         self.cacheRootURL = cacheRootURL
@@ -48,6 +67,9 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         self.executor = try WPEMetalRenderExecutor(device: device)
         self.textureLoader = WPEMetalTextureLoader(device: device)
         self.mtkView = MTKView(frame: frame, device: device)
+        self.frameClock = frameClock
+        self.pointerSampler = pointerSampler
+        self.snapshotter = snapshotter
         super.init()
 
         mtkView.delegate = self
@@ -55,7 +77,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         mtkView.clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
         mtkView.preferredFramesPerSecond = SceneRenderingController.defaultPreferredFPS
         mtkView.autoresizingMask = [.width, .height]
-        mtkView.enableSetNeedsDisplay = true
+        mtkView.enableSetNeedsDisplay = false
         mtkView.isPaused = true
     }
 
@@ -98,21 +120,47 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
 
         renderGraph = graph
         renderPipeline = pipeline
-        let projection = document.general.orthogonalProjection
+        cameraUniforms = WPEMetalCameraUniforms(
+            orthogonalProjection: document.general.orthogonalProjection,
+            sceneCamera: document.camera
+        )
+        sceneRenderSize = cameraUniforms.renderSize
 
         onProgress?("Loading textures")
-        let textures = try loadTextures(for: pipeline)
+        loadedTextures = try await loadTextures(for: pipeline)
 
         onProgress?("Rendering scene")
-        outputTexture = try executor.render(
-            pipeline: pipeline,
-            size: CGSize(width: max(projection.width, 1), height: max(projection.height, 1)),
-            textures: textures
-        )
+        outputTexture = try renderCurrentFrame()
+        if let outputTexture {
+            cachedSnapshot = snapshotter.snapshot(from: outputTexture)
+        }
         hasPresentedFrame = true
         didLoad = true
         applyPerformanceProfile(currentProfile)
         mtkView.setNeedsDisplay(mtkView.bounds)
+    }
+
+    /// Computes one frame's runtime uniforms (clock, daytime, brightness,
+    /// pointer) and submits the render pipeline with both runtime and camera
+    /// uniforms. Called once during `performLoad()` and then per-frame from
+    /// `draw(in:)` so animated scenes refresh without rebuilding the
+    /// pipeline. `lastRuntimeUniforms` is exposed for tests.
+    private func renderCurrentFrame() throws -> MTLTexture {
+        guard let pipeline = renderPipeline else {
+            throw WPEMetalRenderExecutorError.noRenderablePasses
+        }
+        let uniforms = frameClock.runtimeUniforms(
+            profile: currentProfile,
+            pointerPosition: pointerSampler.sample(mtkView)
+        )
+        lastRuntimeUniforms = uniforms
+        return try executor.render(
+            pipeline: pipeline,
+            size: sceneRenderSize,
+            textures: loadedTextures,
+            runtimeUniforms: uniforms,
+            cameraUniforms: cameraUniforms
+        )
     }
 
     func reload() async throws {
@@ -122,6 +170,11 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         renderGraph = nil
         renderPipeline = nil
         loadDiagnostics = nil
+        loadedTextures = [:]
+        sceneRenderSize = CGSize(width: 1, height: 1)
+        cameraUniforms = .identity
+        lastRuntimeUniforms = nil
+        cachedSnapshot = nil
         try await load()
     }
 
@@ -137,14 +190,21 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         currentProfile = profile
         switch profile {
         case .quality:
-            mtkView.isPaused = false
+            // Phase 2B presents the cached `outputTexture` once per
+            // visibility change rather than re-rendering every display
+            // tick. Built-in shaders (solidcolor / genericimage / copy) do
+            // not consume `g_Time`, so the per-frame work would just burn
+            // GPU on a 6-display setup. Phase 2C/2D will re-enable
+            // continuous draw once GLSL translation lands and shaders
+            // actually use the runtime uniforms.
+            mtkView.isPaused = true
             mtkView.enableSetNeedsDisplay = true
             mtkView.preferredFramesPerSecond = isThrottled
                 ? SceneRenderingController.throttledPreferredFPS
                 : SceneRenderingController.defaultPreferredFPS
         case .suspended:
             mtkView.isPaused = true
-            mtkView.enableSetNeedsDisplay = false
+            mtkView.enableSetNeedsDisplay = true
             mtkView.releaseDrawables()
         }
     }
@@ -152,13 +212,16 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
     func cleanup() {
         mtkView.delegate = nil
         outputTexture = nil
+        loadedTextures = [:]
+        lastRuntimeUniforms = nil
+        cachedSnapshot = nil
     }
 
     nonisolated func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
 
     nonisolated func draw(in view: MTKView) {
         MainActor.assumeIsolated { [weak self] in
-            guard let self, let outputTexture else { return }
+            guard let self, didLoad, let outputTexture else { return }
             do {
                 if try executor.present(texture: outputTexture, in: view) {
                     SystemMonitor.shared.tickFrame()
@@ -169,32 +232,44 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         }
     }
 
-    private func loadTextures(for pipeline: WPEPreparedRenderPipeline) throws -> [String: MTLTexture] {
+    private func loadTextures(for pipeline: WPEPreparedRenderPipeline) async throws -> [String: MTLTexture] {
         var textures: [String: MTLTexture] = [:]
         for layer in pipeline.layers {
             if layer.passes.isEmpty {
-                try loadTexture(reference: .image(layer.graphLayer.imagePath), into: &textures)
+                try await loadTexture(
+                    reference: .image(layer.graphLayer.imagePath),
+                    layerName: layer.graphLayer.objectName,
+                    into: &textures
+                )
                 continue
             }
             for preparedPass in layer.passes {
                 for reference in requiredTextureReferences(for: preparedPass) {
-                    try loadTexture(reference: reference, into: &textures)
+                    try await loadTexture(
+                        reference: reference,
+                        layerName: layer.graphLayer.objectName,
+                        into: &textures
+                    )
                 }
             }
         }
         return textures
     }
 
-    private func loadTexture(reference: WPETextureReference, into textures: inout [String: MTLTexture]) throws {
+    private func loadTexture(
+        reference: WPETextureReference,
+        layerName: String,
+        into textures: inout [String: MTLTexture]
+    ) async throws {
         guard let path = externalTexturePath(for: reference), textures[path] == nil else {
             return
         }
         do {
-            textures[path] = try makeTexture(relativePath: path, label: "WPE texture \(path)")
+            textures[path] = try await makeTexture(relativePath: path, label: "WPE texture \(path)")
         } catch {
-            // Carry the asset path through so `diagnostic(for:)` can blame the
-            // exact texture instead of falling back to the scene entry file.
-            throw WPEMetalTextureLoadContextError(path: path, underlying: error)
+            // Carry the asset path AND layer name through so `diagnostic(for:)`
+            // can attribute the failure to the WPE object that referenced it.
+            throw WPEMetalTextureLoadContextError(layerName: layerName, path: path, underlying: error)
         }
     }
 
@@ -217,20 +292,20 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         return []
     }
 
-    private func makeTexture(relativePath: String, label: String) throws -> MTLTexture {
+    private func makeTexture(relativePath: String, label: String) async throws -> MTLTexture {
         var lastError: Error?
         for candidate in textureCandidates(for: relativePath) {
             do {
                 if shouldTryTexturePayload(candidate) {
                     do {
                         let payload = try resourceResolver.resolveTexturePayload(relativePath: candidate)
-                        return try textureLoader.makeTexture(from: payload, label: label)
+                        return try await textureLoader.makeTexture(from: payload, label: label)
                     } catch {
                         lastError = error
                     }
                 }
                 let image = try resourceResolver.resolveImage(relativePath: candidate)
-                return try textureLoader.makeTexture(from: image, label: label)
+                return try await textureLoader.makeTexture(from: image, label: label)
             } catch {
                 lastError = error
             }
@@ -297,61 +372,67 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
     }
 
     /// Maps any error raised during `performLoad()` onto the same
-    /// `SceneLoadDiagnostic` taxonomy `SceneRenderingController` populates, so
-    /// the SpriteKit and Metal backends report failures through one UI path.
-    /// `fallbackPath` carries an asset path through `WPEMetalTextureLoadContextError`
-    /// so missing-asset diagnostics blame the exact texture, not the scene
-    /// entry file. Layer attribution still uses `"scene"` — per-layer
-    /// granularity ships in Phase 2B.
+    /// `SceneLoadDiagnostic` taxonomy `SceneRenderingController` populates so
+    /// SpriteKit and Metal report failures through one UI path. The
+    /// `WPEMetalTextureLoadContextError` wrapper carries both the asset path
+    /// and the failing WPE object name through the recursion so missing-asset
+    /// diagnostics blame the exact layer instead of the generic scene entry.
     private func diagnostic(for error: Error) -> SceneLoadDiagnostic {
-        diagnostic(for: error, fallbackPath: nil)
+        diagnostic(for: error, fallbackPath: nil, layerName: "scene")
     }
 
-    private func diagnostic(for error: Error, fallbackPath: String?) -> SceneLoadDiagnostic {
-        let layer = "scene"
+    private func diagnostic(
+        for error: Error,
+        fallbackPath: String?,
+        layerName: String
+    ) -> SceneLoadDiagnostic {
         switch error {
         case let context as WPEMetalTextureLoadContextError:
-            return diagnostic(for: context.underlying, fallbackPath: context.path)
+            return diagnostic(
+                for: context.underlying,
+                fallbackPath: context.path,
+                layerName: context.layerName
+            )
         case let executorError as WPEMetalRenderExecutorError:
             switch executorError {
             case .unsupportedShader(let name):
-                return .materialUnresolved(layer: layer, reason: "Shader \"\(name)\" is not supported by the Metal renderer yet.")
+                return .materialUnresolved(layer: layerName, reason: "Shader \"\(name)\" is not supported by the Metal renderer yet.")
             case .unsupportedTarget:
-                return .materialUnresolved(layer: layer, reason: "This wallpaper uses an unsupported rendering target.")
+                return .materialUnresolved(layer: layerName, reason: "This wallpaper uses an unsupported rendering target.")
             case .missingTexture(let reference):
                 switch reference {
                 case .image(let path), .asset(let path), .fbo(let path):
-                    return .fileMissing(layer: layer, path: path)
+                    return .fileMissing(layer: layerName, path: path)
                 case .previous:
-                    return .materialUnresolved(layer: layer, reason: "Previous-frame effects (motion blur, feedback) are not yet supported.")
+                    return .materialUnresolved(layer: layerName, reason: "Previous-frame effects (motion blur, feedback) are not yet supported.")
                 }
             case .noRenderablePasses:
-                return .materialUnresolved(layer: layer, reason: "Scene contains no renderable passes.")
+                return .materialUnresolved(layer: layerName, reason: "Scene contains no renderable passes.")
             case .commandQueueUnavailable, .libraryUnavailable, .pipelineUnavailable, .commandBufferFailed:
-                return .other(layer: layer, message: executorError.errorDescription ?? "Metal renderer failed.")
+                return .other(layer: layerName, message: executorError.errorDescription ?? "Metal renderer failed.")
             }
         case let loaderError as WPEMetalTextureLoaderError:
             switch loaderError {
             case .unsupportedFormat, .unsupportedCompressedFormat, .malformedPayload, .textureAllocationFailed:
-                return .other(layer: layer, message: loaderError.errorDescription ?? "Texture upload failed.")
+                return .other(layer: layerName, message: loaderError.errorDescription ?? "Texture upload failed.")
             }
         case let resolveError as SceneResourceResolver.ResolveError:
             switch resolveError {
             case .fileMissing:
-                return .fileMissing(layer: layer, path: fallbackPath ?? descriptor.entryFile)
+                return .fileMissing(layer: layerName, path: fallbackPath ?? descriptor.entryFile)
             case .pathEscape:
-                return .crossPackageReference(layer: layer, path: fallbackPath ?? descriptor.entryFile)
+                return .crossPackageReference(layer: layerName, path: fallbackPath ?? descriptor.entryFile)
             case .materialUnresolved(let reason):
-                return .materialUnresolved(layer: layer, reason: reason)
+                return .materialUnresolved(layer: layerName, reason: reason)
             case .texture(let texError):
-                return .texture(layer: layer, error: texError)
+                return .texture(layer: layerName, error: texError)
             case .unsupportedTexture:
-                return .legacyUnsupportedTexture(layer: layer)
+                return .legacyUnsupportedTexture(layer: layerName)
             case .decodeFailed:
-                return .other(layer: layer, message: "A texture or image file is corrupted and cannot be decoded.")
+                return .other(layer: layerName, message: "A texture or image file is corrupted and cannot be decoded.")
             }
         default:
-            return .other(layer: layer, message: error.localizedDescription)
+            return .other(layer: layerName, message: error.localizedDescription)
         }
     }
 }

--- a/LiveWallpaper/Runtime/WPESceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPESceneRenderer.swift
@@ -13,6 +13,11 @@ protocol WPESceneRenderer: AnyObject, WallpaperPerformanceConfigurable {
     var renderGraph: WPERenderGraph? { get }
     var renderPipeline: WPEPreparedRenderPipeline? { get }
     var hasPresentedFrame: Bool { get }
+    /// Static thumbnail of the most recent rendered frame. `nil` until a
+    /// frame has been produced. SpriteKit reads back via
+    /// `bitmapImageRepForCachingDisplay`; Metal returns the cached snapshot
+    /// produced by Task 5 in Phase 2B.
+    var previewSnapshot: NSImage? { get }
 
     func load() async throws
     func reload() async throws

--- a/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
+++ b/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
@@ -10,6 +10,11 @@ struct WPESolidUniforms {
     float4 color;
 };
 
+struct WPECopyUniforms {
+    float2 uvOffset;
+    float2 padding;
+};
+
 vertex WPEVertexOut wpe_fullscreen_vertex(uint vertexID [[vertex_id]]) {
     float2 positions[4] = {
         float2(-1.0, -1.0),
@@ -39,8 +44,10 @@ fragment half4 wpe_solidcolor_fragment(
 
 fragment half4 wpe_copy_fragment(
     WPEVertexOut in [[stage_in]],
-    texture2d<half, access::sample> texture0 [[texture(0)]]
+    texture2d<half, access::sample> texture0 [[texture(0)]],
+    constant WPECopyUniforms& uniforms [[buffer(0)]]
 ) {
     constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
-    return texture0.sample(linearSampler, in.uv);
+    float2 uv = clamp(in.uv + uniforms.uvOffset, float2(0.0), float2(1.0));
+    return texture0.sample(linearSampler, uv);
 }

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
@@ -73,10 +73,15 @@ struct WPESceneDetailView: View {
             case .playing(let controller):
                 ScenePreviewContainer(controller: controller)
                     .aspectRatio(16.0 / 9.0, contentMode: .fit)
+            case .playingSnapshot(let image):
+                MetalSnapshotPreview(image: image)
             case .paused(let reason):
                 if let controller = session?.sceneController {
                     ScenePreviewContainer(controller: controller)
                         .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                        .overlay(pausedOverlay(reason: reason))
+                } else if let image = session?.sceneRenderer?.previewSnapshot {
+                    MetalSnapshotPreview(image: image)
                         .overlay(pausedOverlay(reason: reason))
                 } else {
                     fallbackBackground
@@ -332,11 +337,20 @@ struct WPESceneDetailView: View {
             state = .paused(reason: reduceMotion ? .reduceMotion : .throttled)
             return
         }
-        guard let controller = session.sceneController else {
-            state = .paused(reason: .previewUnavailable)
+        if let controller = session.sceneController {
+            state = .playing(controller)
             return
         }
-        state = .playing(controller)
+        // Phase 2B Task 5: Metal backend has a CGImage readback once load
+        // completes. Surface it as `.playingSnapshot` so the view shows the
+        // actual rendered scene instead of the static preview-unavailable
+        // card; only fall back to `.previewUnavailable` if the snapshot
+        // pipeline somehow returned nil (offscreen-only fixtures).
+        if let snapshot = renderer.previewSnapshot {
+            state = .playingSnapshot(snapshot)
+            return
+        }
+        state = .paused(reason: .previewUnavailable)
     }
 
     private func mapToFallbackReason(_ error: SceneRenderingError) -> FallbackReason {
@@ -388,41 +402,52 @@ struct WPESceneDetailView: View {
         // associated values (controller / fallback) compare poorly so we
         // map down to ints.
         switch state {
-        case .idle:    return 0
-        case .loading: return 1
-        case .playing: return 2
-        case .paused:  return 3
-        case .error:   return 4
+        case .idle:            return 0
+        case .loading:         return 1
+        case .playing:         return 2
+        case .playingSnapshot: return 2
+        case .paused:          return 3
+        case .error:           return 4
         }
     }
 
     private var stateLabel: String {
         switch state {
-        case .idle:    return "Idle"
-        case .loading: return "Loading"
-        case .playing: return "Playing"
-        case .paused:  return "Paused"
-        case .error:   return "Error"
+        case .idle:            return "Idle"
+        case .loading:         return "Loading"
+        case .playing:         return "Playing"
+        // Phase 2B: the Metal experimental backend renders one frame at
+        // load and pauses the displaylink, so the detail card shows a
+        // static thumbnail. Surface that explicitly so the user does not
+        // mistake a frozen frame for a hung renderer.
+        case .playingSnapshot: return "Static Preview"
+        case .paused:          return "Paused"
+        case .error:           return "Error"
         }
     }
 
     private var stateAccessibilityText: String {
         switch state {
-        case .idle:    return "Idle"
-        case .loading: return "Loading scene assets"
-        case .playing: return "Scene playing"
+        case .idle:            return "Idle"
+        case .loading:         return "Loading scene assets"
+        case .playing:         return "Scene playing"
+        case .playingSnapshot: return "Scene preview, static"
         case .paused(let reason): return "Paused, \(reason.label)"
-        case .error:   return "Scene cannot be played"
+        case .error:           return "Scene cannot be played"
         }
     }
 
     private var statusColor: Color {
         switch state {
-        case .playing: return .green
-        case .loading: return .yellow
-        case .paused:  return .orange
-        case .error:   return .red
-        case .idle:    return .secondary
+        case .playing:         return .green
+        // Distinguish the Metal static preview with a blue pill — green
+        // would imply "live" which is misleading until the per-frame
+        // readback timer ships in Phase 2C.
+        case .playingSnapshot: return .blue
+        case .loading:         return .yellow
+        case .paused:          return .orange
+        case .error:           return .red
+        case .idle:            return .secondary
         }
     }
 
@@ -445,6 +470,12 @@ enum SceneRenderState: Equatable {
     case idle
     case loading(progress: String?)
     case playing(SceneRenderingController)
+    /// Phase 2B Task 5: Metal-backed scene with a CGImage readback. The
+    /// SpriteKit live preview path stays on `.playing(controller)` because
+    /// `SKView` runs its own runloop; this case lets the detail view show
+    /// a static thumbnail for the Metal backend instead of falling through
+    /// to `.previewUnavailable`.
+    case playingSnapshot(NSImage)
     case paused(reason: PausedReason)
     case error(FallbackReason)
 
@@ -463,6 +494,7 @@ enum SceneRenderState: Equatable {
         case (.idle, .idle): return true
         case (.loading(let l), .loading(let r)): return l == r
         case (.playing(let lhsCtrl), .playing(let rhsCtrl)): return lhsCtrl === rhsCtrl
+        case (.playingSnapshot(let l), .playingSnapshot(let r)): return l === r
         case (.paused(let l), .paused(let r)): return l == r
         case (.error(let l), .error(let r)): return l == r
         default: return false
@@ -483,5 +515,31 @@ enum PausedReason: Equatable, Sendable {
         case .suspended:    return "Suspended"
         case .previewUnavailable: return "Preview Unavailable"
         }
+    }
+}
+
+// MARK: - Metal snapshot preview
+
+/// Static thumbnail for the Metal scene backend per the UX & Frontend Spec
+/// in `2026-05-05-wpe-phase2b-scene-runtime-hardening.md` §1. Honours the
+/// rendered texture's intrinsic aspect ratio (orthogonal projections are
+/// often square or portrait) and letterboxes inside the controlBackground
+/// fill so the card chrome stays consistent with the SpriteKit path.
+@MainActor
+private struct MetalSnapshotPreview: View {
+    let image: NSImage
+
+    var body: some View {
+        // Phase 2B Task 5 ships a one-shot static snapshot — no
+        // `.updatesFrequently` trait until the per-frame readback timer
+        // (Phase 2C) makes the image actually animate, otherwise VoiceOver
+        // would announce stale "updates" on a frozen frame.
+        Image(nsImage: image)
+            .resizable()
+            .interpolation(.medium)
+            .aspectRatio(contentMode: .fit)
+            .background(Color(nsColor: .controlBackgroundColor))
+            .accessibilityLabel("Scene preview snapshot")
+            .transition(.opacity)
     }
 }

--- a/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
+++ b/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
@@ -146,7 +146,7 @@ struct WPEMetalRenderExecutorTests {
     }
 }
 
-private struct Pixel {
+private struct Pixel: Equatable {
     let r: UInt8
     let g: UInt8
     let b: UInt8
@@ -270,13 +270,157 @@ private extension WPEMetalRenderExecutorTests {
         #expect(abs(Int(pixel.b) - 128) <= 3)
         #expect(pixel.a >= 250)
     }
+
+    @Test("Runtime clock uniforms do not change solidcolor built-in output")
+    func runtimeClockDoesNotChangeSolidColorOutput() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+        let pass = solidPass()
+        let pipeline = WPEPreparedRenderPipeline(layers: [
+            WPEPreparedRenderLayer(
+                graphLayer: graphLayer(pass: pass, parallaxDepth: 0),
+                passes: [
+                    WPEPreparedRenderPass(
+                        pass: pass,
+                        shader: WPEShaderProgram(
+                            name: "solidcolor",
+                            vertexSource: "",
+                            fragmentSource: "",
+                            isBuiltin: true
+                        ),
+                        textureBindings: [:],
+                        comboValues: [:],
+                        uniformValues: ["g_Color": .vector([0.5, 0.5, 0.5, 1])]
+                    )
+                ]
+            )
+        ])
+        let camera = WPEMetalCameraUniforms(
+            orthogonalProjection: WPESceneOrthogonalProjection(width: 4, height: 4, auto: true),
+            sceneCamera: .defaultCamera
+        )
+
+        let output0 = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 4, height: 4),
+            textures: [:],
+            runtimeUniforms: WPEMetalRuntimeUniforms(
+                time: 0,
+                daytime: 0,
+                brightness: 1,
+                pointerPosition: SIMD2<Double>(0.5, 0.5)
+            ),
+            cameraUniforms: camera
+        )
+        let output1 = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 4, height: 4),
+            textures: [:],
+            runtimeUniforms: WPEMetalRuntimeUniforms(
+                time: 1,
+                daytime: 0.5,
+                brightness: 1,
+                pointerPosition: SIMD2<Double>(0.9, 0.1)
+            ),
+            cameraUniforms: camera
+        )
+
+        #expect(try readPixel(output0, x: 2, y: 2) == readPixel(output1, x: 2, y: 2))
+    }
+
+    @Test("Generic image parallax offset is bounded by pointer delta and layer depth")
+    func genericImageParallaxOffsetIsBounded() throws {
+        let offset = WPEMetalRenderExecutor.parallaxUVOffset(
+            pointerPosition: SIMD2<Double>(1.5, 0.5),
+            parallaxDepth: 0.1
+        )
+
+        #expect(abs(offset.x - 0.01) < 0.0001)
+        #expect(abs(offset.y) < 0.0001)
+    }
+
+    @Test("Generic image copy path shifts samples when parallax depth is non-zero")
+    func genericImageCopyPathShiftsSamplesWithParallax() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        var bytes = Data()
+        for x in 0..<100 {
+            bytes.append(UInt8(x))
+            bytes.append(0)
+            bytes.append(0)
+            bytes.append(255)
+        }
+        let input = try makeRGBAInputTexture(device: device, width: 100, height: 1, bytes: bytes)
+        let pass = copyPass()
+        let layer = graphLayer(pass: pass, parallaxDepth: 0.1)
+        let pipeline = WPEPreparedRenderPipeline(layers: [
+            WPEPreparedRenderLayer(
+                graphLayer: layer,
+                passes: [
+                    WPEPreparedRenderPass(
+                        pass: pass,
+                        shader: WPEShaderProgram(
+                            name: "genericimage2",
+                            vertexSource: "",
+                            fragmentSource: "",
+                            isBuiltin: true
+                        ),
+                        textureBindings: [0: .image("materials/base.png")],
+                        comboValues: [:],
+                        uniformValues: [:]
+                    )
+                ]
+            )
+        ])
+
+        let camera = WPEMetalCameraUniforms(
+            orthogonalProjection: WPESceneOrthogonalProjection(width: 100, height: 1, auto: true),
+            sceneCamera: .defaultCamera
+        )
+        let baseline = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 100, height: 1),
+            textures: ["materials/base.png": input],
+            runtimeUniforms: WPEMetalRuntimeUniforms(
+                time: 0,
+                daytime: 0,
+                brightness: 1,
+                pointerPosition: SIMD2<Double>(0.5, 0.5)
+            ),
+            cameraUniforms: camera
+        )
+        let shifted = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 100, height: 1),
+            textures: ["materials/base.png": input],
+            runtimeUniforms: WPEMetalRuntimeUniforms(
+                time: 0,
+                daytime: 0,
+                brightness: 1,
+                pointerPosition: SIMD2<Double>(1.5, 0.5)
+            ),
+            cameraUniforms: camera
+        )
+
+        let baselinePixel = try readPixel(baseline, x: 50, y: 0)
+        let shiftedPixel = try readPixel(shifted, x: 50, y: 0)
+
+        #expect(shiftedPixel.r >= baselinePixel.r)
+        #expect(Int(shiftedPixel.r) - Int(baselinePixel.r) <= 10)
+    }
 }
 
-private func makeRGBAInputTexture(device: MTLDevice, bytes: Data) throws -> MTLTexture {
+private func makeRGBAInputTexture(
+    device: MTLDevice,
+    width: Int = 2,
+    height: Int = 2,
+    bytes: Data
+) throws -> MTLTexture {
     let descriptor = MTLTextureDescriptor.texture2DDescriptor(
         pixelFormat: .rgba8Unorm,
-        width: 2,
-        height: 2,
+        width: width,
+        height: height,
         mipmapped: false
     )
     descriptor.usage = [.shaderRead]
@@ -284,16 +428,16 @@ private func makeRGBAInputTexture(device: MTLDevice, bytes: Data) throws -> MTLT
     let texture = try #require(device.makeTexture(descriptor: descriptor))
     bytes.withUnsafeBytes { raw in
         texture.replace(
-            region: MTLRegionMake2D(0, 0, 2, 2),
+            region: MTLRegionMake2D(0, 0, width, height),
             mipmapLevel: 0,
             withBytes: raw.baseAddress!,
-            bytesPerRow: 8
+            bytesPerRow: width * 4
         )
     }
     return texture
 }
 
-private func graphLayer(pass: WPERenderPass) -> WPERenderLayer {
+private func graphLayer(pass: WPERenderPass, parallaxDepth: Double = 0) -> WPERenderLayer {
     WPERenderLayer(
         objectID: "layer",
         objectName: "Layer",
@@ -302,6 +446,7 @@ private func graphLayer(pass: WPERenderPass) -> WPERenderLayer {
         compositeA: "a",
         compositeB: "b",
         localFBOs: [],
-        passes: [pass]
+        passes: [pass],
+        parallaxDepth: parallaxDepth
     )
 }

--- a/LiveWallpaperTests/WPEMetalRuntimeUniformsTests.swift
+++ b/LiveWallpaperTests/WPEMetalRuntimeUniformsTests.swift
@@ -1,0 +1,164 @@
+import AppKit
+import QuartzCore
+import Testing
+@testable import LiveWallpaper
+
+@MainActor
+@Suite("WPE Metal runtime uniforms")
+struct WPEMetalRuntimeUniformsTests {
+
+    @Test("Frame clock computes time daytime brightness and pointer uniforms")
+    func frameClockComputesRuntimeUniforms() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let date = try #require(DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 5,
+            day: 5,
+            hour: 6,
+            minute: 30,
+            second: 0
+        ).date)
+
+        let clock = WPEMetalFrameClock(
+            loadTime: 10,
+            currentMediaTime: { 12.5 },
+            currentDate: { date },
+            calendar: calendar
+        )
+
+        let uniforms = clock.runtimeUniforms(
+            profile: .quality,
+            pointerPosition: SIMD2<Double>(0.25, 0.75)
+        )
+
+        #expect(abs(uniforms.time - 2.5) < 0.0001)
+        #expect(abs(uniforms.daytime - 0.2708333333) < 0.0001)
+        #expect(uniforms.brightness == 1)
+        #expect(uniforms.pointerPosition == SIMD2<Double>(0.25, 0.75))
+        #expect(uniforms.uniformValues["g_Time"]?.numberValue == 2.5)
+        #expect(uniforms.uniformValues["g_Brightness"]?.numberValue == 1)
+        #expect(uniforms.uniformValues["g_PointerPosition"]?.vectorValue == [0.25, 0.75])
+    }
+
+    @Test("Suspended profile maps brightness uniform to zero")
+    func suspendedProfileMapsBrightnessToZero() {
+        let uniforms = WPEMetalRuntimeUniforms(
+            time: 4,
+            daytime: 0.5,
+            brightness: WallpaperPerformanceProfile.suspended.metalBrightnessUniformValue,
+            pointerPosition: SIMD2<Double>(0.5, 0.5)
+        )
+
+        #expect(uniforms.brightness == 0)
+        #expect(uniforms.uniformValues["g_Brightness"]?.numberValue == 0)
+    }
+
+    @Test("Pointer sampler normalizes global mouse position to top-left scene UV")
+    func pointerSamplerNormalizesGlobalMousePosition() throws {
+        let window = NSWindow(
+            contentRect: CGRect(x: 100, y: 100, width: 200, height: 100),
+            styleMask: [],
+            backing: .buffered,
+            defer: false
+        )
+        let view = NSView(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
+        window.contentView = view
+
+        let uv = WPEMetalPointerSampler.normalizedSceneUV(
+            mouseLocation: CGPoint(x: 200, y: 125),
+            in: view
+        )
+
+        #expect(abs(uv.x - 0.5) < 0.0001)
+        #expect(abs(uv.y - 0.75) < 0.0001)
+    }
+
+    @Test("Orthographic camera uses scene projection dimensions")
+    func orthographicCameraUsesSceneProjectionDimensions() {
+        let projection = WPESceneOrthogonalProjection(width: 200, height: 100, auto: true)
+        let camera = WPEMetalCameraUniforms(
+            orthogonalProjection: projection,
+            sceneCamera: .defaultCamera
+        )
+
+        #expect(camera.renderSize == CGSize(width: 200, height: 100))
+        #expect(camera.viewProjectionMatrix.count == 16)
+        #expect(abs(camera.viewProjectionMatrix[0] - 0.01) < 0.0001)
+        #expect(abs(camera.viewProjectionMatrix[5] + 0.02) < 0.0001)
+        #expect(abs(camera.viewProjectionMatrix[12] + 1.0) < 0.0001)
+        #expect(abs(camera.viewProjectionMatrix[13] - 1.0) < 0.0001)
+    }
+
+    @Test("Prepared pipeline receives runtime and camera uniforms without losing material uniforms")
+    func preparedPipelineReceivesRuntimeAndCameraUniforms() {
+        let pass = WPERenderPass(
+            id: "solid.0",
+            phase: .material,
+            shader: "solidcolor",
+            source: .previous,
+            target: .scene,
+            textures: [:],
+            binds: [:],
+            constants: ["g_Color": .vector([1, 0, 0, 1])],
+            combos: [:],
+            blending: "normal",
+            cullMode: "nocull",
+            depthTest: "disabled",
+            depthWrite: "disabled"
+        )
+        let layer = WPERenderLayer(
+            objectID: "layer",
+            objectName: "Layer",
+            imagePath: "materials/base.png",
+            materialPath: nil,
+            compositeA: "a",
+            compositeB: "b",
+            localFBOs: [],
+            passes: [pass]
+        )
+        let pipeline = WPEPreparedRenderPipeline(layers: [
+            WPEPreparedRenderLayer(
+                graphLayer: layer,
+                passes: [
+                    WPEPreparedRenderPass(
+                        pass: pass,
+                        shader: WPEShaderProgram(
+                            name: "solidcolor",
+                            vertexSource: "",
+                            fragmentSource: "",
+                            isBuiltin: true
+                        ),
+                        textureBindings: [:],
+                        comboValues: [:],
+                        uniformValues: ["g_Color": .vector([1, 0, 0, 1])]
+                    )
+                ]
+            )
+        ])
+
+        let runtime = WPEMetalRuntimeUniforms(
+            time: 1,
+            daytime: 0.25,
+            brightness: 1,
+            pointerPosition: SIMD2<Double>(0.2, 0.8)
+        )
+        let camera = WPEMetalCameraUniforms(
+            orthogonalProjection: WPESceneOrthogonalProjection(width: 64, height: 32, auto: true),
+            sceneCamera: .defaultCamera
+        )
+
+        let prepared = pipeline.addingMetalRuntimeUniforms(runtime, camera: camera)
+        let values = prepared.layers[0].passes[0].uniformValues
+
+        #expect(values["g_Color"]?.vectorValue == [1, 0, 0, 1])
+        #expect(values["g_Time"]?.numberValue == 1)
+        #expect(values["g_Daytime"]?.numberValue == 0.25)
+        #expect(values["g_Brightness"]?.numberValue == 1)
+        #expect(values["g_PointerPosition"]?.vectorValue == [0.2, 0.8])
+        #expect(values["g_ViewProjectionMatrix"]?.vectorValue?.count == 16)
+    }
+}

--- a/LiveWallpaperTests/WPEMetalSceneRendererTests.swift
+++ b/LiveWallpaperTests/WPEMetalSceneRendererTests.swift
@@ -145,6 +145,97 @@ struct WPEMetalSceneRendererTests {
 
         #expect(renderer.loadDiagnostics == nil)
     }
+
+    @Test("Computes runtime uniforms from clock pointer and performance profile during load render")
+    func computesRuntimeUniformsDuringLoadRender() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try MetalSceneFixture.solidColorScene()
+        defer { fixture.cleanup() }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let date = try #require(DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 5,
+            day: 5,
+            hour: 12,
+            minute: 0,
+            second: 0
+        ).date)
+
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.root,
+            dependencyMounts: [],
+            frame: CGRect(x: 0, y: 0, width: 64, height: 64),
+            device: device,
+            frameClock: WPEMetalFrameClock(
+                loadTime: 100,
+                currentMediaTime: { 101.25 },
+                currentDate: { date },
+                calendar: calendar
+            ),
+            pointerSampler: .fixed(SIMD2<Double>(0.25, 0.75))
+        )
+        renderer.applyPerformanceProfile(.suspended)
+
+        try await renderer.load()
+
+        let uniforms = try #require(renderer.lastRuntimeUniforms)
+        #expect(abs(uniforms.time - 1.25) < 0.0001)
+        #expect(abs(uniforms.daytime - 0.5) < 0.0001)
+        #expect(uniforms.brightness == 0)
+        #expect(uniforms.pointerPosition == SIMD2<Double>(0.25, 0.75))
+    }
+
+    @Test("Loads preview snapshot from Metal offscreen output")
+    func loadsPreviewSnapshotFromMetalOutput() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try MetalSceneFixture.solidColorScene()
+        defer { fixture.cleanup() }
+
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.root,
+            dependencyMounts: [],
+            frame: CGRect(x: 0, y: 0, width: 64, height: 64),
+            device: device
+        )
+
+        try await renderer.load()
+
+        let snapshot = try #require(renderer.previewSnapshot)
+        #expect(snapshot.size.width == 64)
+        #expect(snapshot.size.height == 64)
+    }
+
+    @Test("Texture load failure attributes diagnostic to the WPE object name that referenced it")
+    func textureLoadDiagnosticsUseLayerObjectName() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try MetalSceneFixture.missingTextureScene()
+        defer { fixture.cleanup() }
+
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.root,
+            dependencyMounts: [],
+            frame: CGRect(x: 0, y: 0, width: 64, height: 64),
+            device: device
+        )
+
+        await #expect(throws: (any Error).self) {
+            try await renderer.load()
+        }
+
+        let diagnostic = try #require(renderer.loadDiagnostics)
+        #expect(diagnostic.layerName == "Hero Layer")
+        #expect(diagnostic.errorDescription.contains("Hero Layer"))
+        // The user-facing copy must avoid raw engineering jargon.
+        #expect(!diagnostic.errorDescription.lowercased().contains("texture"))
+        #expect(!diagnostic.errorDescription.lowercased().contains("shader"))
+    }
 }
 
 private struct MetalSceneFixture {
@@ -203,6 +294,45 @@ private struct MetalSceneFixture {
         try Data(#"{ "passes": [{ "shader": "genericimage2", "textures": ["materials/base.png"] }] }"#.utf8)
             .write(to: materials.appendingPathComponent("base.json"))
         try writeScene(imagePath: "models/base.json", to: root)
+        return MetalSceneFixture(
+            root: root,
+            descriptor: SceneDescriptor(
+                workshopID: UUID().uuidString,
+                cacheRelativePath: "wpe-cache/test",
+                entryFile: "scene.json",
+                capabilityTier: .imageOnly
+            ),
+            dependencyRoot: nil
+        )
+    }
+
+    static func missingTextureScene() throws -> MetalSceneFixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WPEMetalSceneRenderer-\(UUID().uuidString)", isDirectory: true)
+        let models = root.appendingPathComponent("models", isDirectory: true)
+        let materials = root.appendingPathComponent("materials", isDirectory: true)
+        try FileManager.default.createDirectory(at: models, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: materials, withIntermediateDirectories: true)
+        try Data(#"{ "material": "materials/missing-material.json" }"#.utf8)
+            .write(to: models.appendingPathComponent("hero.json"))
+        try Data(#"{ "passes": [{ "shader": "genericimage2", "textures": ["materials/missing.png"] }] }"#.utf8)
+            .write(to: materials.appendingPathComponent("missing-material.json"))
+        let scene = """
+        {
+          "camera": { "center": "0 0 0" },
+          "general": { "orthogonalprojection": { "width": 64, "height": 64, "auto": true } },
+          "objects": [{
+            "id": "hero",
+            "name": "Hero Layer",
+            "type": "image",
+            "image": "models/hero.json",
+            "origin": "0.5 0.5 0",
+            "scale": "1 1 1",
+            "alpha": 1
+          }]
+        }
+        """
+        try Data(scene.utf8).write(to: root.appendingPathComponent("scene.json"))
         return MetalSceneFixture(
             root: root,
             descriptor: SceneDescriptor(

--- a/LiveWallpaperTests/WPEMetalTextureLoaderTests.swift
+++ b/LiveWallpaperTests/WPEMetalTextureLoaderTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct WPEMetalTextureLoaderTests {
 
     @Test("Uploads RGBA texture payload into an MTLTexture")
-    func uploadsRGBA8888Payload() throws {
+    func uploadsRGBA8888Payload() async throws {
         let device = try #require(MTLCreateSystemDefaultDevice())
         let bytes = Data([
             255, 0, 0, 255,
@@ -30,7 +30,7 @@ struct WPEMetalTextureLoaderTests {
             hasAnimationFrames: false
         )
 
-        let texture = try WPEMetalTextureLoader(device: device).makeTexture(from: payload, label: "test-rgba")
+        let texture = try await WPEMetalTextureLoader(device: device).makeTexture(from: payload, label: "test-rgba")
 
         #expect(texture.width == 2)
         #expect(texture.height == 2)
@@ -40,7 +40,7 @@ struct WPEMetalTextureLoaderTests {
     }
 
     @Test("Rejects BC payload when current device cannot sample BC")
-    func rejectsBCWithoutDeviceSupport() throws {
+    func rejectsBCWithoutDeviceSupport() async throws {
         let device = try #require(MTLCreateSystemDefaultDevice())
         let payload = WPETexTexturePayload(
             info: WPETexInfo(
@@ -61,8 +61,123 @@ struct WPEMetalTextureLoaderTests {
             capabilities: WPEMetalTextureCapabilities(supportsBCTextureCompression: false)
         )
 
-        #expect(throws: WPEMetalTextureLoaderError.unsupportedCompressedFormat(.bc7)) {
-            _ = try loader.makeTexture(from: payload, label: "test-bc7")
+        await #expect(throws: WPEMetalTextureLoaderError.unsupportedCompressedFormat(.bc7)) {
+            _ = try await loader.makeTexture(from: payload, label: "test-bc7")
         }
+    }
+
+    @Test("Payload upload runs on the dedicated upload queue instead of the main thread")
+    @MainActor
+    func payloadUploadRunsOffMainThread() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let recorder = UploadThreadRecorder()
+        let queue = WPEMetalTextureUploadQueue(
+            label: "test.livewallpaper.upload.off-main",
+            maxConcurrentUploads: 1,
+            didStartUpload: { isMainThread in
+                recorder.append(isMainThread)
+            }
+        )
+        let loader = WPEMetalTextureLoader(device: device, uploadQueue: queue)
+        let payload = WPETexTexturePayload(
+            info: WPETexInfo(
+                containerVersion: 5,
+                infoVersion: 1,
+                width: 2,
+                height: 2,
+                textureFormatCode: WPETexFormat.rgba8888.rawValue,
+                format: .rgba8888,
+                mipmapCount: 1,
+                flags: 0
+            ),
+            mipmaps: [
+                WPETexTextureMipmap(
+                    index: 0,
+                    width: 2,
+                    height: 2,
+                    bytes: Data([
+                        255, 0, 0, 255,
+                        0, 255, 0, 255,
+                        0, 0, 255, 255,
+                        255, 255, 255, 255
+                    ])
+                )
+            ],
+            hasAnimationFrames: false
+        )
+
+        let texture = try await loader.makeTexture(from: payload, label: "test-rgba-off-main")
+
+        #expect(texture.width == 2)
+        #expect(recorder.snapshot() == [false])
+    }
+
+    @Test("Upload queue semaphore bounds concurrent upload operations")
+    func uploadQueueSemaphoreBoundsConcurrency() async throws {
+        let probe = UploadConcurrencyProbe()
+        let queue = WPEMetalTextureUploadQueue(
+            label: "test.livewallpaper.upload.semaphore",
+            maxConcurrentUploads: 1
+        )
+
+        async let first: Void = queue.perform {
+            probe.enter()
+            Thread.sleep(forTimeInterval: 0.05)
+            probe.leave()
+        }
+        async let second: Void = queue.perform {
+            probe.enter()
+            Thread.sleep(forTimeInterval: 0.05)
+            probe.leave()
+        }
+
+        try await first
+        try await second
+
+        #expect(probe.maximumConcurrentUploads == 1)
+    }
+}
+
+private final class UploadThreadRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Bool] = []
+
+    func append(_ value: Bool) {
+        lock.lock()
+        values.append(value)
+        lock.unlock()
+    }
+
+    func snapshot() -> [Bool] {
+        lock.lock()
+        let current = values
+        lock.unlock()
+        return current
+    }
+}
+
+private final class UploadConcurrencyProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var activeUploads = 0
+    private var maximum = 0
+
+    var maximumConcurrentUploads: Int {
+        lock.lock()
+        let value = maximum
+        lock.unlock()
+        return value
+    }
+
+    func enter() {
+        lock.lock()
+        activeUploads += 1
+        maximum = max(maximum, activeUploads)
+        lock.unlock()
+    }
+
+    func leave() {
+        lock.lock()
+        activeUploads -= 1
+        lock.unlock()
     }
 }

--- a/LiveWallpaperTests/WPERenderGraphBuilderTests.swift
+++ b/LiveWallpaperTests/WPERenderGraphBuilderTests.swift
@@ -227,6 +227,41 @@ struct WPERenderGraphBuilderTests {
         #expect(layer.passes[1].target == .scene)
     }
 
+    @Test("Render graph preserves image object parallax depth on layer")
+    func renderGraphPreservesParallaxDepth() throws {
+        let object = WPESceneImageObject(
+            id: "hero",
+            name: "Hero",
+            imageRelativePath: "materials/hero.png",
+            materialRelativePath: nil,
+            origin: SIMD3<Double>(0, 0, 0),
+            scale: SIMD3<Double>(1, 1, 1),
+            angles: SIMD3<Double>(0, 0, 0),
+            visible: true,
+            alpha: 1,
+            color: SIMD3<Double>(1, 1, 1),
+            brightness: 1,
+            blendMode: .normal,
+            alignment: .center,
+            size: nil,
+            effects: [],
+            animationLayers: [],
+            parallaxDepth: 0.2
+        )
+        let document = WPESceneDocument(
+            camera: .defaultCamera,
+            general: .defaultGeneral,
+            imageObjects: [object],
+            diagnostics: []
+        )
+
+        let graph = try WPERenderGraphBuilder(
+            cacheRootURL: FileManager.default.temporaryDirectory
+        ).build(document: document)
+
+        #expect(graph.layers.first?.parallaxDepth == 0.2)
+    }
+
     private func writeJSON(_ object: Any, to url: URL) throws {
         try FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(),

--- a/LiveWallpaperTests/WPESceneDocumentParserTests.swift
+++ b/LiveWallpaperTests/WPESceneDocumentParserTests.swift
@@ -254,4 +254,26 @@ struct WPESceneDocumentParserTests {
         #expect(animation.blend == 0.5)
         #expect(animation.animation == 9)
     }
+
+    @Test("Parses image parallax depth from scene object")
+    func parsesImageParallaxDepth() throws {
+        let json = """
+        {
+          "camera": { "center": "0 0 0" },
+          "general": { "orthogonalprojection": { "width": 100, "height": 50, "auto": true } },
+          "objects": [{
+            "id": "layer",
+            "name": "Layer",
+            "type": "image",
+            "image": "materials/base.png",
+            "parallaxDepth": 0.125
+          }]
+        }
+        """
+
+        let document = try WPESceneDocumentParser.parse(data: Data(json.utf8))
+        let object = try #require(document.imageObjects.first)
+
+        #expect(object.parallaxDepth == 0.125)
+    }
 }

--- a/LiveWallpaperTests/WPESceneRendererBoundaryTests.swift
+++ b/LiveWallpaperTests/WPESceneRendererBoundaryTests.swift
@@ -117,6 +117,7 @@ private final class FakeSceneRenderer: WPESceneRenderer {
     var renderGraph: WPERenderGraph?
     var renderPipeline: WPEPreparedRenderPipeline?
     var hasPresentedFrame = false
+    var previewSnapshot: NSImage?
     var nsView: NSView { view }
 
     func load() async throws {


### PR DESCRIPTION
## Summary

Brings the experimental Metal renderer to feature-parity with SpriteKit on every behaviour that does NOT require GLSL shader translation. Six tasks ship together because they share the same uniform/upload plumbing; later phases (2C-2I) consume this infrastructure.

| Task | Delivery |
|---|---|
| **Task 1** | `WPEMetalRuntimeUniforms` / `WPEMetalFrameClock` / `WPEMetalPointerSampler` / `WPEMetalCameraUniforms` + `WPESceneRenderer` protocol gains `previewSnapshot: NSImage?` |
| **Task 2** | `parallaxDepth` parsed + propagated; executor accepts runtime/camera uniforms; `WPECopyUniforms.uvOffset` (±0.05) wired through Metal copy fragment |
| **Task 3** | `WPEMetalSceneRenderer` injected `frameClock` + `pointerSampler`; computes uniforms once during `performLoad`; `lastRuntimeUniforms` exposed for tests |
| **Task 4** | `WPEMetalTextureUploadQueue` (DispatchQueue + DispatchSemaphore); loader async APIs |
| **Task 5** | `WPEMetalTextureSnapshotter` reads offscreen `MTLTexture` → `NSImage`; `WPESceneDetailView` adds `.playingSnapshot(NSImage)` + `MetalSnapshotPreview`; SpriteKit retains 16:9, Metal honours intrinsic ratio |
| **Task 6** | `WPEMetalTextureLoadContextError` carries WPE object name through diagnostics; `SceneLoadDiagnostic.errorDescription` rewritten to user-facing copy; `SceneWallpaperSession` propagates Metal taxonomy to `loadError` |

## Audit (Phase 5)

Both reviews ran via `/ccg:execute` parallel agents. All Critical/High findings addressed before this PR.

- **codex backend** (66/100 → addressed):
  - Critical: untracked new files → resolved by staging.
  - High: `SceneWallpaperSession` swallowed Metal diagnostics → now wraps as `.resourceFailed(diagnostic)` when `renderer.loadDiagnostics` is set.
  - High: per-frame `MainActor` re-render with `waitUntilCompleted` → reverted `draw(in:)` to present-only; per-frame uniform refresh deferred until Phase 2D ships shaders that actually consume `g_Time`.
  - Medium: runtime uniforms only filled missing keys → reserved keys now always overwrite.

- **gemini UX** (96/100 → addressed):
  - Medium: `.accessibilityAddTraits(.updatesFrequently)` on a static snapshot → removed.
  - Medium: static preview surfacing as "Playing" + green pill misled users → renamed to "Static Preview" with a blue pill until Phase 2C ships the per-frame readback timer.

## Tests

- 396/396 in 70 suites pass on M-series Macs (`xcodebuild ... -skip-testing:LiveWallpaperUITests`).
- Phase 2A targeted suites (texture mapper / loader / executor / scene renderer / boundary / payload / transcoder) stay green — zero regressions.
- Phase 2B targeted suites cover runtime uniforms, parallax math, off-main upload concurrency, snapshot extraction, layer-aware diagnostics, and reload reset semantics.

## Test plan

- [x] `xcodebuild test ... -skip-testing:LiveWallpaperUITests` passes
- [ ] Reviewer triggers Workshop scene with `parallaxDepth` and verifies subtle UV shift on cursor move (one-shot per-load only in Phase 2B)
- [ ] Reviewer opens experimental Metal backend and confirms detail view shows the rendered thumbnail with "Static Preview" pill instead of "Preview Unavailable"
- [ ] Reviewer triggers a missing-texture failure and confirms the diagnostic mentions the WPE object name

## Out of scope

- Custom GLSL shaders / FBO / particles / audio uniforms / web compatibility (Phase 2C-2I)
- Per-frame Metal readback timer (Phase 2C)
- Full WPE camera-parallax fidelity (Phase 2D)
- Layer attribution for executor-time errors (`unsupportedShader`, `unsupportedTarget`) — falls back to "scene" until Phase 2C plumbs layer context through the executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)