### PR TITLE
feat(wpe): Phase 2D-C pre-compiled MSL effect builtins

### DIFF
--- a/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
@@ -104,7 +104,8 @@ private struct WPEShaderSourceLoader: Sendable {
     }
 
     private func builtinProgram(shaderName: String, combos: [String: Int]) -> WPEShaderProgram? {
-        switch normalizedBuiltinShaderName(shaderName) {
+        let normalized = normalizedBuiltinShaderName(shaderName)
+        switch normalized {
         case "solidcolor":
             return solidColorProgram(shaderName: shaderName, combos: combos)
         case "solidlayer":
@@ -114,6 +115,13 @@ private struct WPEShaderSourceLoader: Sendable {
         case "compose":
             return composeProgram(shaderName: shaderName, combos: combos)
         default:
+            // Phase 2D-C: pre-compiled effects share `copyProgram`'s GLSL
+            // skeleton because the runtime renders them through dedicated
+            // MSL fragments — the prepared GLSL is only kept around for
+            // future shader-translator paths.
+            if normalized.hasPrefix("effect_") {
+                return copyProgram(shaderName: shaderName, combos: combos)
+            }
             guard isGenericImageShader(shaderName) else {
                 return nil
             }
@@ -124,18 +132,48 @@ private struct WPEShaderSourceLoader: Sendable {
     private func normalizedBuiltinShaderName(_ shaderName: String) -> String {
         let lower = shaderName.lowercased()
         let withoutJSON = lower.hasSuffix(".json") ? String(lower.dropLast(5)) : lower
-        switch withoutJSON {
+        let stripped = withoutJSON.hasPrefix("materials/")
+            ? String(withoutJSON.dropFirst("materials/".count))
+            : withoutJSON
+        switch stripped {
         case "solidcolor":
             return "solidcolor"
-        case "solidlayer", "materials/util/solidlayer", "models/util/solidlayer":
+        case "solidlayer", "util/solidlayer", "models/util/solidlayer":
             return "solidlayer"
-        case "copy", "commands/copy", "materials/util/copy":
+        case "copy", "commands/copy", "util/copy":
             return "copy"
-        case "compose", "materials/util/compose":
+        case "compose", "util/compose":
             return "compose"
         default:
-            return withoutJSON
+            // Phase 2D-C: recognise pre-compiled effect aliases so the
+            // builder marks them `isBuiltin: true` and routes the dispatch
+            // through the executor's MSL fragment table. The leading
+            // `materials/` prefix is pre-stripped above so Workshop paths
+            // such as `materials/effects/blur/blur.json` resolve here.
+            if Self.isEffectAlias(stripped, family: "colorbalance") {
+                return "effect_colorbalance"
+            }
+            if Self.isEffectAlias(stripped, family: "blur") {
+                return "effect_blur"
+            }
+            if Self.isEffectAlias(stripped, family: "vignette") {
+                return "effect_vignette"
+            }
+            if Self.isEffectAlias(stripped, family: "water")
+                || Self.isEffectAlias(stripped, family: "distort") {
+                return "effect_water"
+            }
+            if Self.isEffectAlias(stripped, family: "shake") {
+                return "effect_shake"
+            }
+            return stripped
         }
+    }
+
+    private static func isEffectAlias(_ shaderName: String, family: String) -> Bool {
+        shaderName == family
+            || shaderName == "effects/\(family)"
+            || shaderName == "effects/\(family)/\(family)"
     }
 
     private func solidLayerProgram(shaderName: String, combos: [String: Int]) -> WPEShaderProgram {

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -44,6 +44,44 @@ struct WPECopyUniforms {
     var padding: SIMD2<Float> = SIMD2<Float>(0, 0)
 }
 
+// Phase 2D-C: per-effect uniform structs. Field order MUST match the
+// matching MSL struct in `WPEMetalBuiltins.metal` exactly so that
+// `setFragmentBytes(...)` lays out correctly.
+
+struct WPEColorBalanceUniforms {
+    var brightness: Float
+    var contrast: Float
+    var saturation: Float
+    var padding: Float = 0
+}
+
+struct WPEBlurUniforms {
+    var texelSize: SIMD2<Float>
+    var radius: Float
+    var padding: Float = 0
+}
+
+struct WPEVignetteUniforms {
+    var innerRadius: Float
+    var outerRadius: Float
+    var intensity: Float
+    var padding: Float = 0
+}
+
+struct WPEWaterUniforms {
+    var amplitude: Float
+    var frequency: Float
+    var speed: Float
+    var time: Float
+}
+
+struct WPEShakeUniforms {
+    var magnitude: Float
+    var time: Float
+    var frequency: Float
+    var padding: Float = 0
+}
+
 /// Logical identity for a render target during one `render(...)` call.
 /// `.scene` is the persistent output texture; `.named(_)` covers FBOs and
 /// layer composites resolved through the pool.
@@ -772,26 +810,106 @@ final class WPEMetalRenderExecutor {
 
     /// Maps the WPE shader name onto one of the executor's built-in fragment
     /// functions. Phase 2C recognises `solidcolor`, `solidlayer`, `copy`,
-    /// `compose`, and `genericimage*` aliases (with or without the
-    /// `materials/util/` prefix and `.json` suffix). Custom shaders still
-    /// throw `unsupportedShader` until Phase 2D ships GLSL translation.
+    /// `compose`, and `genericimage*`. Phase 2D-C extends the table with the
+    /// pre-compiled MSL effect set: `colorbalance`, `blur`, `vignette`,
+    /// `water` (alias `distort`), `shake`. Custom shaders still throw
+    /// `unsupportedShader` until the full GLSL translator (Phase 2D-A/B)
+    /// lands.
     fileprivate func normalizedBuiltinShaderName(_ shaderName: String) -> String {
         let lower = shaderName.lowercased()
         let withoutJSON = lower.hasSuffix(".json") ? String(lower.dropLast(5)) : lower
-        switch withoutJSON {
+        let stripped = withoutJSON.hasPrefix("materials/")
+            ? String(withoutJSON.dropFirst("materials/".count))
+            : withoutJSON
+
+        switch stripped {
         case "solidcolor":
             return "solidcolor"
-        case "solidlayer", "materials/util/solidlayer", "models/util/solidlayer":
+        case "solidlayer", "util/solidlayer", "models/util/solidlayer":
             return "solidlayer"
-        case "copy", "commands/copy", "materials/util/copy":
+        case "copy", "commands/copy", "util/copy":
             return "copy"
-        case "compose", "materials/util/compose":
+        case "compose", "util/compose":
             return "compose"
         default:
-            if withoutJSON.hasPrefix("genericimage") {
+            if Self.isEffectAlias(stripped, family: "colorbalance") {
+                return "effect_colorbalance"
+            }
+            if Self.isEffectAlias(stripped, family: "blur") {
+                return "effect_blur"
+            }
+            if Self.isEffectAlias(stripped, family: "vignette") {
+                return "effect_vignette"
+            }
+            if Self.isEffectAlias(stripped, family: "water")
+                || Self.isEffectAlias(stripped, family: "distort") {
+                return "effect_water"
+            }
+            if Self.isEffectAlias(stripped, family: "shake") {
+                return "effect_shake"
+            }
+            if stripped.hasPrefix("genericimage") {
                 return "copy"
             }
-            return withoutJSON
+            return stripped
+        }
+    }
+
+    /// Phase 2D-C: matches `<family>`, `effects/<family>`, and
+    /// `effects/<family>/<family>` so a Workshop effect-pass shader name
+    /// like `effects/water/water` (or its `materials/effects/...` form,
+    /// already pre-stripped above) resolves to the same builtin.
+    private static func isEffectAlias(_ shaderName: String, family: String) -> Bool {
+        shaderName == family
+            || shaderName == "effects/\(family)"
+            || shaderName == "effects/\(family)/\(family)"
+    }
+
+    /// Phase 2D-C: scalar-uniform lookup that walks `pass.uniformValues`
+    /// first (runtime-merged values from Phase 2B) then `pass.pass.constants`
+    /// (authored material defaults). Multiple aliases supported because WPE
+    /// shader uniforms ship under several legacy names (`u_X`, `X`,
+    /// `g_XOffset`, etc.).
+    fileprivate func floatScalar(
+        named name: String,
+        in pass: WPEPreparedRenderPass,
+        default defaultValue: Float
+    ) -> Float {
+        Self.scalarFloat(pass.uniformValues[name])
+            ?? Self.scalarFloat(pass.pass.constants[name])
+            ?? defaultValue
+    }
+
+    fileprivate func floatScalar(
+        named names: [String],
+        in pass: WPEPreparedRenderPass,
+        default defaultValue: Float
+    ) -> Float {
+        for name in names {
+            if let value = Self.scalarFloat(pass.uniformValues[name]) {
+                return value
+            }
+        }
+        for name in names {
+            if let value = Self.scalarFloat(pass.pass.constants[name]) {
+                return value
+            }
+        }
+        return defaultValue
+    }
+
+    private static func scalarFloat(_ value: WPESceneShaderConstantValue?) -> Float? {
+        switch value {
+        case .number(let number):
+            return Float(number)
+        case .vector(let vector):
+            return vector.first.map(Float.init)
+        case .bool(let bool):
+            return bool ? 1 : 0
+        case .string(let string):
+            return Float(string)
+        case nil:
+            return nil
         }
     }
 }
@@ -881,6 +999,175 @@ private struct WPEMetalResolvedShaderInputs {
             encoder.setFragmentTexture(secondTexture, index: 1)
             var uniforms = WPESolidUniforms(color: executor.colorVector(for: pass))
             encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPESolidUniforms>.stride, index: 0)
+
+        case "effect_colorbalance":
+            encoder.setRenderPipelineState(try executor.renderPipeline(
+                fragmentName: "wpe_effect_colorbalance_fragment",
+                blendMode: pass.pass.blending,
+                colorPixelFormat: destination.texture.pixelFormat,
+                depthPixelFormat: depthPixelFormat
+            ))
+            let reference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
+            let texture = try executor.resolve(
+                reference: reference,
+                textures: textures,
+                frameState: frameState,
+                currentTargetID: destination.id
+            )
+            encoder.setFragmentTexture(texture, index: 0)
+            var uniforms = WPEColorBalanceUniforms(
+                brightness: executor.floatScalar(
+                    named: ["u_Brightness", "brightness", "g_BrightnessOffset"],
+                    in: pass,
+                    default: 0
+                ),
+                contrast: executor.floatScalar(
+                    named: ["u_Contrast", "contrast"],
+                    in: pass,
+                    default: 1
+                ),
+                saturation: executor.floatScalar(
+                    named: ["u_Saturation", "saturation"],
+                    in: pass,
+                    default: 1
+                )
+            )
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPEColorBalanceUniforms>.stride, index: 0)
+
+        case "effect_blur":
+            encoder.setRenderPipelineState(try executor.renderPipeline(
+                fragmentName: "wpe_effect_blur_fragment",
+                blendMode: pass.pass.blending,
+                colorPixelFormat: destination.texture.pixelFormat,
+                depthPixelFormat: depthPixelFormat
+            ))
+            let reference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
+            let texture = try executor.resolve(
+                reference: reference,
+                textures: textures,
+                frameState: frameState,
+                currentTargetID: destination.id
+            )
+            encoder.setFragmentTexture(texture, index: 0)
+            var uniforms = WPEBlurUniforms(
+                texelSize: SIMD2<Float>(
+                    1 / Float(max(texture.width, 1)),
+                    1 / Float(max(texture.height, 1))
+                ),
+                radius: executor.floatScalar(
+                    named: ["u_Radius", "radius", "amount", "strength"],
+                    in: pass,
+                    default: 1
+                )
+            )
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPEBlurUniforms>.stride, index: 0)
+
+        case "effect_vignette":
+            encoder.setRenderPipelineState(try executor.renderPipeline(
+                fragmentName: "wpe_effect_vignette_fragment",
+                blendMode: pass.pass.blending,
+                colorPixelFormat: destination.texture.pixelFormat,
+                depthPixelFormat: depthPixelFormat
+            ))
+            let reference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
+            let texture = try executor.resolve(
+                reference: reference,
+                textures: textures,
+                frameState: frameState,
+                currentTargetID: destination.id
+            )
+            encoder.setFragmentTexture(texture, index: 0)
+            var uniforms = WPEVignetteUniforms(
+                innerRadius: executor.floatScalar(
+                    named: ["u_InnerRadius", "innerRadius", "inner"],
+                    in: pass,
+                    default: 0.35
+                ),
+                outerRadius: executor.floatScalar(
+                    named: ["u_OuterRadius", "outerRadius", "outer"],
+                    in: pass,
+                    default: 0.75
+                ),
+                intensity: executor.floatScalar(
+                    named: ["u_Intensity", "intensity", "amount", "strength"],
+                    in: pass,
+                    default: 0.5
+                )
+            )
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPEVignetteUniforms>.stride, index: 0)
+
+        case "effect_water":
+            encoder.setRenderPipelineState(try executor.renderPipeline(
+                fragmentName: "wpe_effect_water_fragment",
+                blendMode: pass.pass.blending,
+                colorPixelFormat: destination.texture.pixelFormat,
+                depthPixelFormat: depthPixelFormat
+            ))
+            let reference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
+            let texture = try executor.resolve(
+                reference: reference,
+                textures: textures,
+                frameState: frameState,
+                currentTargetID: destination.id
+            )
+            encoder.setFragmentTexture(texture, index: 0)
+            var uniforms = WPEWaterUniforms(
+                amplitude: executor.floatScalar(
+                    named: ["u_Amplitude", "amplitude", "amount", "strength"],
+                    in: pass,
+                    default: 0.01
+                ),
+                frequency: executor.floatScalar(
+                    named: ["u_Frequency", "frequency", "scale"],
+                    in: pass,
+                    default: 20
+                ),
+                speed: executor.floatScalar(
+                    named: ["u_Speed", "speed"],
+                    in: pass,
+                    default: 1
+                ),
+                time: executor.floatScalar(
+                    named: "g_Time",
+                    in: pass,
+                    default: 0
+                )
+            )
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPEWaterUniforms>.stride, index: 0)
+
+        case "effect_shake":
+            encoder.setRenderPipelineState(try executor.renderPipeline(
+                fragmentName: "wpe_effect_shake_fragment",
+                blendMode: pass.pass.blending,
+                colorPixelFormat: destination.texture.pixelFormat,
+                depthPixelFormat: depthPixelFormat
+            ))
+            let reference = pass.textureBindings[0] ?? pass.pass.textures[0] ?? pass.pass.source
+            let texture = try executor.resolve(
+                reference: reference,
+                textures: textures,
+                frameState: frameState,
+                currentTargetID: destination.id
+            )
+            encoder.setFragmentTexture(texture, index: 0)
+            var uniforms = WPEShakeUniforms(
+                magnitude: executor.floatScalar(
+                    named: ["u_Magnitude", "magnitude", "amount", "strength"],
+                    in: pass,
+                    default: 0.01
+                ),
+                time: executor.floatScalar(
+                    named: "g_Time",
+                    in: pass,
+                    default: 0
+                ),
+                frequency: executor.floatScalar(
+                    named: ["u_Frequency", "frequency", "speed"],
+                    in: pass,
+                    default: 24
+                )
+            )
+            encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPEShakeUniforms>.stride, index: 0)
 
         default:
             throw WPEMetalRenderExecutorError.unsupportedShader(pass.pass.shader)

--- a/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
+++ b/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
@@ -85,3 +85,135 @@ fragment half4 wpe_compose_fragment(
     float4 composed = mix(a, b, b.a);
     return half4(float4(composed.rgb * uniforms.color.rgb, composed.a * uniforms.color.a));
 }
+
+// Phase 2D-C: pre-compiled WPE effect set. Each fragment ships hand-written
+// MSL approximating a popular WPE Workshop effect; auto GLSL→MSL
+// translation (Phase 2D route A/B) is a separate, larger project.
+
+struct WPEColorBalanceUniforms {
+    float brightness;
+    float contrast;
+    float saturation;
+    float padding;
+};
+
+fragment half4 wpe_effect_colorbalance_fragment(
+    WPEVertexOut in [[stage_in]],
+    texture2d<half, access::sample> texture0 [[texture(0)]],
+    constant WPEColorBalanceUniforms& uniforms [[buffer(0)]]
+) {
+    constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
+    float4 color = float4(texture0.sample(linearSampler, in.uv));
+
+    float3 rgb = color.rgb + uniforms.brightness;
+    rgb = (rgb - 0.5) * max(uniforms.contrast, 0.0) + 0.5;
+
+    float luma = dot(rgb, float3(0.2126, 0.7152, 0.0722));
+    rgb = mix(float3(luma), rgb, max(uniforms.saturation, 0.0));
+
+    return half4(float4(saturate(rgb), color.a));
+}
+
+struct WPEBlurUniforms {
+    float2 texelSize;
+    float radius;
+    float padding;
+};
+
+fragment half4 wpe_effect_blur_fragment(
+    WPEVertexOut in [[stage_in]],
+    texture2d<half, access::sample> texture0 [[texture(0)]],
+    constant WPEBlurUniforms& uniforms [[buffer(0)]]
+) {
+    constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
+
+    const float offsets[9] = {
+        -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0
+    };
+    const float weights[9] = {
+        0.05, 0.09, 0.12, 0.15, 0.18, 0.15, 0.12, 0.09, 0.05
+    };
+
+    float2 stepUV = float2(uniforms.texelSize.x, 0.0) * max(uniforms.radius, 0.0);
+    float4 color = float4(0.0);
+    for (uint i = 0; i < 9; i++) {
+        float2 uv = clamp(in.uv + stepUV * offsets[i], float2(0.0), float2(1.0));
+        color += float4(texture0.sample(linearSampler, uv)) * weights[i];
+    }
+
+    return half4(color);
+}
+
+struct WPEVignetteUniforms {
+    float innerRadius;
+    float outerRadius;
+    float intensity;
+    float padding;
+};
+
+fragment half4 wpe_effect_vignette_fragment(
+    WPEVertexOut in [[stage_in]],
+    texture2d<half, access::sample> texture0 [[texture(0)]],
+    constant WPEVignetteUniforms& uniforms [[buffer(0)]]
+) {
+    constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
+
+    float4 color = float4(texture0.sample(linearSampler, in.uv));
+    float innerRadius = max(uniforms.innerRadius, 0.0);
+    float outerRadius = max(uniforms.outerRadius, innerRadius + 0.0001);
+    float edge = smoothstep(innerRadius, outerRadius, distance(in.uv, float2(0.5, 0.5)));
+    float factor = mix(1.0, 1.0 - saturate(uniforms.intensity), edge);
+
+    return half4(float4(saturate(color.rgb * factor), color.a));
+}
+
+struct WPEWaterUniforms {
+    float amplitude;
+    float frequency;
+    float speed;
+    float time;
+};
+
+fragment half4 wpe_effect_water_fragment(
+    WPEVertexOut in [[stage_in]],
+    texture2d<half, access::sample> texture0 [[texture(0)]],
+    constant WPEWaterUniforms& uniforms [[buffer(0)]]
+) {
+    constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
+
+    float phase = uniforms.time * uniforms.speed;
+    float frequency = max(uniforms.frequency, 0.0);
+    float2 wave = float2(
+        sin((in.uv.y + phase) * frequency),
+        cos((in.uv.x + phase) * frequency)
+    ) * uniforms.amplitude;
+
+    float2 uv = clamp(in.uv + wave, float2(0.0), float2(1.0));
+    return texture0.sample(linearSampler, uv);
+}
+
+struct WPEShakeUniforms {
+    float magnitude;
+    float time;
+    float frequency;
+    float padding;
+};
+
+fragment half4 wpe_effect_shake_fragment(
+    WPEVertexOut in [[stage_in]],
+    texture2d<half, access::sample> texture0 [[texture(0)]],
+    constant WPEShakeUniforms& uniforms [[buffer(0)]]
+) {
+    constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
+
+    float frequency = max(uniforms.frequency, 0.001);
+    float phase = floor(uniforms.time * frequency);
+    float magnitude = clamp(uniforms.magnitude, 0.0, 0.25);
+    float2 jitter = float2(
+        cos(phase * 12.9898),
+        sin(phase * 78.233)
+    ) * magnitude;
+
+    float2 uv = clamp(in.uv + jitter, float2(0.0), float2(1.0));
+    return texture0.sample(linearSampler, uv);
+}

--- a/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
+++ b/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
@@ -965,3 +965,290 @@ private extension WPEMetalRenderExecutorTests {
         #expect(pixel.a >= 250)
     }
 }
+
+// MARK: - Phase 2D-C effect tests
+
+private func effectPass(
+    id: String,
+    shader: String,
+    source: WPETextureReference,
+    target: WPERenderTarget = .scene,
+    constants: [String: WPESceneShaderConstantValue],
+    blending: String = "disabled"
+) -> WPERenderPass {
+    WPERenderPass(
+        id: id,
+        phase: .effect(file: "\(shader)/effect.json"),
+        shader: shader,
+        source: source,
+        target: target,
+        textures: [0: source],
+        binds: [:],
+        constants: constants,
+        combos: [:],
+        blending: blending,
+        cullMode: "nocull",
+        depthTest: "disabled",
+        depthWrite: "disabled"
+    )
+}
+
+private func expectPixel(
+    _ pixel: Pixel,
+    approximately expected: Pixel,
+    tolerance: Int = 4
+) {
+    #expect(abs(Int(pixel.r) - Int(expected.r)) <= tolerance)
+    #expect(abs(Int(pixel.g) - Int(expected.g)) <= tolerance)
+    #expect(abs(Int(pixel.b) - Int(expected.b)) <= tolerance)
+    #expect(abs(Int(pixel.a) - Int(expected.a)) <= tolerance)
+}
+
+private extension WPEMetalRenderExecutorTests {
+    @Test("Color balance built-in desaturates red to luminance")
+    func colorBalanceDesaturatesRedToLuminance() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+        let input = try makeRGBAInputTexture(
+            device: device,
+            width: 1,
+            height: 1,
+            bytes: Data([255, 0, 0, 255])
+        )
+
+        let pass = effectPass(
+            id: "effect.colorbalance",
+            shader: "effects/colorbalance",
+            source: .image("materials/red.png"),
+            constants: [
+                "u_Brightness": .number(0),
+                "u_Contrast": .number(1),
+                "u_Saturation": .number(0)
+            ]
+        )
+        let pipeline = preparedPipeline(
+            localFBOs: [],
+            passes: [
+                preparedBuiltinPass(
+                    pass,
+                    bindings: [0: .image("materials/red.png")],
+                    uniforms: pass.constants
+                )
+            ]
+        )
+
+        let output = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 1, height: 1),
+            textures: ["materials/red.png": input]
+        )
+        let pixel = try readPixel(output, x: 0, y: 0)
+
+        // Linear luma for red is 0.2126; storing to rgba8Unorm_srgb reads back ~127.
+        expectPixel(pixel, approximately: Pixel(r: 127, g: 127, b: 127, a: 255))
+    }
+
+    @Test("Blur built-in applies centered 9 tap kernel")
+    func blurAppliesCenteredNineTapKernel() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let input = try makeRGBAInputTexture(
+            device: device,
+            width: 9,
+            height: 1,
+            bytes: Data([
+                0, 0, 0, 255,
+                0, 0, 0, 255,
+                0, 0, 0, 255,
+                0, 0, 0, 255,
+                255, 0, 0, 255,
+                0, 0, 0, 255,
+                0, 0, 0, 255,
+                0, 0, 0, 255,
+                0, 0, 0, 255
+            ])
+        )
+
+        let pass = effectPass(
+            id: "effect.blur",
+            shader: "effects/blur",
+            source: .image("materials/pulse.png"),
+            constants: ["u_Radius": .number(1)]
+        )
+        let pipeline = preparedPipeline(
+            localFBOs: [],
+            passes: [
+                preparedBuiltinPass(
+                    pass,
+                    bindings: [0: .image("materials/pulse.png")],
+                    uniforms: pass.constants
+                )
+            ]
+        )
+
+        let output = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 9, height: 1),
+            textures: ["materials/pulse.png": input]
+        )
+        let pixel = try readPixel(output, x: 4, y: 0)
+
+        // Center weight 0.18; storing 0.18 linear red to sRGB reads back ~118.
+        expectPixel(pixel, approximately: Pixel(r: 118, g: 0, b: 0, a: 255))
+    }
+
+    @Test("Vignette built-in darkens outside outer radius")
+    func vignetteDarkensOutsideOuterRadius() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let input = try makeRGBAInputTexture(
+            device: device,
+            width: 4,
+            height: 4,
+            bytes: Data(repeating: 255, count: 4 * 4 * 4)
+        )
+
+        let pass = effectPass(
+            id: "effect.vignette",
+            shader: "effects/vignette/vignette.json",
+            source: .image("materials/white.png"),
+            constants: [
+                "u_InnerRadius": .number(0),
+                "u_OuterRadius": .number(0.5),
+                "u_Intensity": .number(1)
+            ]
+        )
+        let pipeline = preparedPipeline(
+            localFBOs: [],
+            passes: [
+                preparedBuiltinPass(
+                    pass,
+                    bindings: [0: .image("materials/white.png")],
+                    uniforms: pass.constants
+                )
+            ]
+        )
+
+        let output = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 4, height: 4),
+            textures: ["materials/white.png": input]
+        )
+        let pixel = try readPixel(output, x: 0, y: 0)
+
+        expectPixel(pixel, approximately: Pixel(r: 0, g: 0, b: 0, a: 255))
+    }
+
+    @Test("Water built-in displaces UVs with time driven wave")
+    func waterDisplacesUVsWithWave() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let input = try makeRGBAInputTexture(
+            device: device,
+            width: 2,
+            height: 2,
+            bytes: Data([
+                255, 0, 0, 255,
+                255, 0, 0, 255,
+                0, 0, 255, 255,
+                0, 0, 255, 255
+            ])
+        )
+
+        let pass = effectPass(
+            id: "effect.water",
+            shader: "effects/distort",
+            source: .image("materials/two_rows.png"),
+            constants: [
+                "u_Amplitude": .number(1),
+                "u_Frequency": .number(0),
+                "u_Speed": .number(0)
+            ]
+        )
+        let pipeline = preparedPipeline(
+            localFBOs: [],
+            passes: [
+                preparedBuiltinPass(
+                    pass,
+                    bindings: [0: .image("materials/two_rows.png")],
+                    uniforms: pass.constants
+                )
+            ]
+        )
+
+        let output = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 2, height: 2),
+            textures: ["materials/two_rows.png": input],
+            runtimeUniforms: WPEMetalRuntimeUniforms(
+                time: 0,
+                daytime: 0,
+                brightness: 1,
+                pointerPosition: SIMD2<Double>(0.5, 0.5)
+            )
+        )
+        let pixel = try readPixel(output, x: 0, y: 0)
+
+        // amplitude 1 + frequency 0 + speed 0 → wave = (sin(0), cos(0)) * 1 = (0, 1).
+        // UV (0.25, 0.25) + (0, 1) clamps to (0.25, 1.0) → bottom row → blue.
+        expectPixel(pixel, approximately: Pixel(r: 0, g: 0, b: 255, a: 255))
+    }
+
+    @Test("Shake built-in applies bounded deterministic UV offset")
+    func shakeAppliesBoundedDeterministicUVOffset() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+
+        let input = try makeRGBAInputTexture(
+            device: device,
+            width: 4,
+            height: 1,
+            bytes: Data([
+                255, 0, 0, 255,
+                0, 255, 0, 255,
+                0, 0, 255, 255,
+                255, 255, 255, 255
+            ])
+        )
+
+        let pass = effectPass(
+            id: "effect.shake",
+            shader: "effects/shake/shake.json",
+            source: .image("materials/stripe.png"),
+            constants: [
+                "u_Magnitude": .number(0.25),
+                "u_Frequency": .number(1)
+            ]
+        )
+        let pipeline = preparedPipeline(
+            localFBOs: [],
+            passes: [
+                preparedBuiltinPass(
+                    pass,
+                    bindings: [0: .image("materials/stripe.png")],
+                    uniforms: pass.constants
+                )
+            ]
+        )
+
+        let output = try executor.render(
+            pipeline: pipeline,
+            size: CGSize(width: 4, height: 1),
+            textures: ["materials/stripe.png": input],
+            runtimeUniforms: WPEMetalRuntimeUniforms(
+                time: 0,
+                daytime: 0,
+                brightness: 1,
+                pointerPosition: SIMD2<Double>(0.5, 0.5)
+            )
+        )
+        let pixel = try readPixel(output, x: 1, y: 0)
+
+        // At time 0, phase = floor(0*1) = 0; jitter = (cos(0), sin(0)) * 0.25 = (0.25, 0).
+        // Pixel x=1 (uv ≈ 0.375) + 0.25 = 0.625 → samples source x ≈ 2 → blue.
+        expectPixel(pixel, approximately: Pixel(r: 0, g: 0, b: 255, a: 255))
+    }
+}

--- a/LiveWallpaperTests/WPERenderPipelineBuilderTests.swift
+++ b/LiveWallpaperTests/WPERenderPipelineBuilderTests.swift
@@ -408,6 +408,57 @@ struct WPERenderPipelineBuilderTests {
         #expect(shader.fragmentSource.contains("#define lerp mix"))
     }
 
+    @Test(
+        "Recognises Phase 2D-C effect aliases under bare, effects/, and materials/ paths",
+        arguments: [
+            "blur",
+            "effects/blur",
+            "effects/blur/blur",
+            "materials/effects/blur/blur",
+            "materials/effects/blur/blur.json",
+            "MATERIALS/Effects/Blur/Blur.JSON"
+        ]
+    )
+    func recognisesEffectAliasesAcrossPathStyles(shaderName: String) throws {
+        let fixture = try makeFixture(files: [:])
+        defer { fixture.cleanup() }
+
+        let graph = WPERenderGraph(layers: [
+            WPERenderLayer(
+                objectID: "1",
+                objectName: "Layer",
+                imagePath: "materials/base.png",
+                materialPath: nil,
+                compositeA: "a",
+                compositeB: "b",
+                localFBOs: [],
+                passes: [
+                    WPERenderPass(
+                        id: "1.0",
+                        phase: .effect(file: "effects/blur/effect.json"),
+                        shader: shaderName,
+                        source: .fbo("_rt_Source"),
+                        target: .scene,
+                        textures: [0: .fbo("_rt_Source")],
+                        binds: [:],
+                        constants: [:],
+                        combos: [:],
+                        blending: "normal",
+                        cullMode: "nocull",
+                        depthTest: "disabled",
+                        depthWrite: "disabled"
+                    )
+                ]
+            )
+        ])
+
+        let pipeline = try WPERenderPipelineBuilder(cacheRootURL: fixture.root).build(graph: graph)
+        let shader = try #require(pipeline.layers.first?.passes.first?.shader)
+
+        #expect(shader.isBuiltin)
+        #expect(shader.name == shaderName)
+    }
+
     private struct Fixture {
         let root: URL
 


### PR DESCRIPTION
## Summary

Ships hand-written MSL fragments for the five most common Wallpaper Engine Workshop effect families — `colorbalance`, `blur`, `vignette`, `water`/`distort`, `shake` — so authored materials with these shader names resolve to dedicated Metal pipelines instead of failing closed. Auto GLSL→MSL translation (Phase 2D-A/B) remains a separate, larger project; this is the pragmatic **Route C** path selected to unblock Workshop-content compatibility.

## Changes

- **`WPEMetalBuiltins.metal`** — five new fragment shaders + 16-byte aligned uniform structs:
  - Color balance: brightness add, contrast scale around 0.5, saturation luma mix (BT.709 weights)
  - Blur: 9-tap horizontal gaussian (weights {0.05,0.09,0.12,0.15,0.18,0.15,0.12,0.09,0.05})
  - Vignette: smoothstep distance falloff from (0.5, 0.5)
  - Water: sin/cos UV displacement driven by `time × speed`
  - Shake: deterministic per-frame jitter (`floor(time × frequency)` → pseudo-random offset, magnitude clamped to ±0.25)
- **`WPEMetalRenderExecutor`** — extends `normalizedBuiltinShaderName` so `<family>`, `effects/<family>`, and `effects/<family>/<family>` (with optional `materials/` prefix and `.json` suffix) all resolve to the matching MSL fragment, then dispatches with a parity-checked Swift uniform struct.
- **`WPERenderPipelineBuilder`** — mirrors the same alias normalization and routes effect aliases through `copyProgram` so they stay `isBuiltin: true`. Authored GLSL is never executed at runtime; it is kept only for future shader-translator paths.
- **`floatScalar(named: [String], ...)`** — honours the "prepared uniforms first across all aliases, then constants across all aliases" precedence rule so legacy `u_X` / `X` / `g_X` aliases don't let an authored constant shadow a runtime-merged uniform.

## Audit fixes applied (codex review)

- **High** — strip leading `materials/` prefix in both executor and builder before the alias switch so Workshop paths like `materials/effects/blur/blur.json` resolve as builtins.
- **Medium** — fix the multi-name `floatScalar` to use two-pass precedence (uniforms first, then constants) instead of interleaving.
- **Medium** — add builder alias test coverage including `materials/effects/...`, `.json`, and mixed-case input.

## Test plan

- [x] 416 swift-testing tests pass (415 baseline + 1 parameterised builder case with 6 arguments)
- [x] Five new golden-pixel executor cases verify each effect (color balance desaturation, blur center kernel, vignette corner darkening, water UV displacement, shake bounded jitter)
- [x] Parameterised builder case covers `blur` / `effects/blur` / `effects/blur/blur` / `materials/effects/blur/blur` / `.json` suffix / mixed case

🤖 Generated with [Claude Code](https://claude.com/claude-code)