### PR TITLE
Week 2 P0: Apply-to-All, sidebar IA, MenuBar handoff, multi-screen onboarding

### DIFF
--- a/LiveWallpaper/LiveWallpaperApp.swift
+++ b/LiveWallpaper/LiveWallpaperApp.swift
@@ -98,11 +98,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Settings Window
 
     /// Opens settings, optionally selecting a display from the menu bar.
-    func showSettings(initialScreenID: CGDirectDisplayID? = nil) {
+    /// `initialAddWallpaperPromptKind`, when non-nil, is consumed by
+    /// `ContentView.onAppear` to launch the matching picker — this replaces
+    /// the racy `dismiss + DispatchQueue.async + post` chain that the menu
+    /// bar previously used to hand off picker requests.
+    func showSettings(initialScreenID: CGDirectDisplayID? = nil, initialAddWallpaperPromptKind: String? = nil) {
         guard let manager = screenManager else { return }
 
         if let controller = settingsWindowController {
             controller.showWindow(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            controller.window?.makeKeyAndOrderFront(nil)
+            controller.window?.orderFrontRegardless()
             if let id = initialScreenID {
                 NotificationCenter.default.post(
                     name: .selectScreenInSettings,
@@ -110,14 +117,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     userInfo: ["screenID": id]
                 )
             }
-            NSApp.activate(ignoringOtherApps: true)
-            controller.window?.makeKeyAndOrderFront(nil)
-            controller.window?.orderFrontRegardless()
+            if let kind = initialAddWallpaperPromptKind {
+                NotificationCenter.default.post(
+                    name: .promptAddWallpaper,
+                    object: nil,
+                    userInfo: ["kind": kind]
+                )
+            }
             return
         }
 
         let initialNavigation: Navigation? = initialScreenID.map { .screen($0) }
-        let contentView = ContentView(initialNavigation: initialNavigation)
+        let contentView = ContentView(
+            initialNavigation: initialNavigation,
+            initialAddWallpaperPromptKind: initialAddWallpaperPromptKind
+        )
             .environment(manager)
 
         let window = NSWindow(
@@ -225,6 +239,9 @@ struct LiveWallpaperApp: App {
                 },
                 openSettingsForScreen: { [appDelegate] id in
                     appDelegate.showSettings(initialScreenID: id)
+                },
+                promptAddWallpaper: { [appDelegate] kind in
+                    appDelegate.showSettings(initialAddWallpaperPromptKind: kind)
                 }
             )
             .environment(screenManager)

--- a/LiveWallpaper/Models/ScreenConfiguration.swift
+++ b/LiveWallpaper/Models/ScreenConfiguration.swift
@@ -2,7 +2,9 @@ import CoreGraphics
 import Foundation
 
 struct ScreenConfiguration: Codable, Equatable {
-    let screenID: UInt32
+    /// Mutable so `ScreenManager.applyConfigurationToAllDisplays` can clone
+    /// a template for every other screen without recomposing each field.
+    var screenID: UInt32
     var activeWallpaper: WallpaperContent
     var savedVideoBookmarkData: Data?
     /// Last applied HTML source — restored on type switch back to HTML.

--- a/LiveWallpaper/NotificationNames.swift
+++ b/LiveWallpaper/NotificationNames.swift
@@ -32,4 +32,16 @@ extension Notification.Name {
     /// Listeners — including the Scene tab UI — should reload from
     /// `SettingsManager.shared.loadGlobalSettings().recentWPEImports`.
     static let wpeHistoryDidChange = Notification.Name("WPEHistoryDidChange")
+
+    /// Status-bar requested the main window to launch the appropriate
+    /// "Add Wallpaper" picker. The status bar can no longer host a modal
+    /// `NSOpenPanel` reliably — focus loss puts the panel behind the menu
+    /// bar overlay. `userInfo["kind"]: String` is one of "video" / "html-file"
+    /// / "html-folder" / "html-url".
+    static let promptAddWallpaper = Notification.Name("PromptAddWallpaper")
+
+    /// Workshop library root bookmark was set or cleared. Sidebar /
+    /// onboarding watch this so their conditional Workshop entry refreshes
+    /// without needing a manual reopen.
+    static let workshopLibraryRootBookmarkDidChange = Notification.Name("WorkshopLibraryRootBookmarkDidChange")
 }

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -1320,6 +1320,32 @@ final class ScreenManager {
     func getConfiguration(for screen: Screen) -> ScreenConfiguration? {
         configurationStore.get(for: screen.id)
     }
+
+    /// Copies the active wallpaper + per-screen settings from `source` onto
+    /// every other registered screen, restoring each runtime session so the
+    /// new content shows immediately. Used by the "Apply to All" toolbar
+    /// action; no-op when there's only one screen.
+    ///
+    /// The target's existing runtime session is torn down BEFORE
+    /// `restoreWallpaperSession`, otherwise the video path's reuse-existing-
+    /// player branch would persist the new config but keep playing the old
+    /// URL. `releaseRuntimeSession` also bumps the per-screen transition
+    /// generation, so any in-flight async video load on the target invalidates
+    /// itself instead of overwriting the apply-to-all result.
+    func applyConfigurationToAllDisplays(from source: Screen) {
+        guard screens.count > 1,
+              let template = configurationStore.get(for: source.id) else { return }
+
+        for target in screens where target.id != source.id {
+            var copy = template
+            copy.screenID = target.id
+            releaseRuntimeSession(target)
+            saveConfiguration(copy)
+            restoreWallpaperSession(for: target, configuration: copy, preservingState: false)
+            Logger.info("Apply to All: copied configuration from screen \(source.id) → \(target.id)", category: .screenManager)
+        }
+        notifyWallpaperSessionChanged()
+    }
     
     func validateAllConfigurations() -> (valid: Int, invalid: Int) {
         let screenIDs = configurationStore.allScreenIDs()

--- a/LiveWallpaper/SettingsManager.swift
+++ b/LiveWallpaper/SettingsManager.swift
@@ -132,6 +132,7 @@ final class SettingsManager {
     /// is created via `NSOpenPanel` once and reused on subsequent scans.
     func saveWorkshopLibraryRootBookmark(_ bookmark: Data) {
         UserDefaults.standard.set(bookmark, forKey: Keys.workshopLibraryRootBookmark)
+        NotificationCenter.default.post(name: .workshopLibraryRootBookmarkDidChange, object: nil)
     }
 
     func loadWorkshopLibraryRootBookmark() -> Data? {
@@ -140,6 +141,7 @@ final class SettingsManager {
 
     func clearWorkshopLibraryRootBookmark() {
         UserDefaults.standard.removeObject(forKey: Keys.workshopLibraryRootBookmark)
+        NotificationCenter.default.post(name: .workshopLibraryRootBookmarkDidChange, object: nil)
     }
 
     private func applyStartOnLoginSetting(_ startOnLogin: Bool) {

--- a/LiveWallpaper/Views/ContentView.swift
+++ b/LiveWallpaper/Views/ContentView.swift
@@ -5,9 +5,12 @@ import UniformTypeIdentifiers
 struct ContentView: View {
     @Environment(ScreenManager.self) private var screenManager
     @State private var selectedNavigation: Navigation?
+    @State private var didConsumeInitialAddWallpaperPrompt = false
+    private let initialAddWallpaperPromptKind: String?
 
-    init(initialNavigation: Navigation? = nil) {
+    init(initialNavigation: Navigation? = nil, initialAddWallpaperPromptKind: String? = nil) {
         _selectedNavigation = State(initialValue: initialNavigation)
+        self.initialAddWallpaperPromptKind = initialAddWallpaperPromptKind
     }
 
     var body: some View {
@@ -19,6 +22,9 @@ struct ContentView: View {
                 }
                 .onReceive(NotificationCenter.default.publisher(for: .openAppleAerials)) { _ in
                     selectedNavigation = .appleAerials
+                }
+                .onReceive(NotificationCenter.default.publisher(for: .promptAddWallpaper)) { notification in
+                    handleAddWallpaperPrompt(notification: notification)
                 }
         } detail: {
             DetailContent(selection: $selectedNavigation)
@@ -35,6 +41,97 @@ struct ContentView: View {
         }
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 1000, minHeight: 650)
+        .onAppear { consumeInitialAddWallpaperPromptIfNeeded() }
+    }
+
+    /// Receives `.promptAddWallpaper` notifications from a re-used settings
+    /// window (one already mounted). The fresh-window path uses
+    /// `initialAddWallpaperPromptKind` consumed in `onAppear`.
+    private func handleAddWallpaperPrompt(notification: Notification) {
+        guard let kind = notification.userInfo?["kind"] as? String else { return }
+        handleAddWallpaperPrompt(kind: kind)
+    }
+
+    private func consumeInitialAddWallpaperPromptIfNeeded() {
+        guard !didConsumeInitialAddWallpaperPrompt,
+              let kind = initialAddWallpaperPromptKind else { return }
+        didConsumeInitialAddWallpaperPrompt = true
+        handleAddWallpaperPrompt(kind: kind)
+    }
+
+    /// Routes a menu-bar quick-add request to the appropriate picker. Targets
+    /// the currently-selected screen if the user has one open; otherwise the
+    /// first registered display. Selection is also redirected so the user
+    /// sees the result land.
+    private func handleAddWallpaperPrompt(kind: String) {
+        guard let target = preferredAddWallpaperTarget() else { return }
+        selectedNavigation = .screen(target.id)
+
+        switch kind {
+        case "video":
+            promptVideoFile(for: target)
+        case "html-file":
+            promptHTMLFile(for: target)
+        case "html-folder":
+            promptHTMLFolder(for: target)
+        default:
+            break
+        }
+    }
+
+    private func preferredAddWallpaperTarget() -> Screen? {
+        if case .screen(let id) = selectedNavigation,
+           let match = screenManager.screens.first(where: { $0.id == id }) {
+            return match
+        }
+        return screenManager.screens.first
+    }
+
+    private func promptVideoFile(for screen: Screen) {
+        NSApp.activate(ignoringOtherApps: true)
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.movie, .video, .quickTimeMovie, .mpeg4Movie, .avi]
+        panel.directoryURL = SettingsManager.shared.getLastUsedDirectory()
+        panel.prompt = "Use as Wallpaper"
+        guard panel.runModal() == .OK, let url = panel.url,
+              let bookmark = ResourceUtilities.createBookmark(for: url) else { return }
+        SettingsManager.shared.saveLastUsedDirectory(url.deletingLastPathComponent())
+        screenManager.setVideo(url: url, bookmarkData: bookmark, for: screen)
+    }
+
+    private func promptHTMLFile(for screen: Screen) {
+        NSApp.activate(ignoringOtherApps: true)
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [UTType.html]
+        panel.prompt = "Use as Wallpaper"
+        guard panel.runModal() == .OK, let url = panel.url,
+              let source = ResourceUtilities.htmlSourceFromPickedFile(url) else { return }
+        screenManager.setHTMLWallpaperPreservingConfig(source: source, for: screen)
+    }
+
+    private func promptHTMLFolder(for screen: Screen) {
+        NSApp.activate(ignoringOtherApps: true)
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Use as Wallpaper"
+        guard panel.runModal() == .OK, let folderURL = panel.url,
+              let bookmark = ResourceUtilities.createBookmark(for: folderURL) else { return }
+        let didStart = folderURL.startAccessingSecurityScopedResource()
+        defer { if didStart { folderURL.stopAccessingSecurityScopedResource() } }
+        let entries = (try? FileManager.default.contentsOfDirectory(atPath: folderURL.path)) ?? []
+        let indexFileName = ResourceUtilities.inferHTMLIndexFileName(from: entries)
+        screenManager.setHTMLWallpaperPreservingConfig(
+            source: .folder(bookmarkData: bookmark, indexFileName: indexFileName),
+            for: screen
+        )
     }
 }
 
@@ -45,6 +142,7 @@ enum Navigation: Hashable {
     case screen(CGDirectDisplayID)
     case appleAerials
     case bookmarks
+    case workshop
 }
 
 // MARK: - Sidebar View
@@ -52,7 +150,8 @@ struct Sidebar: View {
     @Binding var selection: Navigation?
     @Environment(ScreenManager.self) private var screenManager
     @State private var isReloading = false
-    
+    @State private var workshopLibraryAvailable = false
+
     var body: some View {
         List(selection: $selection) {
             Section(header: HStack(spacing: 4) {
@@ -91,11 +190,19 @@ struct Sidebar: View {
                 Divider()
                 Text("Library").font(.caption).bold().foregroundStyle(.secondary)
             }) {
+                // "My Wallpapers" first so its position stays stable for users
+                // who never connect the conditional Workshop entry.
+                NavigationLink(value: Navigation.bookmarks) {
+                    Label("My Wallpapers", systemImage: "bookmark.fill")
+                }
                 NavigationLink(value: Navigation.appleAerials) {
                     Label("Apple Aerials", systemImage: "sparkles.tv")
                 }
-                NavigationLink(value: Navigation.bookmarks) {
-                    Label("Bookmarks", systemImage: "bookmark.fill")
+                if workshopLibraryAvailable {
+                    NavigationLink(value: Navigation.workshop) {
+                        Label("Steam Workshop", systemImage: "cube.transparent")
+                    }
+                    .accessibilityHint("Browse Wallpaper Engine workshop projects")
                 }
             }
 
@@ -114,6 +221,26 @@ struct Sidebar: View {
         .listStyle(.sidebar)
         // Ideal == min so sidebar opens compact; user can drag to 280.
         .navigationSplitViewColumnWidth(min: 200, ideal: 200, max: 280)
+        .onAppear { refreshWorkshopAvailability() }
+        .onReceive(NotificationCenter.default.publisher(for: .wallpaperConfigurationDidChange)) { _ in
+            refreshWorkshopAvailability()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .wpeHistoryDidChange)) { _ in
+            refreshWorkshopAvailability()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .workshopLibraryRootBookmarkDidChange)) { _ in
+            refreshWorkshopAvailability()
+        }
+    }
+
+    /// Workshop entry is shown only when the user has either bookmarked their
+    /// Steam library or already imported at least one Workshop project. Keeps
+    /// the sidebar tidy for users who never touch Wallpaper Engine.
+    private func refreshWorkshopAvailability() {
+        let settings = SettingsManager.shared.loadGlobalSettings()
+        let hasBookmark = SettingsManager.shared.loadWorkshopLibraryRootBookmark() != nil
+        let hasImports = !settings.recentWPEImports.isEmpty
+        workshopLibraryAvailable = hasBookmark || hasImports
     }
 
     private func reloadWallpapers() {
@@ -302,6 +429,10 @@ struct DetailContent: View {
 
             case .bookmarks:
                 BookmarksLibraryView()
+                    .transition(.opacity)
+
+            case .workshop:
+                WorkshopGalleryView()
                     .transition(.opacity)
 
             case .none:

--- a/LiveWallpaper/Views/MenuBarContent.swift
+++ b/LiveWallpaper/Views/MenuBarContent.swift
@@ -6,6 +6,7 @@ import UniformTypeIdentifiers
 struct MenuBarContent: View {
     let openSettings: () -> Void
     let openSettingsForScreen: (CGDirectDisplayID) -> Void
+    let promptAddWallpaper: (String) -> Void
 
     @Environment(ScreenManager.self) private var screenManager
     @Environment(\.dismiss) private var dismiss
@@ -13,6 +14,10 @@ struct MenuBarContent: View {
     @State private var globalPauseOnBattery: Bool = SettingsManager.shared.loadGlobalSettings().globalPauseOnBattery
     @State private var globalPauseOnFullScreen: Bool = SettingsManager.shared.loadGlobalSettings().pauseOnFullScreen
     @AppStorage("Dashboard.RAMScope") private var ramScopeRaw: String = "system"
+    /// Persisted across launches so power users keep the live readout visible
+    /// while casual users see a one-line summary by default. The 280pt status
+    /// bar overlay was the noisiest surface in the audit.
+    @AppStorage("MenuBar.DashboardExpanded") private var dashboardExpanded: Bool = false
 
     @State private var isWebURLEntryExpanded: Bool = false
     @State private var webURLDraft: String = ""
@@ -82,20 +87,49 @@ struct MenuBarContent: View {
     // MARK: - Mini Dashboard
 
     private var miniDashboard: some View {
-        VStack(spacing: 6) {
-            // RAM scope picker — explicit segmented capsule shared with sidebar.
-            HStack(spacing: 0) {
-                ramScopeButton(label: "All", value: "system")
-                ramScopeButton(label: "App", value: "app")
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                withAnimation(.snappy(duration: 0.18)) { dashboardExpanded.toggle() }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .rotationEffect(.degrees(dashboardExpanded ? 90 : 0))
+                        .foregroundStyle(.secondary)
+                    Text(dashboardSummary)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .padding(2)
-            .background(Capsule().fill(Color.gray.opacity(0.18)))
-            .frame(maxWidth: 180)
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel("RAM scope")
+            .buttonStyle(.plain)
+            .accessibilityLabel("System Monitor")
+            .accessibilityValue(dashboardExpanded ? "Expanded, \(dashboardSummary)" : "Collapsed, \(dashboardSummary)")
+            .accessibilityHint(dashboardExpanded ? "Double tap to collapse" : "Double tap to expand")
 
-            chipRow
+            if dashboardExpanded {
+                // RAM scope picker — explicit segmented capsule shared with sidebar.
+                HStack(spacing: 0) {
+                    ramScopeButton(label: "All", value: "system")
+                    ramScopeButton(label: "App", value: "app")
+                }
+                .padding(2)
+                .background(Capsule().fill(Color.gray.opacity(0.18)))
+                .frame(maxWidth: 180)
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("RAM scope")
+
+                chipRow
+            }
         }
+    }
+
+    private var dashboardSummary: String {
+        let cpu = Int(cpuPercent.rounded())
+        let ram = Int(ramPercent.rounded())
+        let gpu = Int(monitor.gpuUsage.rounded())
+        return "CPU \(cpu)% · GPU \(gpu)% · RAM \(ram)%"
     }
 
     private var chipRow: some View {
@@ -156,10 +190,10 @@ struct MenuBarContent: View {
                     withAnimation(.snappy(duration: 0.18)) { isWebURLEntryExpanded.toggle() }
                 }
                 QuickActionButton(label: "HTML File", systemImage: "doc.richtext") {
-                    pickHTMLFileFromMenuBar()
+                    requestAddWallpaper(kind: "html-file")
                 }
                 QuickActionButton(label: "Folder", systemImage: "folder") {
-                    pickHTMLFolderFromMenuBar()
+                    requestAddWallpaper(kind: "html-folder")
                 }
                 QuickActionButton(label: "Bookmarks", systemImage: "bookmark.fill") {
                     showBookmarksPopover = true
@@ -290,40 +324,14 @@ struct MenuBarContent: View {
         withAnimation(.snappy(duration: 0.18)) { isWebURLEntryExpanded = false }
     }
 
-    private func pickHTMLFileFromMenuBar() {
-        guard let target = screenManager.screens.first else { return }
-        // Activate the app so the modal panel comes to the front instead of
-        // hiding behind the menu bar / other windows.
-        NSApp.activate(ignoringOtherApps: true)
-        let panel = NSOpenPanel()
-        panel.canChooseFiles = true
-        panel.canChooseDirectories = false
-        panel.allowsMultipleSelection = false
-        panel.allowedContentTypes = [UTType.html]
-        panel.prompt = "Use as Wallpaper"
-        guard panel.runModal() == .OK, let url = panel.url,
-              let source = ResourceUtilities.htmlSourceFromPickedFile(url) else { return }
-        screenManager.setHTMLWallpaperPreservingConfig(source: source, for: target)
-    }
-
-    private func pickHTMLFolderFromMenuBar() {
-        guard let target = screenManager.screens.first else { return }
-        NSApp.activate(ignoringOtherApps: true)
-        let panel = NSOpenPanel()
-        panel.canChooseFiles = false
-        panel.canChooseDirectories = true
-        panel.allowsMultipleSelection = false
-        panel.prompt = "Use as Wallpaper"
-        guard panel.runModal() == .OK, let folderURL = panel.url,
-              let bookmark = ResourceUtilities.createBookmark(for: folderURL) else { return }
-        let didStart = folderURL.startAccessingSecurityScopedResource()
-        defer { if didStart { folderURL.stopAccessingSecurityScopedResource() } }
-        let entries = (try? FileManager.default.contentsOfDirectory(atPath: folderURL.path)) ?? []
-        let indexFileName = ResourceUtilities.inferHTMLIndexFileName(from: entries)
-        screenManager.setHTMLWallpaperPreservingConfig(
-            source: .folder(bookmarkData: bookmark, indexFileName: indexFileName),
-            for: target
-        )
+    /// Hands the picker off to the main window via a synchronous closure
+    /// that calls `AppDelegate.showSettings(initialAddWallpaperPromptKind:)`
+    /// — this guarantees `ContentView` receives the request at init time
+    /// (or via post when the window already exists) instead of racing against
+    /// SwiftUI mounting the new scene.
+    private func requestAddWallpaper(kind: String) {
+        dismiss()
+        promptAddWallpaper(kind)
     }
 
     private func refreshGlobalToggles() {

--- a/LiveWallpaper/Views/Onboarding/OnboardingStepFirstWallpaper.swift
+++ b/LiveWallpaper/Views/Onboarding/OnboardingStepFirstWallpaper.swift
@@ -14,98 +14,38 @@ struct OnboardingStepFirstWallpaper: View {
     /// already has a Wallpaper Engine library, jump straight to the
     /// Workshop Gallery instead of presenting a single-folder picker.
     @State private var wpeFolderExists = false
+    /// Stage machine for the picker flow. Single-screen environments skip
+    /// `.screenSelection` entirely; video / HTML pickers route through
+    /// `.livePreview` so the user can confirm before applying.
+    @State private var stage: OnboardingPickerStage = .sourcePicker
+    @State private var selectedScreenIDs: Set<CGDirectDisplayID> = []
+    @State private var previewController = InspectorPreviewController()
 
     var body: some View {
         VStack(spacing: 0) {
             Spacer().frame(height: 32)
 
             VStack(spacing: 8) {
-                Text("Pick Your First Wallpaper")
+                Text(headerTitle)
                     .font(.system(size: 24, weight: .bold, design: .rounded))
                     .accessibilityAddTraits(.isHeader)
 
-                Text("You can always add more later from the menu bar.")
+                Text(headerSubtitle)
                     .font(.system(size: 13))
                     .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
             }
 
             Spacer().frame(height: 24)
 
-            VStack(alignment: .leading, spacing: 16) {
-                sectionHeader("From your Mac")
-                VStack(spacing: 8) {
-                    OnboardingOptionCard(
-                        icon: "film",
-                        iconTint: .blue,
-                        title: "Choose Your Video",
-                        subtitle: "Pick an MP4 or MOV from your Mac.",
-                        isFeatured: !wpeFolderExists,
-                        isLoading: false,
-                        action: chooseVideoFile
-                    )
-                    .keyboardShortcut("1", modifiers: [])
-
-                    OnboardingOptionCard(
-                        icon: "globe",
-                        iconTint: .green,
-                        title: "Add a Web Page",
-                        subtitle: "Use a website or local HTML as a live wallpaper.",
-                        isFeatured: false,
-                        isLoading: false,
-                        action: { showHTMLSheet = true }
-                    )
-                    .keyboardShortcut("2", modifiers: [])
-                }
-
-                sectionHeader("From Steam")
-                OnboardingOptionCard(
-                    icon: "cube.transparent",
-                    iconTint: .orange,
-                    title: wpeFolderExists ? "Browse Workshop Library" : "Import from Wallpaper Engine",
-                    subtitle: wpeFolderExists
-                        ? "We found your Steam folder. Browse Video / Web projects instantly."
-                        : "Use your Steam Workshop wallpapers. Scene types are preview-only.",
-                    isFeatured: wpeFolderExists,
-                    isLoading: false,
-                    action: {
-                        if wpeFolderExists {
-                            showWorkshopGallery = true
-                        } else {
-                            chooseWPEFolder()
-                        }
-                    }
-                )
-                .keyboardShortcut("3", modifiers: [])
-
-                sectionHeader("Built-in")
-                OnboardingOptionCard(
-                    icon: "sparkles.tv",
-                    iconTint: .secondary,
-                    title: "Use Apple Aerials",
-                    subtitle: "Browse Apple's downloaded aerial wallpapers.",
-                    isFeatured: false,
-                    isLoading: isRequestingAerials,
-                    action: chooseAerials
-                )
-                .keyboardShortcut("4", modifiers: [])
-
-                OnboardingOptionCard(
-                    icon: "arrow.right.circle",
-                    iconTint: .secondary,
-                    title: "Skip for Now",
-                    subtitle: "I'll set this up later from the settings.",
-                    isFeatured: false,
-                    isLoading: false,
-                    action: skip
-                )
-                .keyboardShortcut("5", modifiers: [])
-                .padding(.top, 4)
-            }
-            .padding(.horizontal, 36)
+            stageContent
+                .padding(.horizontal, stageHorizontalPadding)
+                .animation(.snappy(duration: 0.22), value: stage)
 
             Spacer()
         }
-        .onAppear { detectWPELibrary() }
+        .onAppear { configureInitialStage() }
+        .onDisappear { previewController.cleanup() }
         .sheet(isPresented: $showWorkshopGallery, onDismiss: nextStep) {
             WorkshopGalleryView()
                 .environment(screenManager)
@@ -116,6 +56,245 @@ struct OnboardingStepFirstWallpaper: View {
                 onConfirm: { source in applyHTML(source) }
             )
         }
+    }
+
+    private var headerTitle: String {
+        switch stage {
+        case .screenSelection: return "Apply To Which Displays?"
+        case .sourcePicker:    return "Pick Your First Wallpaper"
+        case .livePreview:     return "Looks Good?"
+        }
+    }
+
+    private var headerSubtitle: String {
+        switch stage {
+        case .screenSelection:
+            let count = screenManager.screens.count
+            return "You can always tweak each display individually later. (\(count) displays detected)"
+        case .sourcePicker:
+            return "You can always add more later from the menu bar."
+        case .livePreview:
+            return "Confirm to apply to \(selectedScreenIDs.count) display\(selectedScreenIDs.count == 1 ? "" : "s")."
+        }
+    }
+
+    private var stageHorizontalPadding: CGFloat {
+        stage.isScreenSelection ? 24 : 36
+    }
+
+    @ViewBuilder
+    private var stageContent: some View {
+        switch stage {
+        case .screenSelection:
+            screenSelectionView
+        case .sourcePicker:
+            sourcePickerView
+        case .livePreview(let draft):
+            livePreviewView(for: draft)
+        }
+    }
+
+    @ViewBuilder
+    private var screenSelectionView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 220), spacing: 12)], spacing: 12) {
+                ForEach(screenManager.screens, id: \.id) { screen in
+                    ScreenThumbnailCard(
+                        screen: screen,
+                        isSelected: selectedScreenIDs.contains(screen.id)
+                    ) {
+                        toggleScreenSelection(screen.id)
+                    }
+                }
+            }
+
+            HStack {
+                Button("Select All") {
+                    selectedScreenIDs = Set(screenManager.screens.map(\.id))
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(selectedScreenIDs.count == screenManager.screens.count)
+
+                Spacer()
+
+                Button("Continue") {
+                    withAnimation { stage = .sourcePicker }
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(selectedScreenIDs.isEmpty)
+            }
+            .padding(.top, 4)
+        }
+    }
+
+    @ViewBuilder
+    private var sourcePickerView: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            sectionHeader("From your Mac")
+            VStack(spacing: 8) {
+                OnboardingOptionCard(
+                    icon: "film",
+                    iconTint: .blue,
+                    title: "Choose Your Video",
+                    subtitle: "Pick an MP4 or MOV from your Mac.",
+                    isFeatured: !wpeFolderExists,
+                    isLoading: false,
+                    action: chooseVideoFile
+                )
+                .keyboardShortcut("1", modifiers: [])
+
+                OnboardingOptionCard(
+                    icon: "globe",
+                    iconTint: .green,
+                    title: "Add a Web Page",
+                    subtitle: "Use a website or local HTML as a live wallpaper.",
+                    isFeatured: false,
+                    isLoading: false,
+                    action: { showHTMLSheet = true }
+                )
+                .keyboardShortcut("2", modifiers: [])
+            }
+
+            sectionHeader("From Steam")
+            OnboardingOptionCard(
+                icon: "cube.transparent",
+                iconTint: .orange,
+                title: wpeFolderExists ? "Browse Workshop Library" : "Import from Wallpaper Engine",
+                subtitle: wpeFolderExists
+                    ? "We found your Steam folder. Browse Video / Web projects instantly."
+                    : "Use your Steam Workshop wallpapers. Scene types are preview-only.",
+                isFeatured: wpeFolderExists,
+                isLoading: false,
+                action: {
+                    if wpeFolderExists {
+                        showWorkshopGallery = true
+                    } else {
+                        chooseWPEFolder()
+                    }
+                }
+            )
+            .keyboardShortcut("3", modifiers: [])
+
+            sectionHeader("Built-in")
+            OnboardingOptionCard(
+                icon: "sparkles.tv",
+                iconTint: .secondary,
+                title: "Use Apple Aerials",
+                subtitle: "Browse Apple's downloaded aerial wallpapers.",
+                isFeatured: false,
+                isLoading: isRequestingAerials,
+                action: chooseAerials
+            )
+            .keyboardShortcut("4", modifiers: [])
+
+            OnboardingOptionCard(
+                icon: "arrow.right.circle",
+                iconTint: .secondary,
+                title: "Skip for Now",
+                subtitle: "I'll set this up later from the settings.",
+                isFeatured: false,
+                isLoading: false,
+                action: skip
+            )
+            .keyboardShortcut("5", modifiers: [])
+            .padding(.top, 4)
+        }
+    }
+
+    @ViewBuilder
+    private func livePreviewView(for draft: SourceDraft) -> some View {
+        VStack(spacing: 20) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(NSColor.windowBackgroundColor))
+                    .shadow(color: .black.opacity(0.1), radius: 8, y: 4)
+
+                switch draft {
+                case .video:
+                    if let player = previewController.player {
+                        CustomVideoPlayer(player: player, fitMode: .aspectFill)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    } else {
+                        ProgressView().controlSize(.regular)
+                    }
+                case .html:
+                    VStack(spacing: 12) {
+                        Image(systemName: "globe")
+                            .font(.system(size: 64))
+                            .foregroundStyle(.tertiary)
+                        Text("Web Preview Not Available")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        Text("The web wallpaper renders after you confirm.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+            }
+            .aspectRatio(16.0 / 10.0, contentMode: .fit)
+            .frame(maxHeight: 320)
+
+            HStack(spacing: 12) {
+                Button("Pick Different Source") {
+                    previewController.cleanup()
+                    withAnimation { stage = .sourcePicker }
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Set as Wallpaper") {
+                    confirmAndApply(draft: draft)
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .onAppear {
+            if case .video(let url, _) = draft {
+                previewController.startPlaybackPreview(from: url, syncTo: nil)
+            }
+        }
+    }
+
+    private func toggleScreenSelection(_ id: CGDirectDisplayID) {
+        if selectedScreenIDs.contains(id) {
+            // Always keep at least one screen selected.
+            guard selectedScreenIDs.count > 1 else { return }
+            selectedScreenIDs.remove(id)
+        } else {
+            selectedScreenIDs.insert(id)
+        }
+    }
+
+    private func configureInitialStage() {
+        detectWPELibrary()
+        if screenManager.screens.count > 1 {
+            selectedScreenIDs = Set(screenManager.screens.map(\.id))
+            stage = .screenSelection
+        } else if let only = screenManager.screens.first {
+            selectedScreenIDs = [only.id]
+            stage = .sourcePicker
+        }
+    }
+
+    private func confirmAndApply(draft: SourceDraft) {
+        let targets = screenManager.screens.filter { selectedScreenIDs.contains($0.id) }
+        guard !targets.isEmpty else { return }
+        previewController.cleanup()
+
+        switch draft {
+        case .video(let url, let bookmark):
+            for screen in targets {
+                screenManager.setVideo(url: url, bookmarkData: bookmark, for: screen)
+            }
+        case .html(let source):
+            for screen in targets {
+                screenManager.setHTMLWallpaperPreservingConfig(source: source, for: screen)
+            }
+        }
+        nextStep()
     }
 
     @ViewBuilder
@@ -155,25 +334,18 @@ struct OnboardingStepFirstWallpaper: View {
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
         panel.allowedContentTypes = [.movie, .video, .quickTimeMovie, .mpeg4Movie, .avi]
-        panel.prompt = "Use Wallpaper"
+        panel.prompt = "Preview"
 
         let response = panel.runModal()
-        guard response == .OK, let url = panel.url else { return }
-
-        if let screen = screenManager.screens.first,
-           let bookmark = ResourceUtilities.createBookmark(for: url) {
-            screenManager.setVideo(url: url, bookmarkData: bookmark, for: screen)
-            SettingsManager.shared.saveLastUsedDirectory(url.deletingLastPathComponent())
-        }
-        nextStep()
+        guard response == .OK, let url = panel.url,
+              let bookmark = ResourceUtilities.createBookmark(for: url) else { return }
+        SettingsManager.shared.saveLastUsedDirectory(url.deletingLastPathComponent())
+        withAnimation { stage = .livePreview(.video(url, bookmark)) }
     }
 
     private func applyHTML(_ source: HTMLSource) {
-        if let screen = screenManager.screens.first {
-            screenManager.setHTMLWallpaper(source: source, for: screen)
-        }
         showHTMLSheet = false
-        nextStep()
+        withAnimation { stage = .livePreview(.html(source)) }
     }
 
     private func chooseWPEFolder() {
@@ -193,12 +365,18 @@ struct OnboardingStepFirstWallpaper: View {
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
 
-        if let screen = screenManager.screens.first {
-            Task { @MainActor in
+        // WPE import is async + multi-step (validation → cache extraction); the
+        // live-preview path doesn't apply. Apply directly to every selected
+        // display, then advance.
+        let targets = screenManager.screens.filter { selectedScreenIDs.contains($0.id) }
+        guard !targets.isEmpty else {
+            nextStep()
+            return
+        }
+        Task { @MainActor in
+            for screen in targets {
                 await screenManager.importWallpaperEngineProject(at: url, for: screen)
-                nextStep()
             }
-        } else {
             nextStep()
         }
     }
@@ -471,4 +649,72 @@ private struct OnboardingOptionCard: View {
 
 extension Notification.Name {
     static let openAppleAerials = Notification.Name("OpenAppleAerials")
+}
+
+// MARK: - Picker stage machine
+
+/// Tracks the current step of the onboarding picker. The associated value on
+/// `.livePreview` lets us defer applying until the user confirms.
+private enum OnboardingPickerStage: Equatable {
+    case screenSelection
+    case sourcePicker
+    case livePreview(SourceDraft)
+
+    var isScreenSelection: Bool {
+        if case .screenSelection = self { return true }
+        return false
+    }
+}
+
+/// Captures enough state to apply a wallpaper after the user confirms in
+/// the live-preview stage. WPE import / Apple Aerials skip the preview path.
+private enum SourceDraft: Equatable {
+    case video(URL, Data)
+    case html(HTMLSource)
+}
+
+private struct ScreenThumbnailCard: View {
+    let screen: Screen
+    let isSelected: Bool
+    let action: () -> Void
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 8) {
+                Image(systemName: "display")
+                    .font(.system(size: 32))
+                    .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+                    .symbolRenderingMode(.hierarchical)
+
+                VStack(spacing: 2) {
+                    Text(screen.name)
+                        .font(.system(size: 13, weight: .medium))
+                        .lineLimit(1)
+                    Text("\(Int(screen.frame.width)) × \(Int(screen.frame.height))")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.vertical, 16)
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity)
+            .contentShape(RoundedRectangle(cornerRadius: 12))
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.regularMaterial)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 3)
+            )
+        }
+        .buttonStyle(.plain)
+        .focused($isFocused)
+        .accessibilityLabel("\(screen.name), \(Int(screen.frame.width)) by \(Int(screen.frame.height)) pixels")
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+        .accessibilityHint("Toggles whether the first wallpaper applies to this display")
+    }
 }

--- a/LiveWallpaper/Views/ScreenDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetailView.swift
@@ -15,6 +15,62 @@ struct ScreenDetailView: View {
     private var runtimeError: WallpaperRuntimeError? {
         screenManager.runtimeError(for: screen)
     }
+    private var applyToAllConfirmationMessage: String {
+        let others = max(0, screenManager.screens.count - 1)
+        let plural = others == 1 ? "" : "s"
+        return "This replaces the wallpaper on \(others) other display\(plural) with the same content and settings as this one."
+    }
+
+    @ViewBuilder
+    private var runtimeErrorBannerView: some View {
+        if let runtimeError {
+            let activeType = screen.runtimeSession?.wallpaperType ?? selectedWallpaperType
+            let canRePick = activeType == .video || activeType == .html
+            RuntimeErrorBanner(
+                error: runtimeError,
+                canRePick: canRePick,
+                onRetry: { screenManager.retryRuntimeSession(for: screen) },
+                onRePick: rePickRuntimeSource
+            )
+            .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var screenDetailToolbar: some ToolbarContent {
+        ToolbarItem(placement: .principal) {
+            Picker("Wallpaper Type", selection: $selectedWallpaperType) {
+                ForEach(WallpaperType.allCases) { type in
+                    Text(type.rawValue).tag(type)
+                }
+            }
+            .pickerStyle(.segmented)
+            .fixedSize(horizontal: true, vertical: false)
+            .accessibilityLabel("Wallpaper type")
+            .accessibilityHint("Choose between video, HTML, or Metal shader wallpaper")
+            .onChange(of: selectedWallpaperType) { _, newType in
+                switch newType {
+                case .video:
+                    screenManager.switchToVideoWallpaper(for: screen)
+                case .html:
+                    screenManager.switchToHTMLWallpaper(for: screen)
+                case .metalShader, .scene:
+                    break // pickers drive activation themselves
+                }
+            }
+        }
+        ToolbarItem(placement: .primaryAction) {
+            Button {
+                showApplyToAllConfirm = true
+            } label: {
+                Label("Apply to All", systemImage: "square.on.square")
+            }
+            .help("Copy this display's wallpaper and settings to every other display")
+            .accessibilityLabel("Apply to all displays")
+            .accessibilityHint("Copies the current wallpaper and settings to every other connected display")
+            .disabled(screenManager.screens.count <= 1 || screenManager.getConfiguration(for: screen) == nil)
+        }
+    }
     /// Resolved Wallpaper Engine origin metadata for the active wallpaper, or
     /// nil when the user picked content directly. Recomputed on every body
     /// evaluation so save/import flows propagate without local @State.
@@ -49,6 +105,7 @@ struct ScreenDetailView: View {
     @State private var showErrorAlert = false
     @State private var errorMessage = ""
     @State private var showClearConfirm = false
+    @State private var showApplyToAllConfirm = false
     @State private var previewController = InspectorPreviewController()
     @State private var hasPreviewSource = false
 
@@ -162,17 +219,7 @@ struct ScreenDetailView: View {
             .padding(.horizontal, 24)
             .padding(.vertical, 14)
 
-            if let runtimeError {
-                let activeType = screen.runtimeSession?.wallpaperType ?? selectedWallpaperType
-                let canRePick = activeType == .video || activeType == .html
-                RuntimeErrorBanner(
-                    error: runtimeError,
-                    canRePick: canRePick,
-                    onRetry: { screenManager.retryRuntimeSession(for: screen) },
-                    onRePick: rePickRuntimeSource
-                )
-                .transition(reduceMotion ? .opacity : .opacity.combined(with: .move(edge: .top)))
-            }
+            runtimeErrorBannerView
 
             Divider()
 
@@ -272,14 +319,65 @@ struct ScreenDetailView: View {
 
                 Divider()
 
-                if selectedWallpaperType == .video {
-                    ScrollView {
-                        GlassEffectContainer(spacing: 16) {
-                            VStack(spacing: 16) {
-                            HStack(spacing: 0) {
-                                ForEach(WallpaperMode.allCases) { mode in
-                                    Button {
-                                        withAnimation(.snappy(duration: 0.18)) {
+                videoInspectorPanel
+            }
+            .transaction(value: selectedWallpaperType) { $0.animation = nil }
+        }
+        .toolbar { screenDetailToolbar }
+        .confirmationDialog(
+            "Apply this wallpaper to every other display?",
+            isPresented: $showApplyToAllConfirm
+        ) {
+            Button("Apply to All Displays", role: .destructive) {
+                screenManager.applyConfigurationToAllDisplays(from: screen)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(applyToAllConfirmationMessage)
+        }
+        .onAppear { loadScreenConfiguration() }
+        .onDisappear { cleanupPreviewPlayer() }
+        .onChange(of: screen.id) {
+            cleanupPreviewPlayer()
+            loadScreenConfiguration()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .wallpaperConfigurationDidChange)) { notification in
+            guard let changedID = notification.userInfo?["screenID"] as? CGDirectDisplayID,
+                  changedID == screen.id else { return }
+            loadScreenConfiguration()
+        }
+        .alert("Error", isPresented: $showErrorAlert) {
+            Button("OK", role: .cancel) { }
+        } message: { Text(errorMessage) }
+        .confirmationDialog(
+            "Clear Wallpaper Video",
+            isPresented: $showClearConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Clear Video", role: .destructive) {
+                performClearVideo()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Are you sure you want to remove this video? This will delete all configuration for this screen.")
+        }
+        .dropDestination(for: URL.self) { urls, _ in
+            handleDrop(urls: urls)
+        } isTargeted: { targeted in
+            isDraggingOver = targeted
+        }
+    }
+
+    @ViewBuilder
+    private var videoInspectorPanel: some View {
+        if selectedWallpaperType == .video {
+            ScrollView {
+                GlassEffectContainer(spacing: 16) {
+                    VStack(spacing: 16) {
+                        HStack(spacing: 0) {
+                            ForEach(WallpaperMode.allCases) { mode in
+                                Button {
+                                    withAnimation(.snappy(duration: 0.18)) {
                                             selectedWallpaperMode = mode
                                         }
                                         screenManager.updateWallpaperMode(mode, for: screen)
@@ -499,66 +597,6 @@ struct ScreenDetailView: View {
                     .fixedSize(horizontal: true, vertical: false)
                     .background(Color(NSColor.windowBackgroundColor))
                     .clipped()
-                }
-            }
-            .transaction(value: selectedWallpaperType) { $0.animation = nil }
-        }
-        .toolbar {
-            ToolbarItem(placement: .principal) {
-                Picker("Wallpaper Type", selection: $selectedWallpaperType) {
-                    ForEach(WallpaperType.allCases) { type in
-                        Text(type.rawValue).tag(type)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .fixedSize(horizontal: true, vertical: false)
-                .accessibilityLabel("Wallpaper type")
-                .accessibilityHint("Choose between video, HTML, or Metal shader wallpaper")
-                .onChange(of: selectedWallpaperType) { _, newType in
-                    switch newType {
-                    case .video:
-                        screenManager.switchToVideoWallpaper(for: screen)
-                    case .html:
-                        screenManager.switchToHTMLWallpaper(for: screen)
-                    case .metalShader:
-                        break // shader picker drives its own activation
-                    case .scene:
-                        break // Scene tab content lands in Day 4; Day 1+2 only register the segment.
-                    }
-                }
-            }
-        }
-        .onAppear { loadScreenConfiguration() }
-        .onDisappear { cleanupPreviewPlayer() }
-        .onChange(of: screen.id) {
-            cleanupPreviewPlayer()
-            loadScreenConfiguration()
-        }
-        // Keep inspector state aligned with background automation.
-        .onReceive(NotificationCenter.default.publisher(for: .wallpaperConfigurationDidChange)) { notification in
-            guard let changedID = notification.userInfo?["screenID"] as? CGDirectDisplayID,
-                  changedID == screen.id else { return }
-            loadScreenConfiguration()
-        }
-        .alert("Error", isPresented: $showErrorAlert) {
-            Button("OK", role: .cancel) { }
-        } message: { Text(errorMessage) }
-        .confirmationDialog(
-            "Clear Wallpaper Video",
-            isPresented: $showClearConfirm,
-            titleVisibility: .visible
-        ) {
-            Button("Clear Video", role: .destructive) {
-                performClearVideo()
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("Are you sure you want to remove this video? This will delete all configuration for this screen.")
-        }
-        .dropDestination(for: URL.self) { urls, _ in
-            handleDrop(urls: urls)
-        } isTargeted: { targeted in
-            isDraggingOver = targeted
         }
     }
 

--- a/LiveWallpaperTests/WPESceneSectionStateTests.swift
+++ b/LiveWallpaperTests/WPESceneSectionStateTests.swift
@@ -93,6 +93,7 @@ struct WPESceneSectionStateTests {
         #expect(PausedReason.previewUnavailable.label == "Preview Unavailable")
     }
 
+    @MainActor
     @Test("FallbackReason rendering distinguishes parse vs resource failure copy")
     func fallbackReasonCopy() {
         let parse = WPEFallbackCard(


### PR DESCRIPTION
## Summary

Second slice of `.claude/plan/product-pivot-video-html-mvp.md` — Week 2 P0 UX closure for the four critical paths the audit flagged.

- **U-H1 / Apply to All Displays** — `ScreenManager.applyConfigurationToAllDisplays(from:)` clones the source's saved config onto every other registered screen; toolbar primaryAction with destructive-role confirmation dialog. The target's existing runtime session is torn down before `restoreWallpaperSession` so the video reuse-existing-player branch can't keep playing the old URL after the config is updated.
- **U-H2 / Sidebar IA** — `Library` section now hosts `My Wallpapers`, `Apple Aerials`, and a conditional `Steam Workshop` entry (visible when the workshop bookmark is set OR when the user has any imports). Sidebar refreshes on `.wpeHistoryDidChange` and a new `.workshopLibraryRootBookmarkDidChange` notification.
- **U-C2 + U-M2 / MenuBar redesign** — Quick-action buttons no longer launch `NSOpenPanel` from the status overlay (focus loss put it behind the menu strip). The new flow hands the picker request off via a closure (`promptAddWallpaper(kind)`) that calls `AppDelegate.showSettings(initialAddWallpaperPromptKind:)`, which guarantees ContentView observes the prompt either via the new `init`-time argument or via `.promptAddWallpaper` when the window already exists. Dashboard chip row is collapsed by default; one-line summary "CPU x% · GPU y% · RAM z%" with VoiceOver `accessibilityValue`.
- **U-C1 / Onboarding multi-screen + live preview** — Three-stage flow: `.screenSelection` (multi-display only), `.sourcePicker`, `.livePreview`. Video uses the existing `InspectorPreviewController` + `CustomVideoPlayer`; HTML shows an explanatory placeholder card instead of a heavy transient `WKWebView`. WPE folder import / Apple Aerials retain their direct apply because their multi-step pipelines (cache extraction / aerial download) don't fit the preview path.

## Audit + fixes already applied

Each finding from the parallel codex/gemini review is folded into the same PR before review:

- **codex (backend)** — apply-to-all Cloning was missing `releaseRuntimeSession(target)` so a target already running video would persist the new config but not swap the URL; menu-bar prompt race fixed by `init`-time prompt instead of `dismiss + DispatchQueue.async + post`; sidebar reactivity extended to `.wpeHistoryDidChange` + `.workshopLibraryRootBookmarkDidChange`.
- **gemini (UI/UX)** — sidebar Library reordered so "My Wallpapers" stays at the top regardless of Workshop visibility; menubar dashboard a11y switched from hint to `accessibilityValue`; Apply-to-All confirmation button now `role: .destructive`; HTML preview placeholder gains explanatory secondary copy.

## Bonus

- `test: silence WPESceneSection MainActor isolation warnings` (e129633) — `fallbackReasonCopy` runs `WPEFallbackCard.init` which is `@MainActor`; adding `@MainActor` to the test removes four warnings on every test build.

## Commits

- `e129633` test: silence WPESceneSection MainActor isolation warnings
- `4df42db` feat(runtime): apply current configuration to all displays
- `1d17970` refactor(ui): sidebar IA — Library section with Workshop/Aerials top-level
- `c5eb785` feat(menubar): notification handoff replaces NSOpenPanel + collapsible dashboard
- `3462785` feat(onboarding): multi-screen selection + live preview stage

## Verification

- `xcodebuild build -scheme LiveWallpaper -configuration Debug` — BUILD SUCCEEDED
- `xcodebuild test -only-testing:LiveWallpaperTests` — **423 tests / 73 suites passed** (one pre-existing GPU-race flake on `routesLayerCompositeTargetIntoScene` / `Routes declared FBO target into a later FBO source` reproduced once mid-run; the same suite passes when run in isolation. Documented in repo memory; unrelated to this branch.)

## Test plan

- [ ] Two-display setup: configure a video wallpaper on display 1 → click "Apply to All" → confirm the second display swaps to the same URL within ~1s; toolbar button is disabled when only one display is connected.
- [ ] Steam Workshop entry appears in the sidebar after the user picks their library root from Settings; entry disappears after `clearWorkshopLibraryRootBookmark` if no recent imports remain; ordering stays stable for users who never open Workshop.
- [ ] Status-bar HTML File / HTML Folder buttons → main window comes to front → `NSOpenPanel` shows reliably (no menu-bar overlay flicker, no panel hidden behind the menu strip). VoiceOver reads "System Monitor, Collapsed, CPU x% · GPU y% · RAM z%".
- [ ] First-run on a 2-display setup: screen-selection stage with both selected → tile pick → live preview shows the chosen source → "Set as Wallpaper" applies to both. Single-display still goes straight to source picker.

## Out of scope (later weeks)

Week 3 (HDR EDR / exact-seek / common controls / HTML ephemeral data store), Week 4 (HSplitView Inspector / a11y sweep / file splits / lifecycle integration tests) remain in `.claude/plan/product-pivot-video-html-mvp.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)