### PR TITLE
feat(wpe): Phase 2C multi-pass executor — FBO pool, blend, util shaders

### DIFF
--- a/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
@@ -104,16 +104,99 @@ private struct WPEShaderSourceLoader: Sendable {
     }
 
     private func builtinProgram(shaderName: String, combos: [String: Int]) -> WPEShaderProgram? {
-        if shaderName == "solidcolor" {
+        switch normalizedBuiltinShaderName(shaderName) {
+        case "solidcolor":
             return solidColorProgram(shaderName: shaderName, combos: combos)
-        }
-        if shaderName == "commands/copy" {
+        case "solidlayer":
+            return solidLayerProgram(shaderName: shaderName, combos: combos)
+        case "copy":
+            return copyProgram(shaderName: shaderName, combos: combos)
+        case "compose":
+            return composeProgram(shaderName: shaderName, combos: combos)
+        default:
+            guard isGenericImageShader(shaderName) else {
+                return nil
+            }
             return copyProgram(shaderName: shaderName, combos: combos)
         }
-        guard isGenericImageShader(shaderName) else {
-            return nil
+    }
+
+    private func normalizedBuiltinShaderName(_ shaderName: String) -> String {
+        let lower = shaderName.lowercased()
+        let withoutJSON = lower.hasSuffix(".json") ? String(lower.dropLast(5)) : lower
+        switch withoutJSON {
+        case "solidcolor":
+            return "solidcolor"
+        case "solidlayer", "materials/util/solidlayer", "models/util/solidlayer":
+            return "solidlayer"
+        case "copy", "commands/copy", "materials/util/copy":
+            return "copy"
+        case "compose", "materials/util/compose":
+            return "compose"
+        default:
+            return withoutJSON
         }
-        return copyProgram(shaderName: shaderName, combos: combos)
+    }
+
+    private func solidLayerProgram(shaderName: String, combos: [String: Int]) -> WPEShaderProgram {
+        let vertex = """
+        attribute vec3 a_Position;
+
+        void main() {
+            gl_Position = vec4(a_Position, 1.0);
+        }
+        """
+        let fragment = """
+        uniform vec4 g_Color;
+
+        void main() {
+            gl_FragColor = vec4(g_Color.rgb * g_Color.a, g_Color.a);
+        }
+        """
+        return WPEShaderProgram(
+            name: shaderName,
+            vertexSource: shaderPrelude(comboValues: combos, stage: .vertex) + vertex,
+            fragmentSource: shaderPrelude(comboValues: combos, stage: .fragment) + fragment.replacingOccurrences(
+                of: "gl_FragColor",
+                with: "out_FragColor"
+            ),
+            isBuiltin: true
+        )
+    }
+
+    private func composeProgram(shaderName: String, combos: [String: Int]) -> WPEShaderProgram {
+        let vertex = """
+        attribute vec3 a_Position;
+        attribute vec2 a_TexCoord;
+        varying vec2 v_TexCoord;
+
+        void main() {
+            gl_Position = vec4(a_Position, 1.0);
+            v_TexCoord = a_TexCoord;
+        }
+        """
+        let fragment = """
+        uniform sampler2D g_Texture0;
+        uniform sampler2D g_Texture1;
+        uniform vec4 g_Color;
+        varying vec2 v_TexCoord;
+
+        void main() {
+            vec4 a = texSample2D(g_Texture0, v_TexCoord);
+            vec4 b = texSample2D(g_Texture1, v_TexCoord);
+            vec4 composed = mix(a, b, b.a);
+            gl_FragColor = vec4(composed.rgb * g_Color.rgb, composed.a * g_Color.a);
+        }
+        """
+        return WPEShaderProgram(
+            name: shaderName,
+            vertexSource: shaderPrelude(comboValues: combos, stage: .vertex) + vertex,
+            fragmentSource: shaderPrelude(comboValues: combos, stage: .fragment) + fragment.replacingOccurrences(
+                of: "gl_FragColor",
+                with: "out_FragColor"
+            ),
+            isBuiltin: true
+        )
     }
 
     private func copyProgram(shaderName: String, combos: [String: Int]) -> WPEShaderProgram {

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -44,9 +44,103 @@ struct WPECopyUniforms {
     var padding: SIMD2<Float> = SIMD2<Float>(0, 0)
 }
 
+/// Logical identity for a render target during one `render(...)` call.
+/// `.scene` is the persistent output texture; `.named(_)` covers FBOs and
+/// layer composites resolved through the pool.
+private enum WPEMetalTargetID: Hashable {
+    case scene
+    case named(String)
+
+    init(target: WPERenderTarget) {
+        switch target {
+        case .scene:
+            self = .scene
+        case .fbo(let name), .layerComposite(let name):
+            self = .named(name)
+        }
+    }
+}
+
+/// Frame-local state carried through one render pass dispatch. Tracks the
+/// most recent texture written per logical target so `.previous` and
+/// `.fbo(name)` references resolve to live data, and so a new render pass
+/// can decide between `.clear` and `.load` for its color attachment.
+private struct WPEMetalFrameState {
+    let output: MTLTexture
+    let sceneSize: CGSize
+    var latestSceneTexture: MTLTexture?
+    var latestNamedTextures: [String: MTLTexture] = [:]
+    var writtenTargets: Set<WPEMetalTargetID> = []
+    /// Per-physical-texture init tracking. Phase 2C audit fix: ping-pong's
+    /// secondary texture is allocated lazily and may contain garbage on
+    /// first use. Tracking by texture identity (not target) lets us decide
+    /// whether `.load` is safe or whether we need `.clear` (or a blit-copy
+    /// from the previous primary) before rendering a same-target pass that
+    /// blends, culls, or rejects fragments via depth.
+    var initializedTextures: Set<ObjectIdentifier> = []
+    var depthTextures: [WPEMetalDepthTextureKey: MTLTexture] = [:]
+
+    func latestTexture(for targetID: WPEMetalTargetID) -> MTLTexture? {
+        switch targetID {
+        case .scene:
+            return latestSceneTexture
+        case .named(let name):
+            return latestNamedTextures[name]
+        }
+    }
+
+    mutating func registerWrite(texture: MTLTexture, targetID: WPEMetalTargetID) {
+        writtenTargets.insert(targetID)
+        initializedTextures.insert(ObjectIdentifier(texture))
+        switch targetID {
+        case .scene:
+            latestSceneTexture = texture
+        case .named(let name):
+            latestNamedTextures[name] = texture
+        }
+    }
+
+    mutating func markInitialized(_ texture: MTLTexture) {
+        initializedTextures.insert(ObjectIdentifier(texture))
+    }
+
+    func hasInitialized(_ texture: MTLTexture) -> Bool {
+        initializedTextures.contains(ObjectIdentifier(texture))
+    }
+
+    func hasWritten(_ targetID: WPEMetalTargetID) -> Bool {
+        writtenTargets.contains(targetID)
+    }
+}
+
+private struct WPEMetalPipelineKey: Hashable {
+    let fragmentName: String
+    let blendMode: String
+    let colorPixelFormat: MTLPixelFormat
+    /// Phase 2C audit fix: every PSO must declare the SAME depth attachment
+    /// format as the render pass that drives it. We default to `.invalid`
+    /// for non-depth passes so Metal's API validation does not fail when a
+    /// fullscreen copy without depth meets a pipeline that thought it had
+    /// `.depth32Float` attached.
+    let depthPixelFormat: MTLPixelFormat
+}
+
+private struct WPEMetalDepthKey: Hashable {
+    let depthTest: String
+    let depthWrite: String
+}
+
+/// Per-frame depth-texture identity. Keys by (target, exact size) so a
+/// scaled FBO's depth attachment matches its color attachment dimensions.
+private struct WPEMetalDepthTextureKey: Hashable {
+    let targetID: WPEMetalTargetID
+    let width: Int
+    let height: Int
+}
+
 final class WPEMetalRenderExecutor {
-    /// Phase 2A H3: every offscreen target and the on-screen swapchain share a
-    /// single sRGB pixel format so render pipelines built for the offscreen
+    /// Phase 2A H3: every offscreen target and the on-screen swapchain share
+    /// a single sRGB pixel format so render pipelines built for the offscreen
     /// pass can be reused by `present()` without re-creation, and so the
     /// rendered gamma matches the SpriteKit/CGImage fallback on the same
     /// scene fixture.
@@ -55,7 +149,9 @@ final class WPEMetalRenderExecutor {
     private let device: MTLDevice
     private let commandQueue: MTLCommandQueue
     private let library: MTLLibrary
-    private var pipelines: [String: MTLRenderPipelineState] = [:]
+    private let targetPool: WPEMetalRenderTargetPool
+    private var pipelines: [WPEMetalPipelineKey: MTLRenderPipelineState] = [:]
+    private var depthStates: [WPEMetalDepthKey: MTLDepthStencilState] = [:]
 
     init(device: MTLDevice) throws {
         guard let queue = device.makeCommandQueue() else {
@@ -67,6 +163,19 @@ final class WPEMetalRenderExecutor {
         self.device = device
         commandQueue = queue
         self.library = library
+        self.targetPool = WPEMetalRenderTargetPool(device: device)
+    }
+
+    var transientTargetTextureCountForTesting: Int {
+        targetPool.allocatedTextureCount
+    }
+
+    var pipelineStateCountForTesting: Int {
+        pipelines.count
+    }
+
+    func releaseTransientResources() {
+        targetPool.releaseAll()
     }
 
     func render(
@@ -82,20 +191,21 @@ final class WPEMetalRenderExecutor {
             throw WPEMetalRenderExecutorError.commandBufferFailed
         }
 
-        var shouldClear = true
+        targetPool.prepare(pipeline: preparedPipeline)
+        var frameState = WPEMetalFrameState(output: output, sceneSize: size)
         var didEncode = false
+
         for layer in preparedPipeline.layers {
             if layer.passes.isEmpty {
                 try encodeCopy(
                     reference: .image(layer.graphLayer.imagePath),
+                    target: .scene,
                     layer: layer.graphLayer,
                     runtimeUniforms: runtimeUniforms,
-                    output: output,
                     textures: textures,
                     commandBuffer: commandBuffer,
-                    shouldClear: shouldClear
+                    frameState: &frameState
                 )
-                shouldClear = false
                 didEncode = true
                 continue
             }
@@ -103,15 +213,14 @@ final class WPEMetalRenderExecutor {
                 try encode(
                     pass: pass,
                     layer: layer.graphLayer,
-                    output: output,
                     textures: textures,
                     commandBuffer: commandBuffer,
-                    shouldClear: shouldClear
+                    frameState: &frameState
                 )
-                shouldClear = false
                 didEncode = true
             }
         }
+
         guard didEncode else {
             throw WPEMetalRenderExecutorError.noRenderablePasses
         }
@@ -140,7 +249,11 @@ final class WPEMetalRenderExecutor {
         guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor) else {
             throw WPEMetalRenderExecutorError.commandBufferFailed
         }
-        encoder.setRenderPipelineState(try renderPipeline(fragmentName: "wpe_copy_fragment"))
+        encoder.setRenderPipelineState(try renderPipeline(
+            fragmentName: "wpe_copy_fragment",
+            blendMode: "disabled",
+            colorPixelFormat: drawable.texture.pixelFormat
+        ))
         encoder.setFragmentTexture(source, index: 0)
         var uniforms = WPECopyUniforms(uvOffset: SIMD2<Float>(0, 0))
         encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPECopyUniforms>.stride, index: 0)
@@ -155,56 +268,137 @@ final class WPEMetalRenderExecutor {
     private func encode(
         pass: WPEPreparedRenderPass,
         layer: WPERenderLayer,
-        output: MTLTexture,
         textures: [String: MTLTexture],
         commandBuffer: MTLCommandBuffer,
-        shouldClear: Bool
+        frameState: inout WPEMetalFrameState
     ) throws {
-        guard pass.pass.target == .scene else {
-            throw WPEMetalRenderExecutorError.unsupportedTarget(pass.pass.target)
+        let targetID = WPEMetalTargetID(target: pass.pass.target)
+        let previousTextureForTarget = frameState.latestTexture(for: targetID)
+        let readsCurrentTarget = passReadsCurrentTarget(pass, targetID: targetID)
+        let destination = try targetTexture(
+            for: pass.pass.target,
+            layer: layer,
+            frameState: &frameState,
+            avoiding: readsCurrentTarget ? previousTextureForTarget : nil
+        )
+
+        // Phase 2C audit fix: when ping-pong allocates a fresh secondary
+        // texture for `.previous`, copy the prior contents in so blend /
+        // cull / depth-rejected fragments do not see uninitialised memory.
+        if readsCurrentTarget,
+           let previousTextureForTarget,
+           ObjectIdentifier(previousTextureForTarget) != ObjectIdentifier(destination.texture),
+           !frameState.hasInitialized(destination.texture) {
+            try copyTexture(
+                previousTextureForTarget,
+                to: destination.texture,
+                commandBuffer: commandBuffer
+            )
+            frameState.markInitialized(destination.texture)
         }
 
+        let needsDepth = needsDepthAttachment(pass: pass)
+
         let descriptor = MTLRenderPassDescriptor()
-        descriptor.colorAttachments[0].texture = output
-        descriptor.colorAttachments[0].loadAction = shouldClear ? .clear : .load
+        descriptor.colorAttachments[0].texture = destination.texture
+        descriptor.colorAttachments[0].loadAction = frameState.hasInitialized(destination.texture) ? .load : .clear
         descriptor.colorAttachments[0].storeAction = .store
         descriptor.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
+
+        if needsDepth {
+            let depth = try depthTexture(for: destination, frameState: &frameState)
+            descriptor.depthAttachment.texture = depth
+            descriptor.depthAttachment.loadAction = frameState.hasInitialized(destination.texture) ? .load : .clear
+            descriptor.depthAttachment.storeAction = .store
+            descriptor.depthAttachment.clearDepth = 1
+        }
 
         guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor) else {
             throw WPEMetalRenderExecutorError.commandBufferFailed
         }
         defer { encoder.endEncoding() }
 
-        if pass.pass.shader == "solidcolor" {
-            encoder.setRenderPipelineState(try renderPipeline(fragmentName: "wpe_solidcolor_fragment"))
-            var uniforms = WPESolidUniforms(color: colorVector(for: pass))
-            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPESolidUniforms>.stride, index: 0)
-        } else if pass.pass.shader == "commands/copy" || pass.pass.shader.hasPrefix("genericimage") {
-            encoder.setRenderPipelineState(try renderPipeline(fragmentName: "wpe_copy_fragment"))
-            let reference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
-            let texture = try resolve(reference: reference, textures: textures)
-            var uniforms = copyUniforms(for: pass, layer: layer)
-            encoder.setFragmentTexture(texture, index: 0)
-            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPECopyUniforms>.stride, index: 0)
-        } else {
-            throw WPEMetalRenderExecutorError.unsupportedShader(pass.pass.shader)
-        }
+        encoder.setFrontFacing(.counterClockwise)
+        encoder.setCullMode(cullMode(for: pass.pass.cullMode))
+        encoder.setDepthStencilState(depthStencilState(
+            depthTest: pass.pass.depthTest,
+            depthWrite: pass.pass.depthWrite
+        ))
+
+        let resolvedTextures = WPEMetalResolvedShaderInputs(executor: self)
+        try resolvedTextures.dispatch(
+            pass: pass,
+            layer: layer,
+            destination: destination,
+            textures: textures,
+            frameState: frameState,
+            encoder: encoder,
+            depthPixelFormat: needsDepth ? .depth32Float : .invalid
+        )
 
         encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        frameState.registerWrite(texture: destination.texture, targetID: destination.id)
+    }
+
+    /// Phase 2C audit fix: blit-copies a prior physical texture into the
+    /// pool's secondary slot so ping-pong renders that blend or depth-test
+    /// have a defined source to load.
+    private func copyTexture(
+        _ source: MTLTexture,
+        to destination: MTLTexture,
+        commandBuffer: MTLCommandBuffer
+    ) throws {
+        guard let blit = commandBuffer.makeBlitCommandEncoder() else {
+            throw WPEMetalRenderExecutorError.commandBufferFailed
+        }
+        blit.copy(
+            from: source,
+            sourceSlice: 0,
+            sourceLevel: 0,
+            sourceOrigin: MTLOrigin(),
+            sourceSize: MTLSize(width: destination.width, height: destination.height, depth: 1),
+            to: destination,
+            destinationSlice: 0,
+            destinationLevel: 0,
+            destinationOrigin: MTLOrigin()
+        )
+        blit.endEncoding()
     }
 
     private func encodeCopy(
         reference: WPETextureReference,
+        target: WPERenderTarget,
         layer: WPERenderLayer,
         runtimeUniforms: WPEMetalRuntimeUniforms,
-        output: MTLTexture,
         textures: [String: MTLTexture],
         commandBuffer: MTLCommandBuffer,
-        shouldClear: Bool
+        frameState: inout WPEMetalFrameState
     ) throws {
+        let targetID = WPEMetalTargetID(target: target)
+        let previousTextureForTarget = frameState.latestTexture(for: targetID)
+        let readsCurrentTarget = reference == .previous
+        let destination = try targetTexture(
+            for: target,
+            layer: layer,
+            frameState: &frameState,
+            avoiding: readsCurrentTarget ? previousTextureForTarget : nil
+        )
+
+        if readsCurrentTarget,
+           let previousTextureForTarget,
+           ObjectIdentifier(previousTextureForTarget) != ObjectIdentifier(destination.texture),
+           !frameState.hasInitialized(destination.texture) {
+            try copyTexture(
+                previousTextureForTarget,
+                to: destination.texture,
+                commandBuffer: commandBuffer
+            )
+            frameState.markInitialized(destination.texture)
+        }
+
         let descriptor = MTLRenderPassDescriptor()
-        descriptor.colorAttachments[0].texture = output
-        descriptor.colorAttachments[0].loadAction = shouldClear ? .clear : .load
+        descriptor.colorAttachments[0].texture = destination.texture
+        descriptor.colorAttachments[0].loadAction = frameState.hasInitialized(destination.texture) ? .load : .clear
         descriptor.colorAttachments[0].storeAction = .store
         descriptor.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
 
@@ -213,8 +407,23 @@ final class WPEMetalRenderExecutor {
         }
         defer { encoder.endEncoding() }
 
-        encoder.setRenderPipelineState(try renderPipeline(fragmentName: "wpe_copy_fragment"))
-        encoder.setFragmentTexture(try resolve(reference: reference, textures: textures), index: 0)
+        encoder.setFrontFacing(.counterClockwise)
+        encoder.setCullMode(.none)
+
+        encoder.setRenderPipelineState(try renderPipeline(
+            fragmentName: "wpe_copy_fragment",
+            blendMode: "disabled",
+            colorPixelFormat: destination.texture.pixelFormat
+        ))
+        encoder.setFragmentTexture(
+            try resolve(
+                reference: reference,
+                textures: textures,
+                frameState: frameState,
+                currentTargetID: destination.id
+            ),
+            index: 0
+        )
         var uniforms = WPECopyUniforms(
             uvOffset: Self.parallaxUVOffset(
                 pointerPosition: runtimeUniforms.pointerPosition,
@@ -223,6 +432,7 @@ final class WPEMetalRenderExecutor {
         )
         encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPECopyUniforms>.stride, index: 0)
         encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        frameState.registerWrite(texture: destination.texture, targetID: destination.id)
     }
 
     /// Conservative WPE mouse-parallax model. The shader receives a UV
@@ -248,7 +458,7 @@ final class WPEMetalRenderExecutor {
         )
     }
 
-    private func copyUniforms(for pass: WPEPreparedRenderPass, layer: WPERenderLayer) -> WPECopyUniforms {
+    fileprivate func copyUniforms(for pass: WPEPreparedRenderPass, layer: WPERenderLayer) -> WPECopyUniforms {
         let vector = pass.uniformValues["g_PointerPosition"]?.vectorValue ?? [0.5, 0.5]
         let pointer = SIMD2<Double>(
             vector[safe: 0] ?? 0.5,
@@ -262,10 +472,23 @@ final class WPEMetalRenderExecutor {
         )
     }
 
-    private func renderPipeline(fragmentName: String) throws -> MTLRenderPipelineState {
-        if let cached = pipelines[fragmentName] {
+    fileprivate func renderPipeline(
+        fragmentName: String,
+        blendMode: String = "disabled",
+        colorPixelFormat: MTLPixelFormat = WPEMetalRenderExecutor.outputPixelFormat,
+        depthPixelFormat: MTLPixelFormat = .invalid
+    ) throws -> MTLRenderPipelineState {
+        let normalizedBlend = blendMode.lowercased()
+        let key = WPEMetalPipelineKey(
+            fragmentName: fragmentName,
+            blendMode: normalizedBlend,
+            colorPixelFormat: colorPixelFormat,
+            depthPixelFormat: depthPixelFormat
+        )
+        if let cached = pipelines[key] {
             return cached
         }
+
         guard let vertex = library.makeFunction(name: "wpe_fullscreen_vertex"),
               let fragment = library.makeFunction(name: fragmentName) else {
             throw WPEMetalRenderExecutorError.pipelineUnavailable(fragmentName)
@@ -274,11 +497,159 @@ final class WPEMetalRenderExecutor {
         let descriptor = MTLRenderPipelineDescriptor()
         descriptor.vertexFunction = vertex
         descriptor.fragmentFunction = fragment
-        descriptor.colorAttachments[0].pixelFormat = Self.outputPixelFormat
+        descriptor.colorAttachments[0].pixelFormat = colorPixelFormat
+        descriptor.depthAttachmentPixelFormat = depthPixelFormat
+        applyBlendMode(normalizedBlend, to: descriptor.colorAttachments[0]!)
 
         let state = try device.makeRenderPipelineState(descriptor: descriptor)
-        pipelines[fragmentName] = state
+        pipelines[key] = state
         return state
+    }
+
+    private func applyBlendMode(
+        _ mode: String,
+        to attachment: MTLRenderPipelineColorAttachmentDescriptor
+    ) {
+        switch mode {
+        case "disabled":
+            attachment.isBlendingEnabled = false
+
+        case "additive":
+            attachment.isBlendingEnabled = true
+            attachment.rgbBlendOperation = .add
+            attachment.alphaBlendOperation = .add
+            attachment.sourceRGBBlendFactor = .sourceAlpha
+            attachment.destinationRGBBlendFactor = .one
+            attachment.sourceAlphaBlendFactor = .one
+            attachment.destinationAlphaBlendFactor = .one
+
+        case "multiply":
+            // WPE multiply preserves the destination alpha (OpenGL convention).
+            // RGB = src.rgb * dst.rgb; alpha = dst.alpha.
+            attachment.isBlendingEnabled = true
+            attachment.rgbBlendOperation = .add
+            attachment.alphaBlendOperation = .add
+            attachment.sourceRGBBlendFactor = .destinationColor
+            attachment.destinationRGBBlendFactor = .zero
+            attachment.sourceAlphaBlendFactor = .zero
+            attachment.destinationAlphaBlendFactor = .one
+
+        case "translucent":
+            attachment.isBlendingEnabled = true
+            attachment.rgbBlendOperation = .add
+            attachment.alphaBlendOperation = .add
+            attachment.sourceRGBBlendFactor = .one
+            attachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
+            attachment.sourceAlphaBlendFactor = .one
+            attachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
+
+        case "normalmapped", "normal":
+            fallthrough
+
+        default:
+            attachment.isBlendingEnabled = true
+            attachment.rgbBlendOperation = .add
+            attachment.alphaBlendOperation = .add
+            attachment.sourceRGBBlendFactor = .sourceAlpha
+            attachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
+            attachment.sourceAlphaBlendFactor = .one
+            attachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
+        }
+    }
+
+    private func cullMode(for raw: String) -> MTLCullMode {
+        switch raw.lowercased() {
+        case "back":
+            return .back
+        case "front":
+            return .front
+        default:
+            return .none
+        }
+    }
+
+    private func needsDepthAttachment(pass: WPEPreparedRenderPass) -> Bool {
+        pass.pass.depthWrite.lowercased() == "enabled"
+            || pass.pass.depthWrite.lowercased() == "true"
+            || pass.pass.depthTest.lowercased() != "disabled"
+    }
+
+    private func makeDepthTexture(width: Int, height: Int) throws -> MTLTexture {
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .depth32Float,
+            width: max(width, 1),
+            height: max(height, 1),
+            mipmapped: false
+        )
+        descriptor.usage = [.renderTarget]
+        descriptor.storageMode = .private
+
+        guard let texture = device.makeTexture(descriptor: descriptor) else {
+            throw WPEMetalTextureLoaderError.textureAllocationFailed
+        }
+        texture.label = "WPE Metal executor depth"
+        return texture
+    }
+
+    /// Phase 2C audit fix: depth textures key on (target, exact destination
+    /// dimensions) so a scaled FBO's depth attachment matches its color
+    /// attachment dimensions instead of being stuck at scene size.
+    private func depthTexture(
+        for destination: (id: WPEMetalTargetID, texture: MTLTexture),
+        frameState: inout WPEMetalFrameState
+    ) throws -> MTLTexture {
+        let key = WPEMetalDepthTextureKey(
+            targetID: destination.id,
+            width: destination.texture.width,
+            height: destination.texture.height
+        )
+        if let existing = frameState.depthTextures[key] {
+            return existing
+        }
+        let texture = try makeDepthTexture(width: key.width, height: key.height)
+        frameState.depthTextures[key] = texture
+        return texture
+    }
+
+    private func depthStencilState(depthTest: String, depthWrite: String) -> MTLDepthStencilState {
+        let key = WPEMetalDepthKey(
+            depthTest: depthTest.lowercased(),
+            depthWrite: depthWrite.lowercased()
+        )
+        if let cached = depthStates[key] {
+            return cached
+        }
+
+        let descriptor = MTLDepthStencilDescriptor()
+        descriptor.depthCompareFunction = depthCompareFunction(for: key.depthTest)
+        descriptor.isDepthWriteEnabled = key.depthWrite == "enabled" || key.depthWrite == "true"
+
+        let state = device.makeDepthStencilState(descriptor: descriptor)!
+        depthStates[key] = state
+        return state
+    }
+
+    private func depthCompareFunction(for raw: String) -> MTLCompareFunction {
+        switch raw.lowercased() {
+        case "always":
+            return .always
+        case "never":
+            return .never
+        case "less":
+            return .less
+        case "lequal", "lessequal", "less_equal":
+            return .lessEqual
+        case "greater":
+            return .greater
+        case "gequal", "greaterequal", "greater_equal":
+            return .greaterEqual
+        case "equal":
+            return .equal
+        case "notequal", "not_equal":
+            return .notEqual
+        default:
+            return .always
+        }
     }
 
     private func makeOutputTexture(size: CGSize) throws -> MTLTexture {
@@ -297,12 +668,33 @@ final class WPEMetalRenderExecutor {
         return texture
     }
 
-    private func colorVector(for pass: WPEPreparedRenderPass) -> SIMD4<Float> {
+    private func targetTexture(
+        for target: WPERenderTarget,
+        layer: WPERenderLayer,
+        frameState: inout WPEMetalFrameState,
+        avoiding textureToAvoid: MTLTexture? = nil
+    ) throws -> (id: WPEMetalTargetID, texture: MTLTexture) {
+        let targetID = WPEMetalTargetID(target: target)
+        switch target {
+        case .scene:
+            return (targetID, frameState.output)
+        case .fbo, .layerComposite:
+            let texture = try targetPool.texture(
+                for: target,
+                layer: layer,
+                sceneSize: frameState.sceneSize,
+                avoiding: textureToAvoid
+            )
+            return (targetID, texture)
+        }
+    }
+
+    fileprivate func colorVector(for pass: WPEPreparedRenderPass) -> SIMD4<Float> {
         // WPE scene JSON authors `g_Color` in sRGB perceptual space ("0.5 0.5
-        // 0.5" → mid-gray on screen). The render target is sRGB-tagged, so the
-        // hardware applies linear→sRGB encode on store; we therefore must feed
-        // the shader linear-space RGB. Alpha stays unchanged — Metal does not
-        // gamma-encode the alpha channel on sRGB targets.
+        // 0.5" → mid-gray on screen). The render target is sRGB-tagged, so
+        // the hardware applies linear→sRGB encode on store; we therefore
+        // must feed the shader linear-space RGB. Alpha stays unchanged —
+        // Metal does not gamma-encode the alpha channel on sRGB targets.
         let vector = pass.uniformValues["g_Color"]?.vectorValue
             ?? pass.pass.constants["g_Color"]?.vectorValue
             ?? [1, 1, 1, 1]
@@ -323,15 +715,168 @@ final class WPEMetalRenderExecutor {
         return Float(pow(Double((clamped + 0.055) / 1.055), 2.4))
     }
 
-    private func resolve(reference: WPETextureReference, textures: [String: MTLTexture]) throws -> MTLTexture {
+    fileprivate func resolve(
+        reference: WPETextureReference,
+        textures: [String: MTLTexture],
+        frameState: WPEMetalFrameState,
+        currentTargetID: WPEMetalTargetID
+    ) throws -> MTLTexture {
         switch reference {
-        case .image(let path), .asset(let path), .fbo(let path):
+        case .image(let path), .asset(let path):
             guard let texture = textures[path] else {
                 throw WPEMetalRenderExecutorError.missingTexture(reference)
             }
             return texture
+
+        case .fbo(let name):
+            guard let texture = frameState.latestNamedTextures[name] else {
+                throw WPEMetalRenderExecutorError.missingTexture(reference)
+            }
+            return texture
+
         case .previous:
-            throw WPEMetalRenderExecutorError.missingTexture(reference)
+            guard let texture = frameState.latestTexture(for: currentTargetID) else {
+                throw WPEMetalRenderExecutorError.missingTexture(reference)
+            }
+            return texture
+        }
+    }
+
+    private func passReadsCurrentTarget(_ pass: WPEPreparedRenderPass, targetID: WPEMetalTargetID) -> Bool {
+        textureReferences(for: pass).contains { reference in
+            switch (reference, targetID) {
+            case (.previous, _):
+                return true
+            case (.fbo(let name), .named(let targetName)):
+                return name == targetName
+            default:
+                return false
+            }
+        }
+    }
+
+    private func textureReferences(for pass: WPEPreparedRenderPass) -> [WPETextureReference] {
+        var references: [WPETextureReference] = [pass.pass.source]
+        references.append(contentsOf: pass.pass.textures.values)
+        references.append(contentsOf: pass.pass.binds.values)
+        references.append(contentsOf: pass.textureBindings.values)
+        return references
+    }
+
+    /// Maps the WPE shader name onto one of the executor's built-in fragment
+    /// functions. Phase 2C recognises `solidcolor`, `solidlayer`, `copy`,
+    /// `compose`, and `genericimage*` aliases (with or without the
+    /// `materials/util/` prefix and `.json` suffix). Custom shaders still
+    /// throw `unsupportedShader` until Phase 2D ships GLSL translation.
+    fileprivate func normalizedBuiltinShaderName(_ shaderName: String) -> String {
+        let lower = shaderName.lowercased()
+        let withoutJSON = lower.hasSuffix(".json") ? String(lower.dropLast(5)) : lower
+        switch withoutJSON {
+        case "solidcolor":
+            return "solidcolor"
+        case "solidlayer", "materials/util/solidlayer", "models/util/solidlayer":
+            return "solidlayer"
+        case "copy", "commands/copy", "materials/util/copy":
+            return "copy"
+        case "compose", "materials/util/compose":
+            return "compose"
+        default:
+            if withoutJSON.hasPrefix("genericimage") {
+                return "copy"
+            }
+            return withoutJSON
+        }
+    }
+}
+
+/// Dispatches a prepared pass onto the right Metal pipeline state and
+/// fragment uniforms. Extracted so the dispatch logic can stay readable
+/// while sharing access to the executor's pipeline cache, color uniforms,
+/// and texture resolution helpers.
+private struct WPEMetalResolvedShaderInputs {
+    let executor: WPEMetalRenderExecutor
+
+    func dispatch(
+        pass: WPEPreparedRenderPass,
+        layer: WPERenderLayer,
+        destination: (id: WPEMetalTargetID, texture: MTLTexture),
+        textures: [String: MTLTexture],
+        frameState: WPEMetalFrameState,
+        encoder: MTLRenderCommandEncoder,
+        depthPixelFormat: MTLPixelFormat
+    ) throws {
+        switch executor.normalizedBuiltinShaderName(pass.pass.shader) {
+        case "solidcolor":
+            encoder.setRenderPipelineState(try executor.renderPipeline(
+                fragmentName: "wpe_solidcolor_fragment",
+                blendMode: pass.pass.blending,
+                colorPixelFormat: destination.texture.pixelFormat,
+                depthPixelFormat: depthPixelFormat
+            ))
+            var uniforms = WPESolidUniforms(color: executor.colorVector(for: pass))
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPESolidUniforms>.stride, index: 0)
+
+        case "solidlayer":
+            encoder.setRenderPipelineState(try executor.renderPipeline(
+                fragmentName: "wpe_solidlayer_fragment",
+                blendMode: pass.pass.blending,
+                colorPixelFormat: destination.texture.pixelFormat,
+                depthPixelFormat: depthPixelFormat
+            ))
+            var uniforms = WPESolidUniforms(color: executor.colorVector(for: pass))
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPESolidUniforms>.stride, index: 0)
+
+        case "copy":
+            let fragmentName = pass.pass.shader == "commands/copy"
+                ? "wpe_copy_fragment"
+                : "wpe_util_copy_fragment"
+            encoder.setRenderPipelineState(try executor.renderPipeline(
+                fragmentName: fragmentName,
+                blendMode: pass.pass.blending,
+                colorPixelFormat: destination.texture.pixelFormat,
+                depthPixelFormat: depthPixelFormat
+            ))
+            let reference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
+            let texture = try executor.resolve(
+                reference: reference,
+                textures: textures,
+                frameState: frameState,
+                currentTargetID: destination.id
+            )
+            encoder.setFragmentTexture(texture, index: 0)
+            if fragmentName == "wpe_copy_fragment" {
+                var uniforms = executor.copyUniforms(for: pass, layer: layer)
+                encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPECopyUniforms>.stride, index: 0)
+            }
+
+        case "compose":
+            encoder.setRenderPipelineState(try executor.renderPipeline(
+                fragmentName: "wpe_compose_fragment",
+                blendMode: pass.pass.blending,
+                colorPixelFormat: destination.texture.pixelFormat,
+                depthPixelFormat: depthPixelFormat
+            ))
+            let firstReference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
+            let secondReference = pass.textureBindings[1] ?? pass.pass.textures[1] ?? firstReference
+            let firstTexture = try executor.resolve(
+                reference: firstReference,
+                textures: textures,
+                frameState: frameState,
+                currentTargetID: destination.id
+            )
+            let secondTexture = try executor.resolve(
+                reference: secondReference,
+                textures: textures,
+                frameState: frameState,
+                currentTargetID: destination.id
+            )
+            encoder.setFragmentTexture(firstTexture, index: 0)
+            encoder.setFragmentTexture(secondTexture, index: 1)
+            var uniforms = WPESolidUniforms(color: executor.colorVector(for: pass))
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPESolidUniforms>.stride, index: 0)
+
+        default:
+            throw WPEMetalRenderExecutorError.unsupportedShader(pass.pass.shader)
         }
     }
 }

--- a/LiveWallpaper/Runtime/WPEMetalRenderTargetPool.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderTargetPool.swift
@@ -1,0 +1,169 @@
+import CoreGraphics
+import Foundation
+import Metal
+
+/// Identity for a pooled Metal render target. Same name + same scaled
+/// dimensions + same format share a slot; if a pass would read its own
+/// destination texture (e.g. `.previous` ping-pong), the pool returns the
+/// per-slot secondary allocation so Metal never samples from and renders
+/// into the same texture in one encoder.
+struct WPEMetalRenderTargetKey: Hashable {
+    let name: String
+    let sceneWidth: Int
+    let sceneHeight: Int
+    let scale: Double
+    let format: String
+    let pixelFormat: MTLPixelFormat
+
+    init(name: String, sceneSize: CGSize, scale: Double, format: String, pixelFormat: MTLPixelFormat) {
+        self.name = name
+        self.sceneWidth = max(Int(sceneSize.width.rounded()), 1)
+        self.sceneHeight = max(Int(sceneSize.height.rounded()), 1)
+        self.scale = scale
+        self.format = format.lowercased()
+        self.pixelFormat = pixelFormat
+    }
+}
+
+/// Persistent FBO/layer-composite allocation pool used by
+/// `WPEMetalRenderExecutor`. Allocations live across `render(...)` calls
+/// (so per-frame work avoids reallocating large textures) and are released
+/// on `applyPerformanceProfile(.suspended)`, `reload()`, and `cleanup()`.
+///
+/// `MTLHeap` is preferred when `device.heapTextureSizeAndAlign(descriptor:)`
+/// reports a non-zero size; otherwise the pool falls back to discrete
+/// `device.makeTexture(descriptor:)` allocation. The heap reference is held
+/// next to the texture so the heap is not deallocated while the texture is
+/// still in the pool.
+final class WPEMetalRenderTargetPool {
+    private struct Allocation {
+        let texture: MTLTexture
+        let heap: MTLHeap?
+    }
+
+    private final class Slot {
+        var primary: Allocation?
+        var secondary: Allocation?
+    }
+
+    private let device: MTLDevice
+    private var slots: [WPEMetalRenderTargetKey: Slot] = [:]
+    private var declaredFBOs: [String: WPERenderFBO] = [:]
+
+    init(device: MTLDevice) {
+        self.device = device
+    }
+
+    var allocatedTextureCount: Int {
+        slots.values.reduce(0) { count, slot in
+            count + (slot.primary == nil ? 0 : 1) + (slot.secondary == nil ? 0 : 1)
+        }
+    }
+
+    func prepare(pipeline: WPEPreparedRenderPipeline) {
+        declaredFBOs.removeAll(keepingCapacity: true)
+        for layer in pipeline.layers {
+            for fbo in layer.graphLayer.localFBOs {
+                declaredFBOs[fbo.name] = fbo
+            }
+        }
+    }
+
+    func releaseAll() {
+        slots.removeAll(keepingCapacity: true)
+        declaredFBOs.removeAll(keepingCapacity: true)
+    }
+
+    func texture(
+        for target: WPERenderTarget,
+        layer: WPERenderLayer,
+        sceneSize: CGSize,
+        avoiding textureToAvoid: MTLTexture?
+    ) throws -> MTLTexture {
+        let spec = targetSpec(for: target, layer: layer)
+        let pixelFormat = Self.pixelFormat(forFBOFormat: spec.format)
+        let key = WPEMetalRenderTargetKey(
+            name: spec.name,
+            sceneSize: sceneSize,
+            scale: spec.scale,
+            format: spec.format,
+            pixelFormat: pixelFormat
+        )
+        let slot = slots[key] ?? Slot()
+        slots[key] = slot
+
+        if slot.primary == nil {
+            slot.primary = try makeAllocation(key: key, label: "primary")
+        }
+
+        if let textureToAvoid,
+           let primary = slot.primary,
+           primary.texture === textureToAvoid {
+            if slot.secondary == nil {
+                slot.secondary = try makeAllocation(key: key, label: "secondary")
+            }
+            return slot.secondary!.texture
+        }
+
+        return slot.primary!.texture
+    }
+
+    private func targetSpec(for target: WPERenderTarget, layer: WPERenderLayer) -> WPERenderFBO {
+        switch target {
+        case .scene:
+            return WPERenderFBO(name: "scene", scale: 1, format: "rgba8888")
+        case .layerComposite(let name):
+            return WPERenderFBO(name: name, scale: 1, format: "rgba8888")
+        case .fbo(let name):
+            return declaredFBOs[name]
+                ?? layer.localFBOs.first(where: { $0.name == name })
+                ?? WPERenderFBO(name: name, scale: 1, format: "rgba8888")
+        }
+    }
+
+    private func makeAllocation(key: WPEMetalRenderTargetKey, label: String) throws -> Allocation {
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: key.pixelFormat,
+            width: max(Int((Double(key.sceneWidth) * key.scale).rounded()), 1),
+            height: max(Int((Double(key.sceneHeight) * key.scale).rounded()), 1),
+            mipmapped: false
+        )
+        descriptor.usage = [.renderTarget, .shaderRead]
+        descriptor.storageMode = .private
+
+        let sizeAndAlign = device.heapTextureSizeAndAlign(descriptor: descriptor)
+        if sizeAndAlign.size > 0 {
+            let heapDescriptor = MTLHeapDescriptor()
+            heapDescriptor.storageMode = descriptor.storageMode
+            heapDescriptor.size = Self.align(sizeAndAlign.size, to: sizeAndAlign.align)
+            if let heap = device.makeHeap(descriptor: heapDescriptor),
+               let texture = heap.makeTexture(descriptor: descriptor) {
+                texture.label = "WPE \(key.name) \(label) heap texture"
+                return Allocation(texture: texture, heap: heap)
+            }
+        }
+
+        guard let texture = device.makeTexture(descriptor: descriptor) else {
+            throw WPEMetalTextureLoaderError.textureAllocationFailed
+        }
+        texture.label = "WPE \(key.name) \(label) texture"
+        return Allocation(texture: texture, heap: nil)
+    }
+
+    private static func align(_ size: Int, to alignment: Int) -> Int {
+        guard alignment > 0 else { return size }
+        let remainder = size % alignment
+        return remainder == 0 ? size : size + alignment - remainder
+    }
+
+    static func pixelFormat(forFBOFormat format: String) -> MTLPixelFormat {
+        switch format.lowercased() {
+        case "rgba16f", "rgba_half", "rgba16161616f":
+            return .rgba16Float
+        case "r8", "r8unorm":
+            return .r8Unorm
+        default:
+            return WPEMetalRenderExecutor.outputPixelFormat
+        }
+    }
+}

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -38,6 +38,12 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
     private(set) var renderGraph: WPERenderGraph?
     private(set) var renderPipeline: WPEPreparedRenderPipeline?
     private(set) var lastRuntimeUniforms: WPEMetalRuntimeUniforms?
+    /// Test-only forwarder for the executor's pooled FBO/composite texture
+    /// count so suspended-release behaviour can be asserted at the renderer
+    /// boundary (Phase 2C Task 2).
+    var transientTargetTextureCountForTesting: Int {
+        executor.transientTargetTextureCountForTesting
+    }
     var renderedTexture: MTLTexture? { outputTexture }
     /// CGImage readback of the most recent rendered frame; populated at the
     /// end of `performLoad()` so `WPESceneDetailView` can show a thumbnail
@@ -175,6 +181,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         cameraUniforms = .identity
         lastRuntimeUniforms = nil
         cachedSnapshot = nil
+        executor.releaseTransientResources()
         try await load()
     }
 
@@ -206,6 +213,11 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
             mtkView.isPaused = true
             mtkView.enableSetNeedsDisplay = true
             mtkView.releaseDrawables()
+            // Phase 2C Task 2: pooled FBO/layer-composite textures live
+            // across `render(...)` calls; release them when the wallpaper
+            // is suspended so a 6-display setup does not retain hundreds
+            // of MB of transient render targets while paused.
+            executor.releaseTransientResources()
         }
     }
 
@@ -215,6 +227,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         loadedTextures = [:]
         lastRuntimeUniforms = nil
         cachedSnapshot = nil
+        executor.releaseTransientResources()
     }
 
     nonisolated func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
@@ -283,13 +296,42 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
     }
 
     private func requiredTextureReferences(for pass: WPEPreparedRenderPass) -> [WPETextureReference] {
-        if pass.pass.shader == "solidcolor" {
+        switch normalizedBuiltinShaderName(pass.pass.shader) {
+        case "solidcolor", "solidlayer":
+            return []
+
+        case "copy":
+            let reference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
+            return [reference].filter(\.isExternalTextureReference)
+
+        case "compose":
+            let first = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
+            let second = pass.textureBindings[1] ?? pass.pass.textures[1] ?? first
+            return [first, second].filter(\.isExternalTextureReference)
+
+        default:
             return []
         }
-        if pass.pass.shader == "commands/copy" || pass.pass.shader.hasPrefix("genericimage") {
-            return [pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source]
+    }
+
+    private func normalizedBuiltinShaderName(_ shaderName: String) -> String {
+        let lower = shaderName.lowercased()
+        let withoutJSON = lower.hasSuffix(".json") ? String(lower.dropLast(5)) : lower
+        switch withoutJSON {
+        case "solidcolor":
+            return "solidcolor"
+        case "solidlayer", "materials/util/solidlayer", "models/util/solidlayer":
+            return "solidlayer"
+        case "copy", "commands/copy", "materials/util/copy":
+            return "copy"
+        case "compose", "materials/util/compose":
+            return "compose"
+        default:
+            if withoutJSON.hasPrefix("genericimage") {
+                return "copy"
+            }
+            return withoutJSON
         }
-        return []
     }
 
     private func makeTexture(relativePath: String, label: String) async throws -> MTLTexture {
@@ -433,6 +475,20 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
             }
         default:
             return .other(layer: layerName, message: error.localizedDescription)
+        }
+    }
+}
+
+/// Phase 2C: filters out FBO/previous references at the texture-discovery
+/// layer so the renderer never tries to load an in-graph FBO from disk.
+/// Those references resolve at executor time via the frame state.
+private extension WPETextureReference {
+    var isExternalTextureReference: Bool {
+        switch self {
+        case .image, .asset:
+            return true
+        case .fbo, .previous:
+            return false
         }
     }
 }

--- a/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
+++ b/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
@@ -51,3 +51,37 @@ fragment half4 wpe_copy_fragment(
     float2 uv = clamp(in.uv + uniforms.uvOffset, float2(0.0), float2(1.0));
     return texture0.sample(linearSampler, uv);
 }
+
+// Phase 2C util built-ins. `solidlayer` writes color * alpha into the
+// per-layer FBO. `util_copy` is the parallax-free copy used when chaining
+// `materials/util/copy.json` between FBOs. `compose` blends two layer
+// composites into the scene under a tint color.
+
+fragment half4 wpe_solidlayer_fragment(
+    WPEVertexOut in [[stage_in]],
+    constant WPESolidUniforms& uniforms [[buffer(0)]]
+) {
+    float alpha = saturate(uniforms.color.a);
+    return half4(float4(uniforms.color.rgb * alpha, alpha));
+}
+
+fragment half4 wpe_util_copy_fragment(
+    WPEVertexOut in [[stage_in]],
+    texture2d<half, access::sample> texture0 [[texture(0)]]
+) {
+    constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
+    return texture0.sample(linearSampler, in.uv);
+}
+
+fragment half4 wpe_compose_fragment(
+    WPEVertexOut in [[stage_in]],
+    texture2d<half, access::sample> texture0 [[texture(0)]],
+    texture2d<half, access::sample> texture1 [[texture(1)]],
+    constant WPESolidUniforms& uniforms [[buffer(0)]]
+) {
+    constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
+    float4 a = float4(texture0.sample(linearSampler, in.uv));
+    float4 b = float4(texture1.sample(linearSampler, in.uv));
+    float4 composed = mix(a, b, b.a);
+    return half4(float4(composed.rgb * uniforms.color.rgb, composed.a * uniforms.color.a));
+}

--- a/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
+++ b/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
@@ -450,3 +450,518 @@ private func graphLayer(pass: WPERenderPass, parallaxDepth: Double = 0) -> WPERe
         parallaxDepth: parallaxDepth
     )
 }
+
+// MARK: - Phase 2C helpers and tests
+
+private func solidPass(
+    id: String,
+    color: [Double],
+    target: WPERenderTarget,
+    blending: String = "normal",
+    cullMode: String = "nocull",
+    depthTest: String = "disabled",
+    depthWrite: String = "disabled"
+) -> WPERenderPass {
+    WPERenderPass(
+        id: id,
+        phase: .material,
+        shader: "solidcolor",
+        source: .previous,
+        target: target,
+        textures: [:],
+        binds: [:],
+        constants: ["g_Color": .vector(color)],
+        combos: [:],
+        blending: blending,
+        cullMode: cullMode,
+        depthTest: depthTest,
+        depthWrite: depthWrite
+    )
+}
+
+private func copyPass(
+    id: String,
+    source: WPETextureReference,
+    target: WPERenderTarget,
+    blending: String = "normal",
+    cullMode: String = "nocull",
+    depthTest: String = "disabled",
+    depthWrite: String = "disabled"
+) -> WPERenderPass {
+    WPERenderPass(
+        id: id,
+        phase: .command(file: "effects/copy/effect.json"),
+        shader: "commands/copy",
+        source: source,
+        target: target,
+        textures: [0: source],
+        binds: [:],
+        constants: [:],
+        combos: [:],
+        blending: blending,
+        cullMode: cullMode,
+        depthTest: depthTest,
+        depthWrite: depthWrite
+    )
+}
+
+private func preparedPipeline(
+    localFBOs: [WPERenderFBO],
+    passes: [WPEPreparedRenderPass]
+) -> WPEPreparedRenderPipeline {
+    let layer = WPERenderLayer(
+        objectID: "layer",
+        objectName: "Layer",
+        imagePath: "materials/base.png",
+        materialPath: nil,
+        compositeA: "_rt_imageLayerComposite_layer_a",
+        compositeB: "_rt_imageLayerComposite_layer_b",
+        localFBOs: localFBOs,
+        passes: passes.map(\.pass)
+    )
+    return WPEPreparedRenderPipeline(layers: [
+        WPEPreparedRenderLayer(graphLayer: layer, passes: passes)
+    ])
+}
+
+private func preparedBuiltinPass(
+    _ pass: WPERenderPass,
+    bindings: [Int: WPETextureReference] = [:],
+    uniforms: [String: WPESceneShaderConstantValue] = [:]
+) -> WPEPreparedRenderPass {
+    WPEPreparedRenderPass(
+        pass: pass,
+        shader: WPEShaderProgram(name: pass.shader, vertexSource: "", fragmentSource: "", isBuiltin: true),
+        textureBindings: bindings,
+        comboValues: [:],
+        uniformValues: uniforms
+    )
+}
+
+private func makeCheckerTexture(device: MTLDevice) throws -> MTLTexture {
+    try makeRGBAInputTexture(device: device, width: 2, height: 2, bytes: Data([
+        255, 0,   0,   255,
+        0,   255, 0,   255,
+        0,   0,   255, 255,
+        255, 255, 0,   255
+    ]))
+}
+
+private struct BlendFixture: Sendable {
+    let mode: String
+    let expected: Pixel
+}
+
+private let blendFixtures: [BlendFixture] = [
+    BlendFixture(mode: "normal", expected: Pixel(r: 188, g: 0, b: 188, a: 255)),
+    BlendFixture(mode: "additive", expected: Pixel(r: 188, g: 0, b: 255, a: 255)),
+    BlendFixture(mode: "multiply", expected: Pixel(r: 0, g: 0, b: 0, a: 255)),
+    BlendFixture(mode: "translucent", expected: Pixel(r: 255, g: 0, b: 188, a: 255)),
+    BlendFixture(mode: "normalmapped", expected: Pixel(r: 188, g: 0, b: 188, a: 255)),
+    BlendFixture(mode: "disabled", expected: Pixel(r: 255, g: 0, b: 0, a: 128))
+]
+
+private extension WPEMetalRenderExecutorTests {
+    @Test("Routes layerComposite target into a later FBO source")
+    func routesLayerCompositeTargetIntoScene() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let compositeName = "_rt_imageLayerComposite_layer_a"
+        let writeComposite = solidPass(
+            id: "layer.0",
+            color: [1, 0, 0, 1],
+            target: .layerComposite(name: compositeName),
+            blending: "disabled"
+        )
+        let copyToScene = copyPass(
+            id: "layer.1",
+            source: .fbo(compositeName),
+            target: .scene,
+            blending: "disabled"
+        )
+
+        let pipeline = preparedPipeline(
+            localFBOs: [],
+            passes: [
+                preparedBuiltinPass(writeComposite, uniforms: ["g_Color": .vector([1, 0, 0, 1])]),
+                preparedBuiltinPass(copyToScene, bindings: [0: .fbo(compositeName)])
+            ]
+        )
+
+        let output = try executor.render(pipeline: pipeline, size: CGSize(width: 4, height: 4), textures: [:])
+        let pixel = try readPixel(output, x: 2, y: 2)
+
+        #expect(pixel.r >= 250)
+        #expect(pixel.g <= 5)
+        #expect(pixel.b <= 5)
+        #expect(pixel.a >= 250)
+    }
+
+    @Test("Routes declared FBO target into a later FBO source")
+    func routesDeclaredFBOTargetIntoScene() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let fbo = WPERenderFBO(name: "_rt_CustomBuffer", scale: 1, format: "rgba8888")
+        let writeFBO = solidPass(
+            id: "layer.0",
+            color: [0, 1, 0, 1],
+            target: .fbo(name: fbo.name),
+            blending: "disabled"
+        )
+        let copyToScene = copyPass(
+            id: "layer.1",
+            source: .fbo(fbo.name),
+            target: .scene,
+            blending: "disabled"
+        )
+
+        let pipeline = preparedPipeline(
+            localFBOs: [fbo],
+            passes: [
+                preparedBuiltinPass(writeFBO, uniforms: ["g_Color": .vector([0, 1, 0, 1])]),
+                preparedBuiltinPass(copyToScene, bindings: [0: .fbo(fbo.name)])
+            ]
+        )
+
+        let output = try executor.render(pipeline: pipeline, size: CGSize(width: 4, height: 4), textures: [:])
+        let pixel = try readPixel(output, x: 2, y: 2)
+
+        #expect(pixel.r <= 5)
+        #expect(pixel.g >= 250)
+        #expect(pixel.b <= 5)
+        #expect(pixel.a >= 250)
+    }
+
+    @Test("Reuses pooled FBO allocations across render calls")
+    func reusesPooledFBOAllocationsAcrossFrames() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let fbo = WPERenderFBO(name: "_rt_Reused", scale: 1, format: "rgba8888")
+        let write = solidPass(
+            id: "layer.0",
+            color: [0, 0, 1, 1],
+            target: .fbo(name: fbo.name),
+            blending: "disabled"
+        )
+        let copy = copyPass(
+            id: "layer.1",
+            source: .fbo(fbo.name),
+            target: .scene,
+            blending: "disabled"
+        )
+        let pipeline = preparedPipeline(
+            localFBOs: [fbo],
+            passes: [
+                preparedBuiltinPass(write, uniforms: ["g_Color": .vector([0, 0, 1, 1])]),
+                preparedBuiltinPass(copy, bindings: [0: .fbo(fbo.name)])
+            ]
+        )
+
+        _ = try executor.render(pipeline: pipeline, size: CGSize(width: 8, height: 8), textures: [:])
+        let firstAllocationCount = executor.transientTargetTextureCountForTesting
+        _ = try executor.render(pipeline: pipeline, size: CGSize(width: 8, height: 8), textures: [:])
+        let secondAllocationCount = executor.transientTargetTextureCountForTesting
+
+        #expect(firstAllocationCount > 0)
+        #expect(secondAllocationCount == firstAllocationCount)
+    }
+
+    @Test("Releases pooled FBO allocations on explicit transient release")
+    func releasesPooledFBOAllocations() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let fbo = WPERenderFBO(name: "_rt_Releasable", scale: 1, format: "rgba8888")
+        let write = solidPass(
+            id: "layer.0",
+            color: [1, 1, 0, 1],
+            target: .fbo(name: fbo.name),
+            blending: "disabled"
+        )
+        let copy = copyPass(
+            id: "layer.1",
+            source: .fbo(fbo.name),
+            target: .scene,
+            blending: "disabled"
+        )
+        let pipeline = preparedPipeline(
+            localFBOs: [fbo],
+            passes: [
+                preparedBuiltinPass(write, uniforms: ["g_Color": .vector([1, 1, 0, 1])]),
+                preparedBuiltinPass(copy, bindings: [0: .fbo(fbo.name)])
+            ]
+        )
+
+        _ = try executor.render(pipeline: pipeline, size: CGSize(width: 8, height: 8), textures: [:])
+        #expect(executor.transientTargetTextureCountForTesting > 0)
+
+        executor.releaseTransientResources()
+
+        #expect(executor.transientTargetTextureCountForTesting == 0)
+    }
+
+    @Test("Resolves previous to the most recent write to the same FBO target")
+    func resolvesPreviousWithinSameFBOTarget() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let checker = try makeCheckerTexture(device: device)
+        let fbo = WPERenderFBO(name: "_rt_Checker", scale: 1, format: "rgba8888")
+
+        let seedFBO = copyPass(
+            id: "layer.0",
+            source: .image("materials/checker.png"),
+            target: .fbo(name: fbo.name),
+            blending: "disabled"
+        )
+        let copyPreviousBackIntoSameFBO = copyPass(
+            id: "layer.1",
+            source: .previous,
+            target: .fbo(name: fbo.name),
+            blending: "disabled"
+        )
+        let copyFBOToScene = copyPass(
+            id: "layer.2",
+            source: .fbo(fbo.name),
+            target: .scene,
+            blending: "disabled"
+        )
+
+        let pipeline = preparedPipeline(
+            localFBOs: [fbo],
+            passes: [
+                preparedBuiltinPass(seedFBO, bindings: [0: .image("materials/checker.png")]),
+                preparedBuiltinPass(copyPreviousBackIntoSameFBO, bindings: [0: .previous]),
+                preparedBuiltinPass(copyFBOToScene, bindings: [0: .fbo(fbo.name)])
+            ]
+        )
+
+        let output = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 2, height: 2),
+            textures: ["materials/checker.png": checker]
+        )
+
+        #expect(try readPixel(output, x: 0, y: 0).r >= 250)
+        #expect(try readPixel(output, x: 1, y: 0).g >= 250)
+        #expect(try readPixel(output, x: 0, y: 1).b >= 250)
+        #expect(try readPixel(output, x: 1, y: 1).r >= 250)
+        #expect(try readPixel(output, x: 1, y: 1).g >= 250)
+    }
+
+    @Test("Missing previous fails closed before any write to the current target")
+    func missingPreviousFailsClosed() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let fbo = WPERenderFBO(name: "_rt_Empty", scale: 1, format: "rgba8888")
+        let pass = copyPass(
+            id: "layer.0",
+            source: .previous,
+            target: .fbo(name: fbo.name),
+            blending: "disabled"
+        )
+        let pipeline = preparedPipeline(
+            localFBOs: [fbo],
+            passes: [preparedBuiltinPass(pass, bindings: [0: .previous])]
+        )
+
+        #expect(throws: WPEMetalRenderExecutorError.missingTexture(.previous)) {
+            _ = try executor.render(pipeline: pipeline, size: CGSize(width: 2, height: 2), textures: [:])
+        }
+    }
+
+    @Test("Applies WPE blend factors", arguments: blendFixtures)
+    func appliesWPEBlendFactors(fixture: BlendFixture) throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let destination = solidPass(
+            id: "layer.0",
+            color: [0, 0, 1, 1],
+            target: .scene,
+            blending: "disabled"
+        )
+        let source = solidPass(
+            id: "layer.1",
+            color: [1, 0, 0, 0.5],
+            target: .scene,
+            blending: fixture.mode
+        )
+
+        let pipeline = preparedPipeline(
+            localFBOs: [],
+            passes: [
+                preparedBuiltinPass(destination, uniforms: ["g_Color": .vector([0, 0, 1, 1])]),
+                preparedBuiltinPass(source, uniforms: ["g_Color": .vector([1, 0, 0, 0.5])])
+            ]
+        )
+
+        let output = try executor.render(pipeline: pipeline, size: CGSize(width: 4, height: 4), textures: [:])
+        let pixel = try readPixel(output, x: 2, y: 2)
+
+        #expect(abs(Int(pixel.r) - Int(fixture.expected.r)) <= 2)
+        #expect(abs(Int(pixel.g) - Int(fixture.expected.g)) <= 2)
+        #expect(abs(Int(pixel.b) - Int(fixture.expected.b)) <= 2)
+        #expect(abs(Int(pixel.a) - Int(fixture.expected.a)) <= 2)
+    }
+
+    @Test("Front culling discards the fullscreen built-in quad")
+    func frontCullingDiscardsFullscreenQuad() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let red = solidPass(id: "layer.0", color: [1, 0, 0, 1], target: .scene, blending: "disabled")
+        let culledBlue = solidPass(
+            id: "layer.1",
+            color: [0, 0, 1, 1],
+            target: .scene,
+            blending: "disabled",
+            cullMode: "front"
+        )
+
+        let pipeline = preparedPipeline(
+            localFBOs: [],
+            passes: [
+                preparedBuiltinPass(red, uniforms: ["g_Color": .vector([1, 0, 0, 1])]),
+                preparedBuiltinPass(culledBlue, uniforms: ["g_Color": .vector([0, 0, 1, 1])])
+            ]
+        )
+
+        let output = try executor.render(pipeline: pipeline, size: CGSize(width: 4, height: 4), textures: [:])
+        let pixel = try readPixel(output, x: 2, y: 2)
+
+        #expect(pixel.r >= 250)
+        #expect(pixel.g <= 5)
+        #expect(pixel.b <= 5)
+    }
+
+    @Test("Depth less test rejects equal-depth fullscreen pass")
+    func depthLessRejectsEqualDepthPass() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let red = solidPass(
+            id: "layer.0",
+            color: [1, 0, 0, 1],
+            target: .scene,
+            blending: "disabled",
+            depthTest: "always",
+            depthWrite: "enabled"
+        )
+        let rejectedBlue = solidPass(
+            id: "layer.1",
+            color: [0, 0, 1, 1],
+            target: .scene,
+            blending: "disabled",
+            depthTest: "less",
+            depthWrite: "disabled"
+        )
+
+        let pipeline = preparedPipeline(
+            localFBOs: [],
+            passes: [
+                preparedBuiltinPass(red, uniforms: ["g_Color": .vector([1, 0, 0, 1])]),
+                preparedBuiltinPass(rejectedBlue, uniforms: ["g_Color": .vector([0, 0, 1, 1])])
+            ]
+        )
+
+        let output = try executor.render(pipeline: pipeline, size: CGSize(width: 4, height: 4), textures: [:])
+        let pixel = try readPixel(output, x: 2, y: 2)
+
+        #expect(pixel.r >= 250)
+        #expect(pixel.g <= 5)
+        #expect(pixel.b <= 5)
+    }
+
+    @Test("solidlayer writes color multiplied by alpha")
+    func solidlayerWritesColorMultipliedByAlpha() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let pass = WPERenderPass(
+            id: "solidlayer.0",
+            phase: .material,
+            shader: "materials/util/solidlayer.json",
+            source: .previous,
+            target: .scene,
+            textures: [:],
+            binds: [:],
+            constants: ["g_Color": .vector([0, 1, 0, 0.5])],
+            combos: [:],
+            blending: "disabled",
+            cullMode: "nocull",
+            depthTest: "disabled",
+            depthWrite: "disabled"
+        )
+
+        let output = try executor.render(
+            pipeline: preparedPipeline(
+                localFBOs: [],
+                passes: [preparedBuiltinPass(pass, uniforms: ["g_Color": .vector([0, 1, 0, 0.5])])]
+            ),
+            size: CGSize(width: 4, height: 4),
+            textures: [:]
+        )
+        let pixel = try readPixel(output, x: 2, y: 2)
+
+        #expect(pixel.r <= 5)
+        #expect(abs(Int(pixel.g) - 188) <= 4)
+        #expect(pixel.b <= 5)
+        #expect(abs(Int(pixel.a) - 128) <= 4)
+    }
+
+    @Test("compose tints layer composites into the scene")
+    func composeTintsLayerCompositesIntoScene() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let compositeA = "_rt_imageLayerComposite_layer_a"
+        let solid = solidPass(
+            id: "layer.0",
+            color: [1, 1, 1, 1],
+            target: .layerComposite(name: compositeA),
+            blending: "disabled"
+        )
+        let compose = WPERenderPass(
+            id: "layer.1",
+            phase: .command(file: "effects/compose/effect.json"),
+            shader: "materials/util/compose.json",
+            source: .fbo(compositeA),
+            target: .scene,
+            textures: [0: .fbo(compositeA), 1: .fbo(compositeA)],
+            binds: [:],
+            constants: ["g_Color": .vector([0, 1, 0, 1])],
+            combos: [:],
+            blending: "disabled",
+            cullMode: "nocull",
+            depthTest: "disabled",
+            depthWrite: "disabled"
+        )
+
+        let output = try executor.render(
+            pipeline: preparedPipeline(
+                localFBOs: [],
+                passes: [
+                    preparedBuiltinPass(solid, uniforms: ["g_Color": .vector([1, 1, 1, 1])]),
+                    preparedBuiltinPass(
+                        compose,
+                        bindings: [0: .fbo(compositeA), 1: .fbo(compositeA)],
+                        uniforms: ["g_Color": .vector([0, 1, 0, 1])]
+                    )
+                ]
+            ),
+            size: CGSize(width: 4, height: 4),
+            textures: [:]
+        )
+        let pixel = try readPixel(output, x: 2, y: 2)
+
+        #expect(pixel.r <= 5)
+        #expect(pixel.g >= 250)
+        #expect(pixel.b <= 5)
+        #expect(pixel.a >= 250)
+    }
+}


### PR DESCRIPTION
## Summary

Brings the experimental Metal renderer up to real WPE multi-pass execution. Six tasks land together because they share the executor's frame state and pipeline-cache surface; later phases (2D shader translator, 2F particles) consume this infrastructure.

| Task | Delivery |
|---|---|
| **Task 1** | `WPEMetalRenderExecutor` dispatches on `WPERenderTarget`. `.scene` writes the persistent output texture; `.fbo(name)` and `.layerComposite(name)` route through the pool. Frame-local state tracks the latest texture per logical target. |
| **Task 2** | New [`WPEMetalRenderTargetPool`](LiveWallpaper/Runtime/WPEMetalRenderTargetPool.swift) keys allocations by `(name, sceneSize, scale, format, pixelFormat)` and persists them across frames. Prefers `MTLHeap`; falls back to discrete allocation. `WPEMetalSceneRenderer` releases pooled resources on `.suspended` / `reload()` / `cleanup()`. |
| **Task 3** | `.previous` resolves target-locally; before any write it throws `missingTexture(.previous)` (fail closed). Same-target `.previous` reads ping-pong via the pool's secondary slot, with a blit-copy of the prior contents so blend/depth-rejected fragments load defined memory. |
| **Task 4** | 6 WPE blend strings → `MTLPipelineColorAttachmentDescriptor` (incl. `multiply` preserving dst.alpha per OpenGL convention). Cull strings → `MTLCullMode`. Depth test/write strings → cached `MTLDepthStencilState`. Pipeline cache key now `(fragmentName, blendMode, colorPixelFormat, depthPixelFormat)` so non-depth passes never declare `.depth32Float`. Depth textures are sized to the destination texture, not scene size. |
| **Task 5** | [`WPEMetalBuiltins.metal`](LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal) gains `wpe_solidlayer_fragment` (premultiplied), `wpe_util_copy_fragment` (parallax-free), and `wpe_compose_fragment` (mix + tint). [`WPERenderPipelineBuilder`](LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift) recognises `materials/util/{solidlayer,copy,compose}.json` aliases as built-ins. Custom shaders still throw `unsupportedShader` until Phase 2D. |
| **Task 6** | Scene renderer's `requiredTextureReferences(for:)` switches on the same normalised shader names as the executor; FBO/`previous` refs filtered before the disk loader. New `transientTargetTextureCountForTesting` forwarder verifies suspended-release behaviour. |

## Audit (Phase 5)

codex backend (66/100 → addressed). Critical/High findings all fixed before this PR:

- **Critical**: PSO declared `depthAttachmentPixelFormat = .depth32Float` for non-depth passes → fixed by adding `depthPixelFormat` to the pipeline cache key and using `.invalid` unless the pass attaches depth.
- **High**: Ping-pong destinations used logical-target `hasWritten`, so a same-target `.previous` pass with blending could load uninitialised secondary memory → fixed by tracking per-physical-texture init via `ObjectIdentifier`, blit-copying primary→secondary before render, and switching color/depth load actions to `hasInitialized(_:)`.
- **High**: Depth textures allocated at scene size, not destination size → fixed by keying depth cache on `(targetID, width, height)` and allocating from the destination texture's actual dimensions.
- Medium / Low (deferred): shader-name normalisation duplicated across builder/executor/scene renderer (Phase 2D follow-up); translucent uses premultiplied-alpha factors while `solidcolor` outputs straight alpha (acceptable trade-off until Phase 2D shader-author intent).

## Tests

- 407/407 in 70 suites pass (`xcodebuild test ... -skip-testing:LiveWallpaperUITests`)
- Phase 2A/2B Metal suites stay green — zero regressions
- New Phase 2C coverage: target routing (`.fbo` + `.layerComposite`), pool reuse + release, `.previous` ping-pong, missing-`.previous` fail-closed, six blend modes (parameterised fixture), front-face culling, depth-less rejection, `solidlayer` alpha-mul, `compose` tint
- Build clean on Swift 6 strict concurrency

## Test plan

- [x] `xcodebuild test ... -skip-testing:LiveWallpaperUITests` passes
- [ ] Reviewer triggers a real Workshop scene with a multi-pass effect (e.g. blur compose) and confirms the layer composite reaches the scene output via `.fbo(_rt_imageLayerComposite_*)`
- [ ] Reviewer confirms `applyPerformanceProfile(.suspended)` releases pool memory under `top -pid <app>` (look for ~10 MB drop on a 64×64 scene)
- [ ] Reviewer pulls a Workshop scene that uses `materials/util/compose.json` and verifies the tint reaches the final scene

## Out of scope

- Custom GLSL → MSL translation (Phase 2D)
- Particle simulation (Phase 2F)
- Audio uniforms (Phase 2G)
- Per-frame readback timer for Metal `.playingSnapshot`
- Layer-aware diagnostics for executor-time failures (still falls back to "scene")

🤖 Generated with [Claude Code](https://claude.com/claude-code)