### PR TITLE
Week 3 P1: video transform/HDR + HTML ephemeral/retry + CommonPlaybackInspector

### DIFF
--- a/LiveWallpaper/Models/HTMLConfig.swift
+++ b/LiveWallpaper/Models/HTMLConfig.swift
@@ -27,6 +27,18 @@ struct HTMLConfig: Codable, Equatable, Sendable {
     /// misalignment on Retina displays.
     var physicalPixelLayout: Bool = false
 
+    /// When `true`, runs `WKWebView` with `WKWebsiteDataStore.nonPersistent()`
+    /// so cookies / cache / localStorage do not persist across sessions —
+    /// useful for kiosk-style wallpapers and untrusted URL sources. Toggling
+    /// this only takes effect on the next session rebuild because WebKit
+    /// cannot swap its data store after init.
+    var useEphemeralStorage: Bool = false
+
+    /// Maximum auto-retry attempts after navigation failures. Exponential
+    /// backoff: 1s, 2s, 4s ... up to `maxRetries`. After the budget is
+    /// exhausted the runtime surfaces the error in the screen-detail banner.
+    var maxRetries: Int = 3
+
     static let `default` = HTMLConfig()
 
     private enum CodingKeys: String, CodingKey {
@@ -36,6 +48,8 @@ struct HTMLConfig: Codable, Equatable, Sendable {
         case customCSS
         case muteAudio
         case physicalPixelLayout
+        case useEphemeralStorage
+        case maxRetries
     }
 
     init(
@@ -44,7 +58,9 @@ struct HTMLConfig: Codable, Equatable, Sendable {
         blockTrackers: Bool = true,
         customCSS: String? = nil,
         muteAudio: Bool = false,
-        physicalPixelLayout: Bool = false
+        physicalPixelLayout: Bool = false,
+        useEphemeralStorage: Bool = false,
+        maxRetries: Int = 3
     ) {
         self.allowJavaScript = allowJavaScript
         self.allowMouseInteraction = allowMouseInteraction
@@ -52,6 +68,8 @@ struct HTMLConfig: Codable, Equatable, Sendable {
         self.customCSS = customCSS
         self.muteAudio = muteAudio
         self.physicalPixelLayout = physicalPixelLayout
+        self.useEphemeralStorage = useEphemeralStorage
+        self.maxRetries = maxRetries
     }
 
     init(from decoder: Decoder) throws {
@@ -62,5 +80,10 @@ struct HTMLConfig: Codable, Equatable, Sendable {
         customCSS = try c.decodeIfPresent(String.self, forKey: .customCSS)
         muteAudio = try c.decodeIfPresent(Bool.self, forKey: .muteAudio) ?? false
         physicalPixelLayout = try c.decodeIfPresent(Bool.self, forKey: .physicalPixelLayout) ?? false
+        useEphemeralStorage = try c.decodeIfPresent(Bool.self, forKey: .useEphemeralStorage) ?? false
+        // Clamp persisted budget into a sane range so a corrupted defaults
+        // file can't drive an unbounded retry loop.
+        let decodedRetries = try c.decodeIfPresent(Int.self, forKey: .maxRetries) ?? 3
+        maxRetries = min(max(0, decodedRetries), 10)
     }
 }

--- a/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
+++ b/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
@@ -6,8 +6,6 @@ import Metal
 final class AmbientWallpaperSessionBuilder {
     func makeHTMLSession(source: HTMLSource, config: HTMLConfig, frame: CGRect) -> AmbientWallpaperSession {
         let window = VideoWallpaperWindow(frame: frame)
-        let htmlView = HTMLWallpaperView(frame: frame)
-        window.contentView = htmlView
 
         // Untrusted remote URLs run with JS off no matter what config says.
         let trust = HTMLTrust.evaluate(source: source, trustedHosts: TrustedHostStore.shared.hostSet)
@@ -23,6 +21,12 @@ final class AmbientWallpaperSessionBuilder {
             effective.physicalPixelLayout = true
             Logger.info("HTML wallpaper: detected Wallpaper Engine project — enabling physical-pixel layout", category: .screenManager)
         }
+
+        // `WKWebsiteDataStore` is locked into the configuration at WKWebView
+        // init time, so the ephemeral preference must be resolved here before
+        // we instantiate the view.
+        let htmlView = HTMLWallpaperView(frame: frame, initialEphemeral: effective.useEphemeralStorage)
+        window.contentView = htmlView
 
         let session = AmbientWallpaperSession(window: window, wallpaperType: .html, performanceTarget: htmlView)
         // Bridge HTML navigation failures to the session before kicking off the

--- a/LiveWallpaper/VideoPlayback/HTMLWallpaperView.swift
+++ b/LiveWallpaper/VideoPlayback/HTMLWallpaperView.swift
@@ -40,11 +40,21 @@ final class HTMLWallpaperView: NSView {
     private var hasTrackerRulesAttached = false
     private var trackerBlockingRequested = false
     private var activeSecurityScopedURL: URL?
+    /// `WKWebsiteDataStore` is locked at WKWebView init time. We track which
+    /// store the live view is using vs what config now requests so subsequent
+    /// `apply(_:)` calls can warn the caller that the swap will only take
+    /// effect on the next session rebuild.
+    private var currentDataStoreIsEphemeral: Bool
+    private var pendingEphemeral: Bool
     /// Tracks the last applied `HTMLConfig` so re-`apply()` calls with the
     /// same toggles skip the user-script teardown / re-install.
     private var lastAppliedConfig: HTMLConfig?
     /// Replays into `loadSource(_:)` for retry / re-entry (sleep wake, error banner).
     private var lastSource: HTMLSource?
+    /// Counts consecutive navigation failures since the last successful load.
+    /// Capped by `HTMLConfig.maxRetries`; used to drive exponential backoff.
+    private var consecutiveFailureCount: Int = 0
+    private var pendingRetryTask: Task<Void, Never>?
 
     /// Forwarded to the owning `AmbientWallpaperSession` so failures surface as
     /// `RuntimeErrorBanner` and can be retried from the screen-detail UI.
@@ -52,18 +62,23 @@ final class HTMLWallpaperView: NSView {
 
     // MARK: - Initialization
 
-    override init(frame frameRect: NSRect) {
+    init(frame frameRect: NSRect, initialEphemeral: Bool = false) {
         let configuration = WKWebViewConfiguration()
         let preferences = WKWebpagePreferences()
         preferences.allowsContentJavaScript = true
         configuration.defaultWebpagePreferences = preferences
         configuration.mediaTypesRequiringUserActionForPlayback = []
+        configuration.websiteDataStore = initialEphemeral
+            ? .nonPersistent()
+            : .default()
 
         // Register the custom scheme BEFORE the webView is created —
         // schemes cannot be added after WKWebView init.
         let handler = FolderURLSchemeHandler()
         configuration.setURLSchemeHandler(handler, forURLScheme: FolderURLSchemeHandler.scheme)
         self.folderHandler = handler
+        self.currentDataStoreIsEphemeral = initialEphemeral
+        self.pendingEphemeral = initialEphemeral
 
         webView = HTMLWebView(frame: NSRect(origin: .zero, size: frameRect.size), configuration: configuration)
 
@@ -202,6 +217,7 @@ final class HTMLWallpaperView: NSView {
     // MARK: - Public API
 
     func apply(_ config: HTMLConfig) {
+        pendingEphemeral = config.useEphemeralStorage
         if let previous = lastAppliedConfig, previous == config {
             // 完全相同 — 跳过任何注入操作，避免 WebKit 重新评估脚本包。
             return
@@ -211,6 +227,15 @@ final class HTMLWallpaperView: NSView {
         webView.configuration.defaultWebpagePreferences.allowsContentJavaScript = config.allowJavaScript
         allowMouseInteraction = config.allowMouseInteraction
 
+        if currentDataStoreIsEphemeral != pendingEphemeral {
+            let requested = pendingEphemeral ? "ephemeral" : "persistent"
+            let active = currentDataStoreIsEphemeral ? "ephemeral" : "persistent"
+            Logger.warning(
+                "HTML wallpaper requested \(requested) storage but the live WKWebView still uses the \(active) data store; the change applies on next session rebuild.",
+                category: .screenManager
+            )
+        }
+
         // 任何运行时状态变化都先尝试通过 evaluateJavaScript 热更新 — 不重建 user script。
         applyRuntimeState(previous: previous, current: config)
 
@@ -219,6 +244,7 @@ final class HTMLWallpaperView: NSView {
             || (previous?.allowMouseInteraction != config.allowMouseInteraction)
             || (previous?.muteAudio != config.muteAudio)
             || (previous?.allowJavaScript != config.allowJavaScript)
+            || (previous?.useEphemeralStorage != config.useEphemeralStorage)
 
         if needsScriptRebuild {
             installBaselineUserScripts(for: config)
@@ -271,7 +297,17 @@ final class HTMLWallpaperView: NSView {
     }
 
     func loadSource(_ source: HTMLSource) {
+        loadSource(source, resetFailureCount: true)
+    }
+
+    /// Internal entry point distinguishing user-driven loads (which reset the
+    /// retry budget) from `scheduleRetry` continuations (which keep the
+    /// counter so backoff progresses).
+    private func loadSource(_ source: HTMLSource, resetFailureCount: Bool) {
         lastSource = source
+        if resetFailureCount {
+            resetNavigationFailureState()
+        }
         stopActiveSecurityScope()
         // Cut every non-folder source off from the previous folder's scheme handler
         // (C1): if folderURL stayed live, a remote page could probe livewallpaper://.
@@ -321,7 +357,7 @@ final class HTMLWallpaperView: NSView {
     /// Re-applies the most recent `HTMLSource`. Used by `WallpaperRuntimeSession.retry()`.
     func reloadCurrentSource() {
         guard let lastSource else { return }
-        loadSource(lastSource)
+        loadSource(lastSource, resetFailureCount: false)
     }
 
     private func stopActiveSecurityScope() {
@@ -393,6 +429,34 @@ final class HTMLWallpaperView: NSView {
 
     private func reportError(_ error: WallpaperRuntimeError) {
         onError?(error)
+    }
+
+    /// Returns `true` when a retry was scheduled and the caller should skip
+    /// `reportError`. Increments the consecutive failure counter and arms the
+    /// next backoff slot (1s, 2s, 4s …) bounded by `HTMLConfig.maxRetries`.
+    private func shouldRetryNavigationFailure() -> Bool {
+        let maxRetries = max(0, lastAppliedConfig?.maxRetries ?? 0)
+        guard consecutiveFailureCount < maxRetries else { return false }
+        scheduleRetry()
+        return true
+    }
+
+    private func scheduleRetry() {
+        consecutiveFailureCount += 1
+        let delaySeconds = pow(2.0, Double(consecutiveFailureCount - 1))
+        pendingRetryTask?.cancel()
+        pendingRetryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(delaySeconds))
+            guard !Task.isCancelled, let self else { return }
+            self.pendingRetryTask = nil
+            self.reloadCurrentSource()
+        }
+    }
+
+    private func resetNavigationFailureState() {
+        consecutiveFailureCount = 0
+        pendingRetryTask?.cancel()
+        pendingRetryTask = nil
     }
 
     private func navigationFailureURL(webView: WKWebView, error: NSError) -> URL {
@@ -525,6 +589,8 @@ final class HTMLWallpaperView: NSView {
 
     func cleanup() {
         trackerBlockingRequested = false
+        pendingRetryTask?.cancel()
+        pendingRetryTask = nil
         webView.stopLoading()
         webView.navigationDelegate = nil
         webView.uiDelegate = nil
@@ -642,6 +708,7 @@ extension HTMLWallpaperView: WKNavigationDelegate {
     /// 导航完成后兜底：autoplay nudge + 静音状态再施加一次（覆盖晚到的元素）。
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         Logger.info("HTML wallpaper finished loading: \(webView.url?.absoluteString ?? "<no url>")", category: .screenManager)
+        resetNavigationFailureState()
         let muted = lastAppliedConfig?.muteAudio == true ? "true" : "false"
         let nudge = """
         (function() {
@@ -669,6 +736,7 @@ extension HTMLWallpaperView: WKNavigationDelegate {
             "HTML wallpaper didFail [domain=\(nsError.domain) code=\(nsError.code)] url=\(webView.url?.absoluteString ?? "<no url>") — \(nsError.localizedDescription); userInfo=\(nsError.userInfo)",
             category: .screenManager
         )
+        if shouldRetryNavigationFailure() { return }
         reportError(.webNavigationFailed(
             navigationFailureURL(webView: webView, error: nsError),
             code: nsError.code,
@@ -683,6 +751,7 @@ extension HTMLWallpaperView: WKNavigationDelegate {
             "HTML wallpaper didFailProvisionalNavigation [domain=\(nsError.domain) code=\(nsError.code)] url=\(webView.url?.absoluteString ?? "<no url>") — \(nsError.localizedDescription); userInfo=\(nsError.userInfo)",
             category: .screenManager
         )
+        if shouldRetryNavigationFailure() { return }
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorNotConnectedToInternet {
             reportError(.networkOffline)
         } else {

--- a/LiveWallpaper/VideoPlayback/VideoContainerView.swift
+++ b/LiveWallpaper/VideoPlayback/VideoContainerView.swift
@@ -35,6 +35,19 @@ final class PlayerHostView: NSView {
         playerLayer?.videoGravity = gravity
     }
 
+    /// Forwards an HDR / EDR preference to the underlying `AVPlayerLayer`.
+    /// Uses `preferredDynamicRange` on macOS 26+, falls back to the older
+    /// `wantsExtendedDynamicRangeContent` selector on macOS 14-25, and is a
+    /// no-op below 14 so HDR videos still render (just tone-mapped to SDR).
+    func setExtendedDynamicRangeEnabled(_ enabled: Bool) {
+        guard let playerLayer else { return }
+        if #available(macOS 26, *) {
+            playerLayer.preferredDynamicRange = enabled ? .high : .standard
+        } else if playerLayer.responds(to: NSSelectorFromString("setWantsExtendedDynamicRangeContent:")) {
+            playerLayer.setValue(enabled, forKey: "wantsExtendedDynamicRangeContent")
+        }
+    }
+
     override func layout() {
         super.layout()
         playerLayer?.frame = bounds
@@ -107,6 +120,10 @@ class VideoContainerView: NSView {
         currentPlayer = player
         playerHostView.setVideoGravity(fitMode.avLayerVideoGravity)
         playerHostView.setPlayer(player)
+    }
+
+    func applyHDRPreference(_ enabled: Bool) {
+        playerHostView.setExtendedDynamicRangeEnabled(enabled)
     }
 
     // MARK: - Public API — Particles

--- a/LiveWallpaper/VideoPlayback/VideoWallpaperWindow.swift
+++ b/LiveWallpaper/VideoPlayback/VideoWallpaperWindow.swift
@@ -92,6 +92,13 @@ extension VideoWallpaperWindow {
         applyMouseInteractionPolicy()
     }
 
+    /// Switches the window's color space when an HDR video is loaded so the
+    /// composited output preserves the wider gamut. `nil` restores the
+    /// system default (sRGB-tagged) for SDR sources.
+    func setExtendedDynamicRangeEnabled(_ enabled: Bool) {
+        colorSpace = enabled ? NSColorSpace.displayP3 : nil
+    }
+
     private func applyMouseInteractionPolicy() {
         level = NSWindow.Level(rawValue: wallpaperWindowLevel)
         ignoresMouseEvents = !allowsWallpaperMouseInteraction

--- a/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
+++ b/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
@@ -33,6 +33,9 @@ final class WallpaperVideoPlayer {
     private(set) var shouldAutoplayWhenReady = true
     private(set) var requestedFrameRateLimit: Float = 0
     private(set) var runtimeError: WallpaperRuntimeError?
+    /// Populated lazily after `loadingTask` completes by `detectFormatInfoIfNeeded`.
+    /// Drives the EDR / HDR output path on the player layer + window.
+    private(set) var formatInfo: VideoFormatInfo?
     /// Error sink consumed by `VideoWallpaperSession` for UI surfacing. The
     /// sink replays any pre-existing error when assigned so late observers
     /// don't miss failures raised during init.
@@ -149,6 +152,14 @@ final class WallpaperVideoPlayer {
                     timer.checkpoint("Playback configured")
                 }
 
+                do {
+                    try await self.detectFormatInfoIfNeeded(for: url)
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    Logger.warning("Unable to detect video format: \(error.localizedDescription)", category: .videoPlayer)
+                }
+
                 Logger.debug("Video loaded: \(url.lastPathComponent)", category: .videoPlayer)
             } catch is CancellationError {
                 Logger.debug("Video loading task was cancelled", category: .videoPlayer)
@@ -193,6 +204,10 @@ final class WallpaperVideoPlayer {
         self.window = videoWindow
         self.videoView = containerView
 
+        if let formatInfo {
+            applyHDRPreferenceIfNeeded(for: formatInfo)
+        }
+
         if let pending = pendingParticleEffect {
             pendingParticleEffect = nil
             containerView.setParticleEffect(pending.0, density: pending.1)
@@ -208,6 +223,24 @@ final class WallpaperVideoPlayer {
             applyRequestedFrameRateLimitIfReady()
         }
         setupPlayerReadyObserver()
+    }
+
+    private func detectFormatInfoIfNeeded(for url: URL) async throws {
+        guard formatInfo == nil else { return }
+        let detected = try await PlayableVideoLoader.detectFormat(at: url)
+        try Task.checkCancellation()
+        formatInfo = detected
+        applyHDRPreferenceIfNeeded(for: detected)
+    }
+
+    private func applyHDRPreferenceIfNeeded(for formatInfo: VideoFormatInfo) {
+        guard formatInfo.isHDR, let videoView else { return }
+        let details = formatInfo.badges.isEmpty
+            ? "transfer function detected"
+            : formatInfo.badges.joined(separator: " ")
+        Logger.info("Video is HDR (\(details)) — enabling EDR output", category: .videoPlayer)
+        videoView.applyHDRPreference(true)
+        window?.setExtendedDynamicRangeEnabled(true)
     }
 
     private func setupPlayerReadyObserver() {
@@ -345,6 +378,15 @@ final class WallpaperVideoPlayer {
 
     func seek(to time: Double) {
         player?.seek(to: CMTime(seconds: time, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+    }
+
+    /// Frame-accurate seek for playlist boundaries / lock-screen mirroring
+    /// where the default `seek(to:)` tolerances would drift the transition by
+    /// up to ~1 second on long-GOP H.264.
+    func seekExact(seconds: TimeInterval) async {
+        guard let player else { return }
+        let target = CMTime(seconds: seconds, preferredTimescale: 600)
+        await player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero)
     }
 
     func setPlaybackSpeed(_ speed: Double) {
@@ -503,13 +545,23 @@ final class WallpaperVideoPlayer {
                 try Task.checkCancellation()
 
                 let naturalSize = try await videoTrack.load(.naturalSize)
+                let transform = try await videoTrack.load(.preferredTransform)
 
                 try Task.checkCancellation()
 
                 let targetFPS = framesPerSecond
                 let duration = try await asset.load(.duration)
 
-                let layerInstrConfig = AVVideoCompositionLayerInstruction.Configuration(assetTrack: videoTrack)
+                // Apply the asset's `preferredTransform` to the layer instruction
+                // so portrait video (e.g. iPhone vertical recordings) renders
+                // upright. The composition `renderSize` must follow the rotated
+                // bounds — using `naturalSize` directly leaves portrait video
+                // letterboxed inside a landscape canvas.
+                let displayed = naturalSize.applying(transform)
+                let renderSize = CGSize(width: abs(displayed.width), height: abs(displayed.height))
+
+                var layerInstrConfig = AVVideoCompositionLayerInstruction.Configuration(assetTrack: videoTrack)
+                layerInstrConfig.setTransform(transform, at: .zero)
 
                 var instrConfig = AVVideoCompositionInstruction.Configuration()
                 instrConfig.timeRange = CMTimeRange(start: .zero, duration: duration)
@@ -517,7 +569,7 @@ final class WallpaperVideoPlayer {
 
                 var compositionConfig = AVVideoComposition.Configuration()
                 compositionConfig.frameDuration = CMTime(value: 1, timescale: CMTimeScale(targetFPS))
-                compositionConfig.renderSize = naturalSize
+                compositionConfig.renderSize = renderSize
                 compositionConfig.instructions = [AVVideoCompositionInstruction(configuration: instrConfig)]
                 compositionConfig.sourceTrackIDForFrameTiming = videoTrack.trackID
 

--- a/LiveWallpaper/Views/ScreenDetail/CommonPlaybackInspector.swift
+++ b/LiveWallpaper/Views/ScreenDetail/CommonPlaybackInspector.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+
+/// Shared playback / privacy controls that sit above the type-specific
+/// inspector panel (video / HTML / shader / scene). The component is the
+/// resolution of plan U-L1: keep "Mute" / "Frame Rate" / "Sync to Lock Screen"
+/// / "Ephemeral Storage" / "Block Trackers" in a positionally stable spot
+/// regardless of `wallpaperType`, so users don't hunt for the same toggle
+/// after a content-type switch.
+///
+/// Bindings flow back to the parent (`ScreenDetailView`) for in-memory state,
+/// and changes are committed to `ScreenManager` here so persistence happens
+/// at the source of the user gesture instead of leaking through every parent
+/// `onChange`.
+struct CommonPlaybackInspector: View {
+    var screen: Screen
+    var wallpaperType: WallpaperType
+
+    @Environment(ScreenManager.self) private var screenManager
+
+    @Binding var muted: Bool
+    @Binding var frameRateLimit: FrameRateLimit
+    @Binding var syncToLockScreen: Bool
+    /// Optional binding present only when `wallpaperType == .html`. Drives
+    /// the HTML-specific extras (`useEphemeralStorage`, `blockTrackers`)
+    /// AND the audio path so HTML's `WKWebView` actually mutes its media
+    /// elements — `AVPlayer.muted` is a no-op for HTML wallpapers.
+    var htmlConfig: Binding<HTMLConfig>?
+
+    @AppStorage("Inspector.PlaybackExpanded") private var isPlaybackExpanded = true
+    @State private var lockScreenExtracted = false
+
+    var body: some View {
+        GroupBox {
+            CollapsibleSection(
+                title: "Playback & Privacy",
+                systemImage: "play.circle",
+                isExpanded: $isPlaybackExpanded
+            ) {
+                VStack(spacing: 8) {
+                    audioRow
+                    if showsFrameRateRow {
+                        Divider()
+                        frameRateRow
+                    }
+                    if showsSyncToLockScreenRow {
+                        Divider()
+                        syncToLockScreenRow
+                    }
+                    if let htmlConfig {
+                        Divider()
+                        ephemeralStorageRow(htmlConfig)
+                        Divider()
+                        trackerBlockingRow(htmlConfig)
+                    }
+                }
+            }
+        }
+        .groupBoxStyle(ContainerGroupBoxStyle())
+    }
+
+    // MARK: - Row availability
+
+    private var showsFrameRateRow: Bool {
+        switch wallpaperType {
+        case .video, .metalShader, .scene: return true
+        case .html: return false
+        }
+    }
+
+    private var showsSyncToLockScreenRow: Bool {
+        wallpaperType == .video
+    }
+
+    // MARK: - Rows
+
+    private var audioRow: some View {
+        let mutedBinding = audioMutedBinding
+        let isMuted = mutedBinding.wrappedValue
+        return SettingRow(
+            icon: isMuted ? "speaker.slash" : "speaker.wave.2",
+            iconColor: isMuted ? .secondary : .blue,
+            title: "Audio",
+            subtitle: isMuted ? "Muted (default)" : "Routed through system output"
+        ) {
+            Toggle("", isOn: Binding(
+                get: { !mutedBinding.wrappedValue },
+                set: { mutedBinding.wrappedValue = !$0 }
+            ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .accessibilityLabel("Audio")
+                .accessibilityHint("When off, audio tracks are disabled entirely so macOS does not engage the audio engine")
+        }
+    }
+
+    private var frameRateRow: some View {
+        SettingRow(
+            icon: "gauge.with.dots.needle.bottom.50percent",
+            iconColor: .blue,
+            title: "Frame Rate"
+        ) {
+            Picker("", selection: $frameRateLimit) {
+                ForEach(FrameRateLimit.allCases) { limit in
+                    Text(limit.description).tag(limit)
+                }
+            }
+            .labelsHidden()
+            .frame(width: 110)
+            .onChange(of: frameRateLimit) { _, newValue in
+                screenManager.updateFrameRateLimit(newValue, for: screen)
+            }
+            .accessibilityLabel("Frame rate limit")
+            .accessibilityValue(frameRateLimit.description)
+        }
+    }
+
+    private var syncToLockScreenRow: some View {
+        SettingRow(icon: "photo.on.rectangle", iconColor: .blue, title: "Desktop Picture") {
+            HStack(spacing: 6) {
+                if lockScreenExtracted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .transition(.scale.combined(with: .opacity))
+                }
+                Toggle("", isOn: $syncToLockScreen)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .onChange(of: syncToLockScreen) { _, newValue in
+                        screenManager.updateSetAsDesktopPicture(newValue, for: screen)
+                        guard newValue else { return }
+                        screenManager.extractLockScreenFrame(for: screen)
+                        withAnimation(.snappy(duration: 0.25)) { lockScreenExtracted = true }
+                        Task {
+                            try? await Task.sleep(for: .seconds(2))
+                            withAnimation(.snappy(duration: 0.25)) { lockScreenExtracted = false }
+                        }
+                    }
+                    .accessibilityLabel("Set current frame as desktop picture")
+                    .accessibilityHint("Captures the currently visible video frame and uses it as the macOS desktop picture")
+                    .help("Apply the current video frame as the desktop picture")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func ephemeralStorageRow(_ htmlConfig: Binding<HTMLConfig>) -> some View {
+        SettingRow(
+            icon: "archivebox",
+            iconColor: .purple,
+            title: "Clear Data on Exit",
+            subtitle: htmlConfig.wrappedValue.useEphemeralStorage
+                ? "Browsing data is cleared on each session"
+                : "Browsing data is saved across sessions"
+        ) {
+            Toggle("", isOn: htmlConfigBinding(htmlConfig, keyPath: \.useEphemeralStorage))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .accessibilityLabel("Ephemeral browsing data")
+                .accessibilityHint("When on, the wallpaper's WKWebView starts fresh each session — cookies, localStorage, and cache are not persisted")
+        }
+    }
+
+    @ViewBuilder
+    private func trackerBlockingRow(_ htmlConfig: Binding<HTMLConfig>) -> some View {
+        SettingRow(
+            icon: "shield",
+            iconColor: .red,
+            title: "Block Trackers"
+        ) {
+            Toggle("", isOn: htmlConfigBinding(htmlConfig, keyPath: \.blockTrackers))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .accessibilityLabel("Block trackers")
+                .accessibilityHint("Filters analytics and ad scripts before they reach the wallpaper renderer")
+        }
+    }
+
+    // MARK: - Bindings
+
+    /// Routes the audio toggle to the correct backing store: video sessions
+    /// use `AVPlayer.muted` via `ScreenManager.updateMuted`, HTML sessions
+    /// flip `HTMLConfig.muteAudio` so the WKWebView's media elements mute.
+    /// Without this split the HTML mute toggle was a visual no-op.
+    private var audioMutedBinding: Binding<Bool> {
+        if let htmlConfig {
+            return htmlConfigBinding(htmlConfig, keyPath: \.muteAudio)
+        }
+        return Binding(
+            get: { muted },
+            set: { newValue in
+                guard muted != newValue else { return }
+                muted = newValue
+                screenManager.updateMuted(newValue, for: screen)
+            }
+        )
+    }
+
+    /// Threads `HTMLConfig` keypath writes back through the parent `Binding`
+    /// AND `ScreenManager.updateHTMLConfig` so persistence and runtime apply
+    /// happen in one place. Identity-noop sets are filtered to avoid extra
+    /// session rebuilds.
+    private func htmlConfigBinding<Value: Equatable>(
+        _ htmlConfig: Binding<HTMLConfig>,
+        keyPath: WritableKeyPath<HTMLConfig, Value>
+    ) -> Binding<Value> {
+        Binding(
+            get: { htmlConfig.wrappedValue[keyPath: keyPath] },
+            set: { newValue in
+                guard htmlConfig.wrappedValue[keyPath: keyPath] != newValue else { return }
+                var next = htmlConfig.wrappedValue
+                next[keyPath: keyPath] = newValue
+                htmlConfig.wrappedValue = next
+                screenManager.updateHTMLConfig(next, for: screen)
+            }
+        )
+    }
+}

--- a/LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift
@@ -259,43 +259,9 @@ struct HTMLSourceSection: View {
                 .font(.caption2)
                 .foregroundStyle(.secondary)
 
-            HStack {
-                Label("Mute Audio", systemImage: "speaker.slash")
-                Spacer()
-                Toggle("", isOn: Binding(
-                    get: { config.muteAudio },
-                    set: { newValue in
-                        config.muteAudio = newValue
-                        commitConfig()
-                    }
-                ))
-                .labelsHidden()
-                .accessibilityLabel("Mute Audio")
-                .toggleStyle(.switch)
-                .controlSize(.small)
-            }
-            Text("Silences any <audio> or <video> elements without pausing the visuals.")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-
-            HStack {
-                Label("Block Trackers", systemImage: "shield")
-                Spacer()
-                Toggle("", isOn: Binding(
-                    get: { config.blockTrackers },
-                    set: { newValue in
-                        config.blockTrackers = newValue
-                        commitConfig()
-                    }
-                ))
-                .labelsHidden()
-                .accessibilityLabel("Block Trackers")
-                .toggleStyle(.switch)
-                .controlSize(.small)
-            }
-            Text("Filters common analytics and ad scripts from URL wallpapers.")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+            // "Mute Audio" / "Block Trackers" moved to CommonPlaybackInspector
+            // (Playback & Privacy section) so the controls share a stable
+            // physical position with the equivalent video toggles.
 
             HStack {
                 Label("Physical-pixel layout", systemImage: "rectangle.split.2x1")

--- a/LiveWallpaper/Views/ScreenDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetailView.swift
@@ -134,7 +134,6 @@ struct ScreenDetailView: View {
     @AppStorage("Inspector.ScheduleExpanded") private var isScheduleExpanded = false
     @AppStorage("Inspector.EnvironmentExpanded") private var isEnvironmentExpanded = true
     @AppStorage("Inspector.ColorExpanded") private var isColorExpanded = false
-    @AppStorage("Inspector.DisplayExpanded") private var isDisplayExpanded = false
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -319,7 +318,7 @@ struct ScreenDetailView: View {
 
                 Divider()
 
-                videoInspectorPanel
+                inspectorPanel
             }
             .transaction(value: selectedWallpaperType) { $0.animation = nil }
         }
@@ -369,11 +368,21 @@ struct ScreenDetailView: View {
     }
 
     @ViewBuilder
-    private var videoInspectorPanel: some View {
-        if selectedWallpaperType == .video {
+    private var inspectorPanel: some View {
+        if selectedWallpaperType == .video || selectedWallpaperType == .html {
             ScrollView {
                 GlassEffectContainer(spacing: 16) {
                     VStack(spacing: 16) {
+                        CommonPlaybackInspector(
+                            screen: screen,
+                            wallpaperType: selectedWallpaperType,
+                            muted: $videoMuted,
+                            frameRateLimit: $selectedFrameRateLimit,
+                            syncToLockScreen: $setAsLockScreen,
+                            htmlConfig: selectedWallpaperType == .html ? $htmlConfig : nil
+                        )
+
+                        if selectedWallpaperType == .video {
                         HStack(spacing: 0) {
                             ForEach(WallpaperMode.allCases) { mode in
                                 Button {
@@ -513,82 +522,8 @@ struct ScreenDetailView: View {
                                 }
                             }
                             .groupBoxStyle(ContainerGroupBoxStyle())
-
-                            GroupBox {
-                                CollapsibleSection(
-                                    title: "Display",
-                                    systemImage: "display.and.arrow.down",
-                                    isExpanded: $isDisplayExpanded
-                                ) {
-                                    VStack(spacing: 8) {
-                                        SettingRow(icon: "gauge.with.dots.needle.bottom.50percent", iconColor: .blue, title: "Frame Rate") {
-                                            Picker("", selection: $selectedFrameRateLimit) {
-                                                ForEach(FrameRateLimit.allCases) { limit in
-                                                    Text(limit.description).tag(limit)
-                                                }
-                                            }
-                                            .labelsHidden()
-                                            .frame(width: 110)
-                                            .onChange(of: selectedFrameRateLimit) { _, newValue in
-                                                screenManager.updateFrameRateLimit(newValue, for: screen)
-                                            }
-                                            .accessibilityLabel("Frame rate limit")
-                                            .accessibilityValue(selectedFrameRateLimit.description)
-                                        }
-
-                                        Divider()
-
-                                        SettingRow(
-                                            icon: videoMuted ? "speaker.slash" : "speaker.wave.2",
-                                            iconColor: videoMuted ? .secondary : .blue,
-                                            title: "Audio",
-                                            subtitle: videoMuted
-                                                ? "Muted (default)"
-                                                : "Routed through system output"
-                                        ) {
-                                            Toggle("", isOn: Binding(get: { !videoMuted }, set: { videoMuted = !$0 }))
-                                                .labelsHidden()
-                                                .toggleStyle(.switch)
-                                                .onChange(of: videoMuted) { _, newValue in
-                                                    screenManager.updateMuted(newValue, for: screen)
-                                                }
-                                                .accessibilityLabel("Video audio")
-                                                .accessibilityHint("When off, audio tracks are disabled entirely so macOS does not engage the audio engine")
-                                        }
-
-                                        Divider()
-
-                                        SettingRow(icon: "photo.on.rectangle", iconColor: .blue, title: "Desktop Picture") {
-                                            HStack(spacing: 6) {
-                                                if lockScreenExtracted {
-                                                    Image(systemName: "checkmark.circle.fill")
-                                                        .foregroundStyle(.green)
-                                                        .transition(.scale.combined(with: .opacity))
-                                                }
-                                                Toggle("", isOn: $setAsLockScreen)
-                                                    .labelsHidden()
-                                                    .toggleStyle(.switch)
-                                                    .onChange(of: setAsLockScreen) { _, newValue in
-                                                        screenManager.updateSetAsDesktopPicture(newValue, for: screen)
-                                                        if newValue {
-                                                            screenManager.extractLockScreenFrame(for: screen)
-                                                            withAnimation(.snappy(duration: 0.25)) { lockScreenExtracted = true }
-                                                            Task {
-                                                                try? await Task.sleep(for: .seconds(2))
-                                                                withAnimation(.snappy(duration: 0.25)) { lockScreenExtracted = false }
-                                                            }
-                                                        }
-                                                    }
-                                                    .accessibilityLabel("Set current frame as desktop picture")
-                                                    .accessibilityHint("Captures the currently visible video frame and uses it as the macOS desktop picture")
-                                                    .help("Apply the current video frame as the desktop picture")
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            .groupBoxStyle(ContainerGroupBoxStyle())
-                            }
+                        }
+                    }
                         }
                         .padding(.horizontal, 12)
                         .padding(.vertical, 14)


### PR DESCRIPTION
## Summary

Third slice of `.claude/plan/product-pivot-video-html-mvp.md` — Week 3 P1 closes the four content-completeness gaps the audit flagged for the video and HTML pipelines and unifies their inspector controls.

- **3.1 / M1+M2** — `WallpaperVideoPlayer.setFrameRateLimit` now loads `videoTrack.preferredTransform`, applies it to the layer instruction with `setTransform(_:at: .zero)`, and uses `abs(naturalSize.applying(transform))` for `renderSize`. Portrait video that rendered rotated 90° once the fps cap took over now stays upright. New `seekExact(seconds:)` async helper uses `toleranceBefore: .zero / toleranceAfter: .zero` so playlist boundaries and lock-screen mirror frames hit on the requested frame instead of drifting up to ~1s.
- **3.2 / M3** — `WallpaperVideoPlayer.detectFormatInfoIfNeeded` runs after playback configuration, reads `PlayableVideoLoader.detectFormat(at:)`, and routes `formatInfo.isHDR` to `VideoContainerView.applyHDRPreference(true)` + `VideoWallpaperWindow.setExtendedDynamicRangeEnabled(true)`. The host view sets `AVPlayerLayer.preferredDynamicRange = .high` on macOS 26+ and falls back to the older `wantsExtendedDynamicRangeContent` selector via KVC on macOS 14-25. SDR sources clear the window color space so they don't inherit displayP3.
- **3.3 / M4** — `HTMLConfig` gains `useEphemeralStorage` and `maxRetries` (clamped 0...10 on decode). `HTMLWallpaperView.init(frame:initialEphemeral:)` picks `WKWebsiteDataStore.nonPersistent()` vs `.default()` at WKWebView init time. `AmbientWallpaperSessionBuilder` resolves the effective config (trust + WPE auto-detect) BEFORE creating the view so the right store is locked in. Navigation failures retry through a `Task.sleep(for: 1s, 2s, 4s ...)` backoff up to `maxRetries`; the counter resets on `didFinish` and on every user-driven `loadSource`. Retry tasks are `[weak self]` and cancelled in `cleanup()`.
- **3.4 / U-L1** — New `CommonPlaybackInspector` SwiftUI component hosts Mute / Frame Rate / Desktop Picture (lockscreen) / Clear Data on Exit / Block Trackers in a "Playback & Privacy" disclosure group at the top of the inspector. The inspector is now shown for video AND HTML wallpapers; the audio binding splits at runtime so HTML sessions actually mute via `HTMLConfig.muteAudio` (previously the shared binding was a no-op for HTML). `HTMLSourceSection.togglesGrid` drops its duplicate Mute / Block Trackers rows; the old per-video Display GroupBox is gone.

## Audit + fixes already applied

Each finding from the parallel codex/gemini review is folded into the same PR:

- **codex (backend)** — added `useEphemeralStorage` to `needsScriptRebuild` so user-script cache invalidates with the storage preference; clamped `maxRetries` decode to a sane `0...10` so corrupted prefs cannot drive an unbounded retry loop.
- **codex + gemini (UI/UX)** — HTML mute / ephemeral / blockTrackers toggles now persist via `ScreenManager.updateHTMLConfig` (previously they only mutated SwiftUI state); audio binding split for video vs HTML; HTMLSourceSection duplicates removed; "Ephemeral Storage" relabeled "Clear Data on Exit" with friendlier subtitle copy.

## Commits

- `8b5ffba` fix(video): apply preferredTransform + add seekExact API
- `bfdfe39` feat(video): EDR output for HDR-tagged sources
- `81eca38` feat(html): ephemeral data store + retry-with-backoff
- `df880b5` refactor(ui): extract CommonPlaybackInspector for video & html

## Verification

- `xcodebuild build -scheme LiveWallpaper -configuration Debug` — BUILD SUCCEEDED, zero warnings on top of the existing baseline.
- `xcodebuild test -only-testing:LiveWallpaperTests` — **423 tests / 73 suites passed**.

## Test plan

- [ ] Drop a portrait iPhone video onto a screen → cap frame rate at 30 / 60 fps in the inspector → verify the video stays upright (was rotating 90°).
- [ ] Apply an HDR-tagged video on an XDR display → verify highlights pop instead of being tone-mapped to SDR; switch to an SDR video → verify color stays neutral (no displayP3 cast).
- [ ] Switch wallpaper type from Video → HTML → toggle Mute in the inspector → verify the wallpaper goes silent (previously the toggle was a visual no-op for HTML).
- [ ] Enable "Clear Data on Exit", load a site that sets cookies, restart the app → verify the site loads anonymously.
- [ ] Disable network, point an HTML wallpaper at a remote URL → verify three retry attempts (1s, 2s, 4s backoff) before the runtime error banner appears.
- [ ] Toggle frame rate / lockscreen sync from a video screen → switch to HTML → verify Mute stays in the same row position so muscle memory works.

## Out of scope (Week 4)

`HSplitView` Inspector layout, design tokens, accessibility sweep, lifecycle integration tests, file splits — all stay in `.claude/plan/product-pivot-video-html-mvp.md` for the final slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)