### PR TITLE
Week 1 P0: HTML scheme isolation, runtime lifecycle, error banner

### DIFF
--- a/LiveWallpaper/Models/WallpaperRuntimeError.swift
+++ b/LiveWallpaper/Models/WallpaperRuntimeError.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// User-visible runtime errors raised by a wallpaper session.
+/// Surfaced through `WallpaperRuntimeSession.runtimeError` and rendered by
+/// `RuntimeErrorBanner` in screen-detail UI so failures stop being silent.
+enum WallpaperRuntimeError: Error, Equatable, Sendable {
+    case fileAccessDenied(URL)
+    case mediaNotPlayable(URL, code: Int?)
+    case webNavigationFailed(URL, code: Int?, description: String)
+    case networkOffline
+    case sandboxRevoked
+
+    var userMessage: String {
+        switch self {
+        case .fileAccessDenied(let url):
+            return "Cannot access \(url.lastPathComponent). Re-pick the source to restore permission."
+        case .mediaNotPlayable(let url, let code):
+            if let code {
+                return "The video \(url.lastPathComponent) cannot be played (error \(code))."
+            }
+            return "The video \(url.lastPathComponent) cannot be played."
+        case .webNavigationFailed(let url, let code, let description):
+            if let code {
+                return "The HTML wallpaper at \(url.absoluteString) failed to load (error \(code)): \(description)"
+            }
+            return "The HTML wallpaper at \(url.absoluteString) failed to load: \(description)"
+        case .networkOffline:
+            return "The network appears to be offline."
+        case .sandboxRevoked:
+            return "File permission expired. Re-pick the source to restore access."
+        }
+    }
+
+    var canRetry: Bool {
+        switch self {
+        case .fileAccessDenied, .sandboxRevoked:
+            return false
+        case .mediaNotPlayable, .webNavigationFailed, .networkOffline:
+            return true
+        }
+    }
+}

--- a/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
+++ b/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
@@ -24,6 +24,13 @@ final class AmbientWallpaperSessionBuilder {
             Logger.info("HTML wallpaper: detected Wallpaper Engine project — enabling physical-pixel layout", category: .screenManager)
         }
 
+        let session = AmbientWallpaperSession(window: window, wallpaperType: .html, performanceTarget: htmlView)
+        // Bridge HTML navigation failures to the session before kicking off the
+        // first load so an immediate sandbox failure still surfaces.
+        htmlView.onError = { [weak session] error in
+            session?.recordRuntimeError(error)
+        }
+
         htmlView.apply(effective)
         htmlView.loadSource(source)
 
@@ -32,7 +39,7 @@ final class AmbientWallpaperSessionBuilder {
         // 别再追加额外的 orderBack — 否则会把抬升的交互窗户拉回桌面层、
         // 导致 "Click wallpaper to reveal desktop" 重新生效。
         window.setWallpaperMouseInteractionEnabled(config.allowMouseInteraction)
-        return AmbientWallpaperSession(window: window, wallpaperType: .html, performanceTarget: htmlView)
+        return session
     }
 
     /// Wallpaper Engine workshop projects ship a `project.json` next to the

--- a/LiveWallpaper/Runtime/WallpaperRuntimeSession.swift
+++ b/LiveWallpaper/Runtime/WallpaperRuntimeSession.swift
@@ -6,6 +6,9 @@ protocol WallpaperRuntimeSession: AnyObject {
     var summary: WallpaperSessionSummary { get }
     var videoPlayer: WallpaperVideoPlayer? { get }
     var wallpaperWindow: NSWindow? { get }
+    /// Latest user-visible failure or `nil` while the session is healthy.
+    /// Surfaced through `RuntimeErrorBanner` in screen-detail UI.
+    var runtimeError: WallpaperRuntimeError? { get }
 
     func show()
     func hide()
@@ -13,11 +16,31 @@ protocol WallpaperRuntimeSession: AnyObject {
     func updateFrame(to frame: CGRect)
     func cleanup()
 
+    /// Suspend during `NSWorkspaceWillSleep` — pauses playback while
+    /// remembering enough state for `resume()` to restore it.
+    func suspend()
+    /// Resume after `NSWorkspaceDidWake`.
+    func resume()
+    /// User-triggered retry from the error banner.
+    func retry() async
+
     /// Wait for the first frame so transitions do not flash empty.
     func prepareForDisplay(timeout: Duration) async -> Bool
 }
 
 extension WallpaperRuntimeSession {
+    var runtimeError: WallpaperRuntimeError? { nil }
+
+    func suspend() {
+        applyPerformanceProfile(.suspended)
+    }
+
+    func resume() {
+        applyPerformanceProfile(.quality)
+    }
+
+    func retry() async {}
+
     func prepareForDisplay(timeout: Duration) async -> Bool {
         do {
             try await Task.sleep(for: .milliseconds(50))
@@ -49,9 +72,19 @@ protocol WallpaperPlaybackControllable: WallpaperRuntimeSession {
 @MainActor
 final class VideoWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackControllable {
     private var player: WallpaperVideoPlayer?
+    private var wasPlayingBeforeSuspend: Bool?
+    private(set) var runtimeError: WallpaperRuntimeError? {
+        didSet {
+            guard oldValue != runtimeError else { return }
+            onRuntimeErrorChange?()
+        }
+    }
+    var onRuntimeErrorChange: (@MainActor () -> Void)?
 
     init(player: WallpaperVideoPlayer) {
         self.player = player
+        runtimeError = player.runtimeError
+        attachErrorHandler(to: player)
     }
 
     var wallpaperType: WallpaperType {
@@ -60,11 +93,12 @@ final class VideoWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
 
     var summary: WallpaperSessionSummary {
         guard let player else { return .notConfigured }
+        let isHealthy = runtimeError == nil
         return WallpaperSessionSummary(
             wallpaperType: .video,
-            activity: player.isPlaying ? .active : .paused,
+            activity: isHealthy && player.isPlaying ? .active : .paused,
             supportsPlaybackControl: true,
-            subtitle: nil
+            subtitle: runtimeError?.userMessage
         )
     }
 
@@ -105,9 +139,53 @@ final class VideoWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
         player?.pause()
     }
 
+    func suspend() {
+        guard wasPlayingBeforeSuspend == nil else { return }
+        wasPlayingBeforeSuspend = player?.isPlaying ?? false
+        player?.suspend()
+    }
+
+    func resume() {
+        guard let wasPlayingBeforeSuspend else { return }
+        self.wasPlayingBeforeSuspend = nil
+        guard wasPlayingBeforeSuspend else { return }
+        player?.resume()
+    }
+
+    func retry() async {
+        guard let oldPlayer = player, let url = oldPlayer.videoURL else { return }
+        let frame = oldPlayer.currentWindowFrame
+        let fitMode = oldPlayer.currentFitMode
+        let muted = oldPlayer.isMuted
+        let speed = Double(oldPlayer.player?.defaultRate ?? 1)
+        let frameRateLimit = oldPlayer.requestedFrameRateLimit
+        let shouldAutoplay = oldPlayer.isPlaying || oldPlayer.shouldAutoplayWhenReady
+
+        oldPlayer.cleanup()
+
+        let replacement = WallpaperVideoPlayer(url: url, frame: frame, fitMode: fitMode)
+        attachErrorHandler(to: replacement)
+        replacement.setMuted(muted)
+        replacement.setPlaybackSpeed(speed)
+        if frameRateLimit > 0 {
+            replacement.setFrameRateLimit(frameRateLimit)
+        }
+        if !shouldAutoplay {
+            replacement.pause()
+        }
+        player = replacement
+        runtimeError = replacement.runtimeError
+    }
+
     func cleanup() {
         player?.cleanup()
         player = nil
+    }
+
+    private func attachErrorHandler(to player: WallpaperVideoPlayer) {
+        player.onError = { [weak self] error in
+            self?.runtimeError = error
+        }
     }
 }
 
@@ -116,8 +194,16 @@ final class AmbientWallpaperSession: WallpaperRuntimeSession {
     private var window: NSWindow?
     private weak var performanceTarget: (any WallpaperPerformanceConfigurable)?
     private var currentProfile: WallpaperPerformanceProfile = .quality
+    private var profileBeforeSuspend: WallpaperPerformanceProfile?
     private var isVisible = true
     let wallpaperType: WallpaperType
+    private(set) var runtimeError: WallpaperRuntimeError? {
+        didSet {
+            guard oldValue != runtimeError else { return }
+            onRuntimeErrorChange?()
+        }
+    }
+    var onRuntimeErrorChange: (@MainActor () -> Void)?
 
     init(
         window: NSWindow,
@@ -131,12 +217,13 @@ final class AmbientWallpaperSession: WallpaperRuntimeSession {
     }
 
     var summary: WallpaperSessionSummary {
-        let activity: WallpaperSessionActivity = isVisible && currentProfile != .suspended ? .active : .paused
+        let isHealthy = runtimeError == nil
+        let activity: WallpaperSessionActivity = isHealthy && isVisible && currentProfile != .suspended ? .active : .paused
         return WallpaperSessionSummary(
             wallpaperType: wallpaperType,
             activity: activity,
             supportsPlaybackControl: false,
-            subtitle: nil
+            subtitle: runtimeError?.userMessage
         )
     }
 
@@ -167,6 +254,28 @@ final class AmbientWallpaperSession: WallpaperRuntimeSession {
     func applyPerformanceProfile(_ profile: WallpaperPerformanceProfile) {
         currentProfile = profile
         performanceTarget?.applyPerformanceProfile(isVisible ? profile : .suspended)
+    }
+
+    func suspend() {
+        guard profileBeforeSuspend == nil else { return }
+        profileBeforeSuspend = currentProfile
+        applyPerformanceProfile(.suspended)
+    }
+
+    func resume() {
+        guard let profileBeforeSuspend else { return }
+        self.profileBeforeSuspend = nil
+        applyPerformanceProfile(profileBeforeSuspend)
+    }
+
+    func retry() async {
+        runtimeError = nil
+        (performanceTarget as? HTMLWallpaperView)?.reloadCurrentSource()
+    }
+
+    /// Bridged from `HTMLWallpaperView.onError` so the session keeps the user-visible error.
+    func recordRuntimeError(_ error: WallpaperRuntimeError) {
+        runtimeError = error
     }
 
     func cleanup() {

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -130,7 +130,16 @@ final class ScreenManager {
             }
             .store(in: &cleanupTasks)
         
-        NotificationCenter.default.publisher(for: NSWorkspace.didWakeNotification)
+        // Sleep / wake notifications are posted on NSWorkspace's notification
+        // center, NOT NotificationCenter.default. The previous version subscribed
+        // on the wrong center and effectively never fired on wake.
+        NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.willSleepNotification)
+            .sink { [weak self] _ in
+                self?.handleSystemSleep()
+            }
+            .store(in: &cleanupTasks)
+
+        NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)
             .sink { [weak self] _ in
                 self?.handleSystemWake()
             }
@@ -326,6 +335,10 @@ final class ScreenManager {
     /// Use `clearWallpaperForScreen(_:)` when you also want to delete the saved
     /// configuration for that screen.
     private func releaseRuntimeSession(_ screen: Screen) {
+        // Bump generation first so any in-flight async transition (e.g.
+        // setVideo / playlist / schedule) sees the new value and short-circuits
+        // before instantiating a player against a now-dead screen.
+        bumpTransition(for: screen.id)
         videoEffectsApplier.cancelInflight(for: screen.id)
         assetReadinessWork[screen.id]?.cancel()
         assetReadinessWork[screen.id] = nil
@@ -435,23 +448,26 @@ final class ScreenManager {
             return
         }
 
-        let generation = bumpTransition(for: screen.id)
+        let screenID = screen.id
+        let generation = bumpTransition(for: screenID)
         Task {
             do {
                 try await PlayableVideoLoader.validatePlayableVideo(at: url)
                 await MainActor.run { [weak self] in
-                    guard let self, self.isCurrentTransition(generation, for: screen.id) else { return }
+                    guard let self,
+                          self.isCurrentTransition(generation, for: screenID),
+                          let liveScreen = self.screens.first(where: { $0.id == screenID }) else { return }
                     self.configurationStore.save(configuration)
-                    guard SettingsManager.shared.validateConfiguration(for: screen.id) else {
-                        Logger.error("Failed to save video configuration for screen \(screen.id)", category: .screenManager)
+                    guard SettingsManager.shared.validateConfiguration(for: screenID) else {
+                        Logger.error("Failed to save video configuration for screen \(screenID)", category: .screenManager)
                         if let existing {
                             self.configurationStore.save(existing)
                         } else {
-                            self.configurationStore.remove(for: screen.id)
+                            self.configurationStore.remove(for: screenID)
                         }
                         return
                     }
-                    self.setupVideoPlayback(url: url, screen: screen)
+                    self.setupVideoPlayback(url: url, screen: liveScreen)
                 }
             } catch {
                 await MainActor.run {
@@ -556,7 +572,9 @@ final class ScreenManager {
                     frame: screen.frame,
                     fitMode: configuration.fitMode
                 )
-                screen.installRuntimeSession(VideoWallpaperSession(player: player))
+                let session = VideoWallpaperSession(player: player)
+                observeRuntimeErrors(for: session)
+                screen.installRuntimeSession(session)
                 notifyWallpaperSessionChanged()
 
                 player.setPlaybackSpeed(configuration.playbackSpeed)
@@ -665,7 +683,9 @@ final class ScreenManager {
         }
 
         if let index = screens.firstIndex(where: { $0.id == screen.id }) {
-            screens[index].installRuntimeSession(VideoWallpaperSession(player: player))
+            let session = VideoWallpaperSession(player: player)
+            observeRuntimeErrors(for: session)
+            screens[index].installRuntimeSession(session)
             let liveScreen = screens[index]
             let globalSettings = SettingsManager.shared.loadGlobalSettings()
             applyPerformancePolicy(
@@ -774,6 +794,35 @@ final class ScreenManager {
 
     func wallpaperSummary(for screen: Screen) -> WallpaperSessionSummary {
         wallpaperSessionSummaryCache.summary(for: screen.id, fallback: screen.wallpaperSessionSummary)
+    }
+
+    /// Currently surfaced error for a screen's runtime session (or `nil`).
+    /// Reads through `wallpaperSessionStateVersion` so SwiftUI re-evaluates
+    /// the banner when the session reports a new state.
+    func runtimeError(for screen: Screen) -> WallpaperRuntimeError? {
+        _ = wallpaperSessionStateVersion
+        return screen.runtimeSession?.runtimeError
+    }
+
+    func retryRuntimeSession(for screen: Screen) {
+        Task { @MainActor [weak self, weak screen] in
+            guard let self, let screen else { return }
+            await screen.runtimeSession?.retry()
+            self.markWallpaperSessionStateChanged()
+        }
+    }
+
+    /// Subscribes the manager to a session's error changes so the SwiftUI
+    /// banner refreshes when a player or web view starts / clears a failure.
+    private func observeRuntimeErrors(for session: any WallpaperRuntimeSession) {
+        let notify: @MainActor () -> Void = { [weak self] in
+            self?.markWallpaperSessionStateChanged()
+        }
+        if let session = session as? VideoWallpaperSession {
+            session.onRuntimeErrorChange = notify
+        } else if let session = session as? AmbientWallpaperSession {
+            session.onRuntimeErrorChange = notify
+        }
     }
 
     func wallpaperDisplayName(for screen: Screen) -> String? {
@@ -942,8 +991,19 @@ final class ScreenManager {
     }
     
     // MARK: - System Events
+    private func handleSystemSleep() {
+        Logger.info("System sleep detected", category: .lifecycle)
+        for screen in screens {
+            screen.runtimeSession?.suspend()
+        }
+        markWallpaperSessionStateChanged()
+    }
+
     private func handleSystemWake() {
         Logger.info("System wake detected", category: .lifecycle)
+        for screen in screens {
+            screen.runtimeSession?.resume()
+        }
         refreshScreens()
         powerMonitor.refreshPowerStatus()
         handlePowerStateChange(powerMonitor.currentPowerSource)
@@ -1514,6 +1574,7 @@ final class ScreenManager {
                 Logger.warning("Scene wallpaper for screen \(screen.id) (workshop \(descriptor.workshopID)) could not be built — cache missing or descriptor invalid", category: .screenManager)
                 return
             }
+            observeRuntimeErrors(for: sceneSession)
             screen.installRuntimeSession(sceneSession)
             // Sync exclusive-rendering state on install so a scene mounted
             // while the inspector window is already key starts at 1 fps
@@ -1534,6 +1595,7 @@ final class ScreenManager {
             return
         }
 
+        observeRuntimeErrors(for: session)
         screen.installRuntimeSession(session)
         let globalSettings = SettingsManager.shared.loadGlobalSettings()
         applyPerformancePolicy(

--- a/LiveWallpaper/VideoPlayback/FolderURLSchemeHandler.swift
+++ b/LiveWallpaper/VideoPlayback/FolderURLSchemeHandler.swift
@@ -1,5 +1,5 @@
 import Foundation
-import WebKit
+@preconcurrency import WebKit
 import UniformTypeIdentifiers
 
 /// Serves files from a security-scoped folder under a custom `livewallpaper://`
@@ -7,32 +7,62 @@ import UniformTypeIdentifiers
 /// of Vite/webpack ES-module bundles fail because `<script type="module">`
 /// + `crossorigin` triggers CORS rejection that file:// cannot satisfy; this
 /// handler avoids the issue entirely.
+///
+/// Top-level navigations must include the per-session `?n=<nonce>` query
+/// parameter so a stale `livewallpaper://wallpaper/...` URL retained by a
+/// previous folder cannot be replayed against the active folder. Subresource
+/// requests inherit security from the enclosing document, so they don't
+/// need the nonce; WebKit only routes them here while the parent document
+/// loaded with the matching nonce.
+///
 /// `@unchecked Sendable` because WebKit invokes the protocol methods on the
-/// main thread (documented behaviour) and `folderURL` is only ever read /
-/// written from the main thread by `HTMLWallpaperView`.
+/// main thread (documented behaviour) and all mutable state is read / written
+/// from the main thread by `HTMLWallpaperView`.
 final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sendable {
     static let scheme = "livewallpaper"
     static let host = "wallpaper"
     nonisolated static let responseChunkSize = 64 * 1024
 
+    private var activeFolderURL: URL?
+    private var sessionNonce: String?
+    private var activeTasks: [ObjectIdentifier: ActiveTask] = [:]
+
     /// Updated each time `HTMLWallpaperView.loadSource(.folder)` swaps content.
-    var folderURL: URL?
+    /// Setting `nil` (or any different folder) immediately cancels in-flight
+    /// scheme requests so a stale detached worker cannot keep streaming the
+    /// previous folder after the security scope is gone.
+    var folderURL: URL? {
+        get { activeFolderURL }
+        set {
+            if activeFolderURL != newValue {
+                cancelAllActiveTasks()
+            }
+            activeFolderURL = newValue
+            sessionNonce = newValue == nil ? nil : UUID().uuidString
+        }
+    }
+
+    /// Nonce produced for the current `folderURL` session. `HTMLWallpaperView`
+    /// embeds it as `?n=<nonce>` on the top-level URL it asks WebKit to load.
+    var currentSessionNonce: String? {
+        sessionNonce
+    }
 
     func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
-        handle(urlSchemeTask)
-    }
-
-    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {
-        // Reads are synchronous; nothing to cancel.
-    }
-
-    private func handle(_ urlSchemeTask: any WKURLSchemeTask) {
         guard let url = urlSchemeTask.request.url else {
-            urlSchemeTask.didFailWithError(Self.error(.badURL))
+            urlSchemeTask.didFailWithError(Self.makeError(.badURL))
             return
         }
-        guard let folderURL else {
-            urlSchemeTask.didFailWithError(Self.error(.notConnectedToInternet, "No active folder"))
+
+        do {
+            try validateRequest(urlSchemeTask.request, url: url)
+        } catch {
+            urlSchemeTask.didFailWithError(error)
+            return
+        }
+
+        guard let folderURL = activeFolderURL else {
+            urlSchemeTask.didFailWithError(Self.makeError(.notConnectedToInternet, "No active folder"))
             return
         }
 
@@ -44,27 +74,118 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
             return
         }
 
-        do {
-            let mime = Self.mimeType(for: fileURL)
-            let fileSize = try Self.fileSize(for: fileURL)
-            let response = HTTPURLResponse(
-                url: url,
-                statusCode: 200,
-                httpVersion: "HTTP/1.1",
-                headerFields: [
+        let mime = Self.mimeType(for: fileURL)
+        let rangeHeader = urlSchemeTask.request.value(forHTTPHeaderField: "Range")
+        let delivery = SchemeTaskDelivery(urlSchemeTask)
+        let taskID = ObjectIdentifier(urlSchemeTask as AnyObject)
+
+        // Replace any earlier work for the same task identifier (defensive — WK
+        // does not normally re-issue start without first invoking stop).
+        activeTasks[taskID]?.cancel()
+
+        let worker = Task.detached(priority: .userInitiated) { [weak self, fileURL, mime, rangeHeader, url, delivery, taskID] in
+            do {
+                let fileSize = try Self.fileSize(for: fileURL)
+                let range = Self.byteRange(from: rangeHeader, totalLength: fileSize)
+                let statusCode = range == nil ? 200 : 206
+                let contentLength = range?.length ?? fileSize
+
+                var headers = [
                     "Content-Type": mime,
-                    "Content-Length": "\(fileSize)",
-                    // Same-origin for everything served under this scheme.
+                    "Content-Length": "\(contentLength)",
+                    "Accept-Ranges": "bytes",
                     "Access-Control-Allow-Origin": "*"
                 ]
-            ) ?? URLResponse(url: url, mimeType: mime, expectedContentLength: fileSize, textEncodingName: nil) as URLResponse
-            urlSchemeTask.didReceive(response)
-            try Self.sendFile(fileURL, to: urlSchemeTask)
-            urlSchemeTask.didFinish()
-        } catch {
-            Logger.warning("FolderScheme: \(fileURL.lastPathComponent) — \(error.localizedDescription)", category: .screenManager)
-            urlSchemeTask.didFailWithError(error)
+                if let range {
+                    headers["Content-Range"] = "bytes \(range.start)-\(range.end)/\(fileSize)"
+                }
+
+                let response = HTTPURLResponse(
+                    url: url,
+                    statusCode: statusCode,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: headers
+                ) ?? URLResponse(
+                    url: url,
+                    mimeType: mime,
+                    expectedContentLength: contentLength,
+                    textEncodingName: nil
+                )
+
+                await delivery.deliver(response: response)
+                try await Self.streamFile(
+                    fileURL,
+                    to: delivery,
+                    offset: range?.start ?? 0,
+                    length: contentLength
+                )
+                await delivery.finish()
+            } catch is CancellationError {
+                await delivery.fail(with: Self.makeError(.cancelled, "Request cancelled"))
+            } catch {
+                Logger.warning("FolderScheme: \(fileURL.lastPathComponent) — \(error.localizedDescription)", category: .screenManager)
+                await delivery.fail(with: error)
+            }
+
+            await MainActor.run {
+                self?.activeTasks.removeValue(forKey: taskID)
+            }
         }
+
+        activeTasks[taskID] = ActiveTask(worker: worker, delivery: delivery)
+        // Tiny-file race: the detached worker might already have finished and
+        // run its main-thread cleanup before this assignment happened, leaving
+        // a permanently retained entry. Re-check and prune.
+        if delivery.hasTerminated {
+            activeTasks.removeValue(forKey: taskID)
+        }
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {
+        let taskID = ObjectIdentifier(urlSchemeTask as AnyObject)
+        guard let entry = activeTasks.removeValue(forKey: taskID) else { return }
+        // Mark the delivery first so any in-flight `await delivery.deliver(...)`
+        // hop completes as a no-op instead of touching the (now invalid) task.
+        entry.cancel()
+    }
+
+    /// Cancels every in-flight scheme worker. Used when `folderURL` changes
+    /// so the previous folder's bytes never finish streaming after the
+    /// security scope is released.
+    private func cancelAllActiveTasks() {
+        let entries = activeTasks
+        activeTasks.removeAll()
+        for entry in entries.values {
+            entry.cancel()
+        }
+    }
+
+    // MARK: - Validation
+
+    private func validateRequest(_ request: URLRequest, url: URL) throws {
+        guard url.host?.lowercased() == Self.host else {
+            throw Self.makeError(.badURL, "Host mismatch")
+        }
+        guard activeFolderURL != nil else {
+            throw Self.makeError(.notConnectedToInternet, "No active folder")
+        }
+
+        let isTopLevel = request.mainDocumentURL == nil || request.mainDocumentURL == url
+        if isTopLevel, !topLevelNonceIsValid(for: url) {
+            throw Self.makeError(.badURL, "Invalid folder session nonce")
+        }
+    }
+
+    private func topLevelNonceIsValid(for url: URL) -> Bool {
+        guard let sessionNonce,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let items = components.queryItems,
+              items.count == 1,
+              items[0].name == "n",
+              items[0].value == sessionNonce else {
+            return false
+        }
+        return true
     }
 
     // MARK: - Helpers
@@ -82,7 +203,7 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
         let candidatePath = normalizedPath(candidate.path(percentEncoded: false))
 
         guard candidatePath == rootPath || candidatePath.hasPrefix(rootPath + "/") else {
-            throw Self.error(.noPermissionsToReadFile, "Path escapes folder")
+            throw Self.makeError(.noPermissionsToReadFile, "Path escapes folder")
         }
 
         return candidate
@@ -99,25 +220,74 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
     nonisolated private static func fileSize(for url: URL) throws -> Int {
         let values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
         guard values.isRegularFile == true else {
-            throw Self.error(.cannotOpenFile, "Requested resource is not a regular file")
+            throw Self.makeError(.cannotOpenFile, "Requested resource is not a regular file")
         }
         guard let fileSize = values.fileSize else {
-            throw Self.error(.cannotOpenFile, "Missing file size")
+            throw Self.makeError(.cannotOpenFile, "Missing file size")
         }
         return fileSize
     }
 
-    nonisolated private static func sendFile(_ url: URL, to urlSchemeTask: any WKURLSchemeTask) throws {
+    nonisolated private static func streamFile(
+        _ url: URL,
+        to delivery: SchemeTaskDelivery,
+        offset: Int,
+        length: Int
+    ) async throws {
         let handle = try FileHandle(forReadingFrom: url)
-        defer {
-            try? handle.close()
+        defer { try? handle.close() }
+
+        if offset > 0 {
+            try handle.seek(toOffset: UInt64(offset))
         }
 
-        while true {
-            let chunk = try handle.read(upToCount: responseChunkSize) ?? Data()
+        var bytesRemaining = length
+        while bytesRemaining > 0 {
+            try Task.checkCancellation()
+            let chunkLimit = min(responseChunkSize, bytesRemaining)
+            let chunk = try handle.read(upToCount: chunkLimit) ?? Data()
             guard !chunk.isEmpty else { break }
-            urlSchemeTask.didReceive(chunk)
+            bytesRemaining -= chunk.count
+            await delivery.deliver(chunk: chunk)
         }
+    }
+
+    private struct ByteRange: Sendable {
+        let start: Int
+        let end: Int
+        var length: Int { end - start + 1 }
+    }
+
+    nonisolated private static func byteRange(from header: String?, totalLength: Int) -> ByteRange? {
+        guard totalLength > 0,
+              let header,
+              header.lowercased().hasPrefix("bytes="),
+              !header.contains(",") else { return nil }
+
+        let spec = String(header.dropFirst("bytes=".count))
+        let parts = spec.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return nil }
+
+        // Suffix syntax: `bytes=-N` → last N bytes.
+        if parts[0].isEmpty {
+            guard let suffixLength = Int(parts[1]), suffixLength > 0 else { return nil }
+            let length = min(suffixLength, totalLength)
+            let start = totalLength - length
+            return ByteRange(start: start, end: totalLength - 1)
+        }
+
+        guard let start = Int(parts[0]), start >= 0, start < totalLength else { return nil }
+
+        let end: Int
+        if parts[1].isEmpty {
+            end = totalLength - 1
+        } else if let parsed = Int(parts[1]), parsed >= start {
+            end = min(parsed, totalLength - 1)
+        } else {
+            return nil
+        }
+
+        return ByteRange(start: start, end: end)
     }
 
     nonisolated private static func mimeType(for url: URL) -> String {
@@ -136,9 +306,68 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
         }
     }
 
-    nonisolated private static func error(_ code: URLError.Code, _ message: String? = nil) -> NSError {
+    nonisolated static func makeError(_ code: URLError.Code, _ message: String? = nil) -> NSError {
         var info: [String: Any] = [:]
         if let message { info[NSLocalizedDescriptionKey] = message }
         return NSError(domain: NSURLErrorDomain, code: code.rawValue, userInfo: info)
+    }
+}
+
+// MARK: - Internal Types
+
+private struct ActiveTask {
+    let worker: Task<Void, Never>
+    let delivery: SchemeTaskDelivery
+
+    @MainActor
+    func cancel() {
+        delivery.markStopped()
+        worker.cancel()
+    }
+}
+
+/// Bridges the detached worker back to the main-thread `WKURLSchemeTask`.
+/// Once `markStopped()` is called every subsequent delivery is dropped, so a
+/// late chunk can never reach an invalidated task.
+private final class SchemeTaskDelivery: @unchecked Sendable {
+    private let task: any WKURLSchemeTask
+    @MainActor private var isLive: Bool = true
+
+    init(_ task: any WKURLSchemeTask) {
+        self.task = task
+    }
+
+    @MainActor
+    var hasTerminated: Bool { !isLive }
+
+    @MainActor
+    func markStopped() {
+        isLive = false
+    }
+
+    @MainActor
+    func deliver(response: URLResponse) {
+        guard isLive else { return }
+        task.didReceive(response)
+    }
+
+    @MainActor
+    func deliver(chunk data: Data) {
+        guard isLive else { return }
+        task.didReceive(data)
+    }
+
+    @MainActor
+    func finish() {
+        guard isLive else { return }
+        isLive = false
+        task.didFinish()
+    }
+
+    @MainActor
+    func fail(with error: Error) {
+        guard isLive else { return }
+        isLive = false
+        task.didFailWithError(error)
     }
 }

--- a/LiveWallpaper/VideoPlayback/HTMLWallpaperView.swift
+++ b/LiveWallpaper/VideoPlayback/HTMLWallpaperView.swift
@@ -43,6 +43,12 @@ final class HTMLWallpaperView: NSView {
     /// Tracks the last applied `HTMLConfig` so re-`apply()` calls with the
     /// same toggles skip the user-script teardown / re-install.
     private var lastAppliedConfig: HTMLConfig?
+    /// Replays into `loadSource(_:)` for retry / re-entry (sleep wake, error banner).
+    private var lastSource: HTMLSource?
+
+    /// Forwarded to the owning `AmbientWallpaperSession` so failures surface as
+    /// `RuntimeErrorBanner` and can be retried from the screen-detail UI.
+    var onError: (@MainActor (WallpaperRuntimeError) -> Void)?
 
     // MARK: - Initialization
 
@@ -265,20 +271,39 @@ final class HTMLWallpaperView: NSView {
     }
 
     func loadSource(_ source: HTMLSource) {
+        lastSource = source
         stopActiveSecurityScope()
+        // Cut every non-folder source off from the previous folder's scheme handler
+        // (C1): if folderURL stayed live, a remote page could probe livewallpaper://.
+        if case .folder = source {
+            // folderURL is set below — do not clear here.
+        } else {
+            folderHandler.folderURL = nil
+        }
+
         switch source {
         case .file(let bookmarkData):
-            guard let url = HTMLWallpaperView.resolveBookmark(bookmarkData) else { return }
+            guard let url = HTMLWallpaperView.resolveBookmark(bookmarkData) else {
+                reportError(.sandboxRevoked)
+                return
+            }
             activeSecurityScopedURL = url
             webView.loadFileURL(url, allowingReadAccessTo: Self.readAccessRoot(forFileURL: url))
         case .folder(let bookmarkData, let indexFileName):
-            guard let folderURL = HTMLWallpaperView.resolveBookmark(bookmarkData) else { return }
+            guard let folderURL = HTMLWallpaperView.resolveBookmark(bookmarkData) else {
+                reportError(.sandboxRevoked)
+                return
+            }
             activeSecurityScopedURL = folderURL
             // Route through custom scheme so ES module / CORS / fetch all
             // behave like normal HTTP. file:// would block `<script type="module" crossorigin>`.
             folderHandler.folderURL = folderURL
+            guard let nonce = folderHandler.currentSessionNonce else {
+                Logger.error("HTML folder load: missing session nonce for \(indexFileName)", category: .screenManager)
+                return
+            }
             let escapedIndex = indexFileName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? indexFileName
-            let urlString = "\(FolderURLSchemeHandler.scheme)://\(FolderURLSchemeHandler.host)/\(escapedIndex)"
+            let urlString = "\(FolderURLSchemeHandler.scheme)://\(FolderURLSchemeHandler.host)/\(escapedIndex)?n=\(nonce)"
             guard let url = URL(string: urlString) else {
                 Logger.error("HTML folder load: failed to build scheme URL for \(indexFileName)", category: .screenManager)
                 return
@@ -291,6 +316,12 @@ final class HTMLWallpaperView: NSView {
         case .inline(let html):
             webView.loadHTMLString(html, baseURL: nil)
         }
+    }
+
+    /// Re-applies the most recent `HTMLSource`. Used by `WallpaperRuntimeSession.retry()`.
+    func reloadCurrentSource() {
+        guard let lastSource else { return }
+        loadSource(lastSource)
     }
 
     private func stopActiveSecurityScope() {
@@ -345,8 +376,37 @@ final class HTMLWallpaperView: NSView {
         }
     }
 
+    /// Sleep / wake suspend hook. Identical to `applyPerformanceProfile(.suspended)`
+    /// today, but kept distinct so the AmbientWallpaperSession can layer
+    /// "system asleep" on top of the existing power-policy profile state.
+    func suspend() {
+        setMediaPlaybackSuspended(true)
+    }
+
+    func resume() {
+        setMediaPlaybackSuspended(false)
+    }
+
     private func setMediaPlaybackSuspended(_ suspended: Bool) {
         webView.setAllMediaPlaybackSuspended(suspended) {}
+    }
+
+    private func reportError(_ error: WallpaperRuntimeError) {
+        onError?(error)
+    }
+
+    private func navigationFailureURL(webView: WKWebView, error: NSError) -> URL {
+        if let url = webView.url {
+            return url
+        }
+        if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
+            return url
+        }
+        if let urlString = error.userInfo[NSURLErrorFailingURLStringErrorKey] as? String,
+           let url = URL(string: urlString) {
+            return url
+        }
+        return URL(string: "about:blank") ?? URL(fileURLWithPath: "/")
     }
 
     // MARK: - Tracker Blocking
@@ -613,6 +673,11 @@ extension HTMLWallpaperView: WKNavigationDelegate {
             "HTML wallpaper didFail [domain=\(nsError.domain) code=\(nsError.code)] url=\(webView.url?.absoluteString ?? "<no url>") — \(nsError.localizedDescription); userInfo=\(nsError.userInfo)",
             category: .screenManager
         )
+        reportError(.webNavigationFailed(
+            navigationFailureURL(webView: webView, error: nsError),
+            code: nsError.code,
+            description: nsError.localizedDescription
+        ))
     }
 
     /// Pre-commit failures (file not found, sandbox denial, scheme blocked).
@@ -622,12 +687,23 @@ extension HTMLWallpaperView: WKNavigationDelegate {
             "HTML wallpaper didFailProvisionalNavigation [domain=\(nsError.domain) code=\(nsError.code)] url=\(webView.url?.absoluteString ?? "<no url>") — \(nsError.localizedDescription); userInfo=\(nsError.userInfo)",
             category: .screenManager
         )
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorNotConnectedToInternet {
+            reportError(.networkOffline)
+        } else {
+            reportError(.webNavigationFailed(
+                navigationFailureURL(webView: webView, error: nsError),
+                code: nsError.code,
+                description: nsError.localizedDescription
+            ))
+        }
     }
 
     /// Captures unhandled JS exceptions + console messages from the page.
     func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping @MainActor @Sendable (WKNavigationResponsePolicy) -> Void) {
         if let response = navigationResponse.response as? HTTPURLResponse, response.statusCode >= 400 {
             Logger.warning("HTML wallpaper response: HTTP \(response.statusCode) for \(response.url?.absoluteString ?? "?")", category: .screenManager)
+            let failingURL = response.url ?? webView.url ?? URL(string: "about:blank") ?? URL(fileURLWithPath: "/")
+            reportError(.webNavigationFailed(failingURL, code: response.statusCode, description: "HTTP \(response.statusCode)"))
         }
         decisionHandler(.allow)
     }

--- a/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
+++ b/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
@@ -32,6 +32,19 @@ final class WallpaperVideoPlayer {
     private(set) var isMuted: Bool = true
     private(set) var shouldAutoplayWhenReady = true
     private(set) var requestedFrameRateLimit: Float = 0
+    private(set) var runtimeError: WallpaperRuntimeError?
+    /// Error sink consumed by `VideoWallpaperSession` for UI surfacing. The
+    /// sink replays any pre-existing error when assigned so late observers
+    /// don't miss failures raised during init.
+    var onError: (@MainActor (WallpaperRuntimeError) -> Void)? {
+        didSet {
+            if let runtimeError {
+                onError?(runtimeError)
+            }
+        }
+    }
+    var currentWindowFrame: CGRect { window?.frame ?? initialFrame }
+    var currentFitMode: VideoFitMode { fitMode }
 
     // MARK: - Private Properties
 
@@ -67,6 +80,7 @@ final class WallpaperVideoPlayer {
             )
             Logger.error("Invalid frame provided: \(frame)", category: .videoPlayer)
             Logger.error("WallpaperVideoPlayer init error: \(error.localizedDescription)", category: .videoPlayer)
+            reportError(.mediaNotPlayable(url, code: error.code))
             return
         }
 
@@ -91,9 +105,10 @@ final class WallpaperVideoPlayer {
             )
             Logger.error("Failed to access security scoped resource: \(url.lastPathComponent)", category: .videoPlayer)
             Logger.error("WallpaperVideoPlayer init error: \(error.localizedDescription)", category: .videoPlayer)
+            reportError(.fileAccessDenied(url))
             return
         }
-        
+
         loadingTask = Task { [weak self] in
             guard let self else { return }
 
@@ -108,6 +123,9 @@ final class WallpaperVideoPlayer {
                 guard isPlayable else {
                     self.stopAccessingResource()
                     Logger.error("Video is not playable: \(url.lastPathComponent)", category: .videoPlayer)
+                    await MainActor.run { [weak self] in
+                        self?.reportError(.mediaNotPlayable(url, code: nil))
+                    }
                     return
                 }
 
@@ -138,6 +156,10 @@ final class WallpaperVideoPlayer {
             } catch {
                 self.stopAccessingResource()
                 Logger.error("Error loading video: \(error.localizedDescription)", category: .videoPlayer)
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+                    self.reportError(self.makeRuntimeError(from: error, url: url))
+                }
             }
         }
     }
@@ -232,6 +254,9 @@ final class WallpaperVideoPlayer {
                     return
                 }
                 Logger.warning("Playback item failed (code: \(nsError.code)): \(error.localizedDescription)", category: .videoPlayer)
+                if let url = self.videoURL {
+                    self.reportError(self.makeRuntimeError(from: error, url: url))
+                }
             }
             .store(in: &cleanupTasks)
     }
@@ -527,7 +552,33 @@ final class WallpaperVideoPlayer {
         guard requestedFrameRateLimit > 0, currentVideoComposition == nil else { return }
         setFrameRateLimit(requestedFrameRateLimit)
     }
-    
+
+    /// Sleep / wake suspend hook. Distinct from `pause()` so the session can
+    /// remember "was playing before sleep" and resume to the right state.
+    func suspend() {
+        pause()
+    }
+
+    func resume() {
+        play()
+    }
+
+    private func reportError(_ error: WallpaperRuntimeError) {
+        runtimeError = error
+        onError?(error)
+    }
+
+    private func makeRuntimeError(from error: Error, url: URL) -> WallpaperRuntimeError {
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorNotConnectedToInternet {
+            return .networkOffline
+        }
+        if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileReadNoPermissionError {
+            return .fileAccessDenied(url)
+        }
+        return .mediaNotPlayable(url, code: nsError.code)
+    }
+
     private func stopAccessingResource() {
         if accessToken, let url = videoURL {
             url.stopAccessingSecurityScopedResource()

--- a/LiveWallpaper/Views/ScreenDetail/RuntimeErrorBanner.swift
+++ b/LiveWallpaper/Views/ScreenDetail/RuntimeErrorBanner.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// Inline banner shown above the screen-detail content when the active
+/// wallpaper session reports a `WallpaperRuntimeError`. Provides a
+/// retryable hint plus a re-pick fallback for unrecoverable cases.
+struct RuntimeErrorBanner: View {
+    let error: WallpaperRuntimeError
+    /// `false` for backends that don't have a picker (shader / scene); the
+    /// banner hides the Re-pick button so it doesn't dead-end on a no-op.
+    var canRePick: Bool = true
+    let onRetry: () -> Void
+    let onRePick: () -> Void
+
+    private var subtitleText: String {
+        switch (error.canRetry, canRePick) {
+        case (true, true):
+            return "Tap Retry to try again or Re-pick to choose another source."
+        case (true, false):
+            return "Tap Retry to try again."
+        case (false, true):
+            return "Tap Re-pick to choose another source."
+        case (false, false):
+            return "Switch to a different wallpaper type to recover."
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.orange)
+                .font(.title3)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(error.userMessage)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(2)
+                Text(subtitleText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 8)
+
+            if error.canRetry {
+                Button("Retry", action: onRetry)
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .accessibilityHint("Retry loading the current wallpaper source")
+            }
+            if canRePick {
+                Button("Re-pick", action: onRePick)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityHint("Pick a different wallpaper source")
+            }
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(.orange.opacity(0.4), lineWidth: 1)
+        )
+        .padding(.horizontal, 12)
+        .padding(.top, 8)
+    }
+}

--- a/LiveWallpaper/Views/ScreenDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetailView.swift
@@ -12,6 +12,9 @@ struct ScreenDetailView: View {
     private var wallpaperSessionSummary: WallpaperSessionSummary {
         screenManager.wallpaperSummary(for: screen)
     }
+    private var runtimeError: WallpaperRuntimeError? {
+        screenManager.runtimeError(for: screen)
+    }
     /// Resolved Wallpaper Engine origin metadata for the active wallpaper, or
     /// nil when the user picked content directly. Recomputed on every body
     /// evaluation so save/import flows propagate without local @State.
@@ -77,6 +80,7 @@ struct ScreenDetailView: View {
     @AppStorage("Inspector.DisplayExpanded") private var isDisplayExpanded = false
 
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         VStack(spacing: 0) {
@@ -157,6 +161,18 @@ struct ScreenDetailView: View {
             }
             .padding(.horizontal, 24)
             .padding(.vertical, 14)
+
+            if let runtimeError {
+                let activeType = screen.runtimeSession?.wallpaperType ?? selectedWallpaperType
+                let canRePick = activeType == .video || activeType == .html
+                RuntimeErrorBanner(
+                    error: runtimeError,
+                    canRePick: canRePick,
+                    onRetry: { screenManager.retryRuntimeSession(for: screen) },
+                    onRePick: rePickRuntimeSource
+                )
+                .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+            }
 
             Divider()
 
@@ -703,6 +719,38 @@ struct ScreenDetailView: View {
         guard panel.runModal() == .OK, let url = panel.url else { return }
         SettingsManager.shared.saveLastUsedDirectory(url.deletingLastPathComponent())
         handleSelectedFile(url: url)
+    }
+
+    /// Routes the banner's "Re-pick" button to the picker matching the current
+    /// session type. Falls back to the video picker for non-pickable backends
+    /// (scene / shader sessions are switched via the type segmented control).
+    private func rePickRuntimeSource() {
+        let activeType = screen.runtimeSession?.wallpaperType ?? selectedWallpaperType
+        switch activeType {
+        case .video:
+            showFilePicker()
+        case .html:
+            showHTMLSourcePicker()
+        case .metalShader, .scene:
+            selectedWallpaperType = activeType
+        }
+    }
+
+    private func showHTMLSourcePicker() {
+        NSApp.activate(ignoringOtherApps: true)
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Use as Wallpaper"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard isHTMLDrop(url) else {
+            errorMessage = "Choose an HTML file or folder."
+            showErrorAlert = true
+            return
+        }
+        selectedWallpaperType = .html
+        applyHTMLDrop(url)
     }
 
     private func handleSelectedFile(url: URL) {

--- a/LiveWallpaperTests/HTMLSchemeIsolationTests.swift
+++ b/LiveWallpaperTests/HTMLSchemeIsolationTests.swift
@@ -1,0 +1,221 @@
+import Testing
+import Foundation
+import WebKit
+@testable import LiveWallpaper
+
+/// Verifies the C1 (HTML local-file isolation) and H2 (async/range scheme
+/// handler) hardening from Week 1 of the product-pivot plan.
+@Suite("FolderURLSchemeHandler isolation regressions")
+@MainActor
+struct FolderURLSchemeHandlerIsolationTests {
+
+    @Test("Clearing folderURL also rotates the session nonce")
+    func clearingFolderURLDropsNonce() {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        handler.folderURL = folder
+        let firstNonce = handler.currentSessionNonce
+        #expect(firstNonce != nil)
+
+        handler.folderURL = nil
+        #expect(handler.currentSessionNonce == nil)
+
+        handler.folderURL = folder
+        #expect(handler.currentSessionNonce != firstNonce)
+    }
+
+    @Test("Top-level requests are rejected once the folder is cleared")
+    func staleTopLevelRequestRejected() {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        try? "<!doctype html><title>x</title>".write(
+            to: folder.appendingPathComponent("index.html"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        handler.folderURL = folder
+        let nonce = handler.currentSessionNonce ?? ""
+        let request = URLRequest(url: URL(string: "livewallpaper://wallpaper/index.html?n=\(nonce)")!)
+
+        // Sanity: with active folder + matching nonce, validation succeeds.
+        let live = FakeURLSchemeTask(request: request)
+        handler.webView(WKWebView(), start: live)
+        // Stop right away to release the worker; we only care that no error fired.
+        handler.webView(WKWebView(), stop: live)
+        #expect(live.failedError == nil)
+
+        // Now flip to a remote source — folder must be unreachable.
+        handler.folderURL = nil
+        let stale = FakeURLSchemeTask(request: request)
+        handler.webView(WKWebView(), start: stale)
+        #expect(stale.failedError != nil)
+    }
+
+    @Test("Top-level requests with a wrong nonce are rejected")
+    func wrongNonceRejected() {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        handler.folderURL = folder
+        let request = URLRequest(url: URL(string: "livewallpaper://wallpaper/index.html?n=NOT-THE-NONCE")!)
+        let task = FakeURLSchemeTask(request: request)
+        handler.webView(WKWebView(), start: task)
+
+        #expect(task.failedError != nil)
+    }
+
+    @Test("Top-level requests without any query are rejected")
+    func missingNonceRejected() {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        handler.folderURL = folder
+        let request = URLRequest(url: URL(string: "livewallpaper://wallpaper/index.html")!)
+        let task = FakeURLSchemeTask(request: request)
+        handler.webView(WKWebView(), start: task)
+
+        #expect(task.failedError != nil)
+    }
+
+    @Test("Wrong host is rejected even when folder is active")
+    func wrongHostRejected() {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        handler.folderURL = folder
+        let nonce = handler.currentSessionNonce ?? ""
+        let request = URLRequest(url: URL(string: "livewallpaper://other-host/index.html?n=\(nonce)")!)
+        let task = FakeURLSchemeTask(request: request)
+        handler.webView(WKWebView(), start: task)
+
+        #expect(task.failedError != nil)
+    }
+
+    @Test("Subresource requests bypass the nonce check (scheme + host already gated)")
+    func subresourceWithoutNonceAllowed() async throws {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let payload = Data("console.log('ok')".utf8)
+        try payload.write(to: folder.appendingPathComponent("app.js"))
+
+        handler.folderURL = folder
+
+        // Subresource — main document was an earlier same-scheme top-level URL.
+        let mainDocURL = URL(string: "livewallpaper://wallpaper/index.html?n=\(handler.currentSessionNonce ?? "")")!
+        var request = URLRequest(url: URL(string: "livewallpaper://wallpaper/app.js")!)
+        request.mainDocumentURL = mainDocURL
+
+        let task = FakeURLSchemeTask(request: request)
+        handler.webView(WKWebView(), start: task)
+
+        // Detached worker is async — wait until either succeeds or errors out.
+        try await waitUntil(timeout: .seconds(2)) { task.didFinishCalled || task.failedError != nil }
+        handler.webView(WKWebView(), stop: task)
+
+        #expect(task.failedError == nil)
+        #expect(task.didFinishCalled)
+    }
+
+    // MARK: - helpers
+
+    private func makeTemporaryFolder() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LWSchemeTest-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func waitUntil(
+        timeout: Duration,
+        _ condition: @MainActor () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if condition() { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+}
+
+@Suite("HTMLWallpaperView source-isolation contract")
+@MainActor
+struct HTMLWallpaperViewSourceIsolationTests {
+
+    @Test("Switching from .folder to .url clears folderURL and rotates nonce")
+    func switchingToRemoteClearsFolder() {
+        let view = HTMLWallpaperView(frame: NSRect(x: 0, y: 0, width: 320, height: 240))
+        let folder = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LWView-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        try? "<!doctype html><title>z</title>".write(
+            to: folder.appendingPathComponent("index.html"),
+            atomically: true,
+            encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        guard let bookmark = ResourceUtilities.createBookmark(for: folder) else {
+            Issue.record("Bookmark creation failed in test environment")
+            return
+        }
+        view.loadSource(.folder(bookmarkData: bookmark, indexFileName: "index.html"))
+        #expect(view.folderHandlerSnapshot.folderURL != nil)
+
+        view.loadSource(.url(URL(string: "https://example.com")!))
+        #expect(view.folderHandlerSnapshot.folderURL == nil)
+        #expect(view.folderHandlerSnapshot.currentSessionNonce == nil)
+    }
+}
+
+// MARK: - Test helpers
+
+private final class FakeURLSchemeTask: NSObject, WKURLSchemeTask, @unchecked Sendable {
+    let request: URLRequest
+    private(set) var receivedResponse: URLResponse?
+    private(set) var receivedData: [Data] = []
+    private(set) var didFinishCalled: Bool = false
+    private(set) var failedError: Error?
+
+    init(request: URLRequest) {
+        self.request = request
+    }
+
+    func didReceive(_ response: URLResponse) {
+        receivedResponse = response
+    }
+
+    func didReceive(_ data: Data) {
+        receivedData.append(data)
+    }
+
+    func didFinish() {
+        didFinishCalled = true
+    }
+
+    func didFailWithError(_ error: Error) {
+        failedError = error
+    }
+}
+
+extension HTMLWallpaperView {
+    /// Test-only window into the scheme handler so the isolation contract is
+    /// observable without relying on private state.
+    @MainActor
+    var folderHandlerSnapshot: (folderURL: URL?, currentSessionNonce: String?) {
+        let mirror = Mirror(reflecting: self)
+        guard let handler = mirror.children.first(where: { $0.label == "folderHandler" })?.value as? FolderURLSchemeHandler else {
+            return (nil, nil)
+        }
+        return (handler.folderURL, handler.currentSessionNonce)
+    }
+}

--- a/LiveWallpaperTests/WallpaperArchitectureTests.swift
+++ b/LiveWallpaperTests/WallpaperArchitectureTests.swift
@@ -377,7 +377,12 @@ struct HTMLFolderURLSchemeTests {
         let handler = FolderURLSchemeHandler()
         handler.folderURL = fixture.folder
 
-        let task = CapturingURLSchemeTask(url: URL(string: "livewallpaper://wallpaper/%2e%2e/secret.txt")!)
+        // Path traversal must be blocked even when nonce is valid: simulate a
+        // subresource request originating from the active top-level document.
+        let task = CapturingURLSchemeTask(
+            url: URL(string: "livewallpaper://wallpaper/%2e%2e/secret.txt")!,
+            mainDocumentURL: makeTopLevelURL(handler: handler)
+        )
 
         handler.webView(WKWebView(), start: task)
 
@@ -393,7 +398,10 @@ struct HTMLFolderURLSchemeTests {
         let handler = FolderURLSchemeHandler()
         handler.folderURL = fixture.folder
 
-        let task = CapturingURLSchemeTask(url: URL(string: "livewallpaper://wallpaper/linked-secret.txt")!)
+        let task = CapturingURLSchemeTask(
+            url: URL(string: "livewallpaper://wallpaper/linked-secret.txt")!,
+            mainDocumentURL: makeTopLevelURL(handler: handler)
+        )
 
         handler.webView(WKWebView(), start: task)
 
@@ -402,7 +410,7 @@ struct HTMLFolderURLSchemeTests {
     }
 
     @Test("Folder scheme sends large assets in bounded chunks")
-    func sendsLargeAssetsInBoundedChunks() throws {
+    func sendsLargeAssetsInBoundedChunks() async throws {
         let fixture = try makeFolderFixture()
         let largeFile = fixture.folder.appendingPathComponent("large.bin")
         let payload = Data(repeating: 0xA5, count: 200 * 1024)
@@ -410,15 +418,34 @@ struct HTMLFolderURLSchemeTests {
         let handler = FolderURLSchemeHandler()
         handler.folderURL = fixture.folder
 
-        let task = CapturingURLSchemeTask(url: URL(string: "livewallpaper://wallpaper/large.bin")!)
+        // Asset URL pretends to be a subresource of the active top-level
+        // document so it bypasses the nonce gate (real subresources do).
+        let task = CapturingURLSchemeTask(
+            url: URL(string: "livewallpaper://wallpaper/large.bin")!,
+            mainDocumentURL: makeTopLevelURL(handler: handler)
+        )
 
         handler.webView(WKWebView(), start: task)
+
+        // Detached worker; wait until streaming completes.
+        let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+        while task.didFinishCallCount == 0, task.failure == nil, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
 
         #expect(task.failure == nil)
         #expect(task.didFinishCallCount == 1)
         #expect(task.receivedData.count > 1)
         #expect(task.receivedData.allSatisfy { $0.count <= 64 * 1024 })
         #expect(task.receivedData.reduce(0) { $0 + $1.count } == payload.count)
+    }
+
+    /// Builds a `livewallpaper://wallpaper/index.html?n=<nonce>` URL using the
+    /// handler's current session nonce — used as a `mainDocumentURL` stand-in
+    /// so subresource requests skip the top-level nonce gate.
+    private func makeTopLevelURL(handler: FolderURLSchemeHandler) -> URL {
+        let nonce = handler.currentSessionNonce ?? ""
+        return URL(string: "livewallpaper://wallpaper/index.html?n=\(nonce)")!
     }
 
     private func makeFolderFixture() throws -> (root: URL, folder: URL, secret: URL) {
@@ -487,15 +514,17 @@ struct HTMLWallpaperMouseInteractionTests {
     }
 }
 
-private final class CapturingURLSchemeTask: NSObject, WKURLSchemeTask {
+private final class CapturingURLSchemeTask: NSObject, WKURLSchemeTask, @unchecked Sendable {
     let request: URLRequest
     private(set) var responses: [URLResponse] = []
     private(set) var receivedData: [Data] = []
     private(set) var didFinishCallCount = 0
     private(set) var failure: Error?
 
-    init(url: URL) {
-        request = URLRequest(url: url)
+    init(url: URL, mainDocumentURL: URL? = nil) {
+        var request = URLRequest(url: url)
+        request.mainDocumentURL = mainDocumentURL
+        self.request = request
     }
 
     func didReceive(_ response: URLResponse) {


### PR DESCRIPTION
## Summary

First slice of `.claude/plan/product-pivot-video-html-mvp.md` — Week 1 P0 backend + UX hardening so the video / HTML pipelines stop leaking, going silent on failure, and ignoring sleep/wake.

- **C1 (Critical)** HTML local-file isolation: every non-folder `loadSource` clears `folderHandler.folderURL`; folder loads carry a per-session UUID nonce and are gated by host + nonce on top-level navigation.
- **H1 (High)** Video transition leak: `releaseRuntimeSession` bumps the per-screen transition generation; `setVideo`'s post-validate guard requires the screen still be live before instantiating a player.
- **H2 (High)** `FolderURLSchemeHandler` is now a `Task.detached` worker with HTTP `Range` (`bytes=N-` and `bytes=-N`), cancellation via `webView(_:stop:)`, and a `SchemeTaskDelivery` actor hop that drops late chunks after stop.
- **H3 (High)** Sleep / wake closure: `willSleep` + `didWake` subscribe through `NSWorkspace.shared.notificationCenter`; sessions get `suspend()` / `resume()` that remember `wasPlaying` / pre-suspend profile.
- **H4 (High)** `WallpaperRuntimeError` enum + `RuntimeErrorBanner` SwiftUI surface; `WallpaperVideoPlayer` and `HTMLWallpaperView` publish failures via `onError`; `ScreenManager.runtimeError(for:)` / `retryRuntimeSession(for:)` thread state into `ScreenDetailView`.

## Audit + fixes already applied

Each finding from the parallel codex/gemini review is folded into the same commits before review:

- codex (backend): `folderURL` setter cancels in-flight workers when the folder changes; tiny-file race pruned via `delivery.hasTerminated`; HTTP 4xx/5xx now reach `onError`; suffix `Range` `bytes=-N` parses.
- gemini (UI/UX): dropped `.accessibilityElement(.combine)` so VoiceOver can hit each button; banner subtitle adapts to whichever recovery path is available; `canRePick=false` for shader/scene; banner transition respects `accessibilityReduceMotion`; user-facing copy polished.

## Commits

- `d3d2101` test: html scheme isolation + async-range regressions
- `f407fe0` fix(html): isolated async range-capable folder scheme handler
- `02af795` feat(runtime): suspend/resume + transition guard + error plumbing
- `9446726` feat(ui): WallpaperRuntimeError + RuntimeErrorBanner with retry/re-pick

## Verification

- `xcodebuild build -scheme LiveWallpaper -configuration Debug` — BUILD SUCCEEDED
- `xcodebuild build-for-testing` — TEST BUILD SUCCEEDED
- `xcodebuild test -only-testing:LiveWallpaperTests` — **423 tests / 73 suites passed**, including 7 new `HTMLSchemeIsolationTests` covering nonce rotation, host check, top-level rejection without nonce, and subresource bypass.

## Test plan

- [ ] Open an HTML folder wallpaper, then switch to a remote URL — confirm `livewallpaper://wallpaper/...` requests fail (Web Inspector or Console).
- [ ] Drop in a 100MB file under the folder; confirm UI stays responsive while WebKit streams the response.
- [ ] Plug / unplug an external display while a video transition is in flight — no orphan AVPlayer should remain (Activity Monitor / `lsof`).
- [ ] Lid-close → open, lock → unlock — players resume to their pre-sleep `isPlaying` state.
- [ ] Force a video / HTML failure (rename file, kill network) — banner appears with Retry / Re-pick wired to the right picker; VoiceOver can focus each button independently; Reduce Motion suppresses the slide-in.

## Out of scope (later weeks of plan)

Week 2 (Onboarding / MenuBar / Apply-to-All / Sidebar IA), Week 3 (HDR / exact-seek / common controls), Week 4 (HSplitView / a11y sweep / file splits) remain in `.claude/plan/product-pivot-video-html-mvp.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)