### PR TITLE
feat(week4): protocolize deps + HSplitView Inspector + design tokens + a11y

### DIFF
--- a/LiveWallpaper/Infrastructure/PlayableVideoLoader.swift
+++ b/LiveWallpaper/Infrastructure/PlayableVideoLoader.swift
@@ -2,7 +2,17 @@ import AVFoundation
 import CoreMedia
 import Foundation
 
-enum PlayableVideoLoader {
+struct PlayableVideoLoader: PlayableVideoLoading, Sendable {
+    init() {}
+
+    func validatePlayableVideo(at url: URL) async throws {
+        try await Self.validatePlayableVideo(at: url)
+    }
+
+    func detectFormat(at url: URL) async throws -> VideoFormatInfo {
+        try await Self.detectFormat(at: url)
+    }
+
     static func validatePlayableVideo(at url: URL) async throws {
         let didStartScope = url.startAccessingSecurityScopedResource()
         defer {

--- a/LiveWallpaper/Infrastructure/Protocols/DisplayRegistering.swift
+++ b/LiveWallpaper/Infrastructure/Protocols/DisplayRegistering.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+/// Enumerates connected displays and resolves screen identity for the wallpaper layer.
+@MainActor
+protocol DisplayRegistering: AnyObject {
+    func currentScreens() -> [Screen]
+    func findNSScreen(for screenID: CGDirectDisplayID) -> NSScreen?
+}
+
+extension DisplayRegistry: DisplayRegistering {}

--- a/LiveWallpaper/Infrastructure/Protocols/FullScreenDetecting.swift
+++ b/LiveWallpaper/Infrastructure/Protocols/FullScreenDetecting.swift
@@ -1,0 +1,13 @@
+import CoreGraphics
+import Foundation
+
+/// Reports per-display occlusion by full-screen apps so wallpapers can suspend.
+@MainActor
+protocol FullScreenDetecting: AnyObject {
+    var hiddenScreens: [CGDirectDisplayID: Bool] { get }
+    func isDesktopHidden(for screenID: CGDirectDisplayID) -> Bool
+    func checkNow()
+    func setFallbackPollingEnabled(_ enabled: Bool)
+}
+
+extension FullScreenDetector: FullScreenDetecting {}

--- a/LiveWallpaper/Infrastructure/Protocols/PlayableVideoLoading.swift
+++ b/LiveWallpaper/Infrastructure/Protocols/PlayableVideoLoading.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Validates and probes video assets prior to handing them to the player.
+protocol PlayableVideoLoading: Sendable {
+    func validatePlayableVideo(at url: URL) async throws
+    func detectFormat(at url: URL) async throws -> VideoFormatInfo
+}

--- a/LiveWallpaper/Infrastructure/Protocols/PowerMonitoring.swift
+++ b/LiveWallpaper/Infrastructure/Protocols/PowerMonitoring.swift
@@ -1,0 +1,12 @@
+import Combine
+import Foundation
+
+/// Reports the system's power source state so policy can throttle wallpapers on battery.
+@MainActor
+protocol PowerMonitoring: AnyObject {
+    var powerSourcePublisher: AnyPublisher<PowerMonitor.PowerSource, Never> { get }
+    var currentPowerSource: PowerMonitor.PowerSource { get }
+    func refreshPowerStatus()
+}
+
+extension PowerMonitor: PowerMonitoring {}

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -42,6 +42,18 @@ struct WallpaperSessionSummaryCache: Equatable {
 struct ScreenManagerStartupOptions: Equatable {
     var restoreSavedWallpapers: Bool = true
     var startAutomation: Bool = true
+    var powerMonitor: (any PowerMonitoring)? = nil
+    var fullScreenDetector: (any FullScreenDetecting)? = nil
+    var playableVideoLoader: (any PlayableVideoLoading)? = nil
+    var displayRegistry: (any DisplayRegistering)? = nil
+
+    // Reference-typed protocol fields are not synthesizable for Equatable.
+    // Compare only the value-typed boolean configuration; injected dependencies
+    // are test-time concerns and equality is irrelevant for them.
+    static func == (lhs: ScreenManagerStartupOptions, rhs: ScreenManagerStartupOptions) -> Bool {
+        lhs.restoreSavedWallpapers == rhs.restoreSavedWallpapers
+            && lhs.startAutomation == rhs.startAutomation
+    }
 }
 
 @MainActor @Observable
@@ -56,16 +68,17 @@ final class ScreenManager {
     private(set) var lastWPEImportErrors: [CGDirectDisplayID: AppError] = [:]
 
     @ObservationIgnored private var cleanupTasks: Set<AnyCancellable> = []
-    @ObservationIgnored private let displayRegistry = DisplayRegistry()
+    @ObservationIgnored private let displayRegistry: any DisplayRegistering
     @ObservationIgnored private let configurationStore = WallpaperConfigurationStore()
     @ObservationIgnored private let ambientSessionBuilder = AmbientWallpaperSessionBuilder()
     @ObservationIgnored private let wpeImportService = WallpaperEngineImportService()
     @ObservationIgnored private let wpeCachedContentResolver = WPECachedContentResolver()
     @ObservationIgnored private let automationCoordinator = WallpaperAutomationCoordinator()
     @ObservationIgnored private let powerPolicy = PowerPolicyController()
-    @ObservationIgnored private let powerMonitor: PowerMonitor = .shared
+    @ObservationIgnored private let powerMonitor: any PowerMonitoring
     @ObservationIgnored private let playbackStateSubject = CurrentValueSubject<Bool, Never>(false)
-    @ObservationIgnored private let fullScreenDetector = FullScreenDetector()
+    @ObservationIgnored private let fullScreenDetector: any FullScreenDetecting
+    @ObservationIgnored private let playableVideoLoader: any PlayableVideoLoading
     @ObservationIgnored private let videoEffectsApplier = VideoEffectsApplicationService()
     @ObservationIgnored private let restoresSavedWallpapersOnScreenRefresh: Bool
     @ObservationIgnored private let exclusiveRenderingCoordinator = ExclusiveRenderingCoordinator()
@@ -81,6 +94,10 @@ final class ScreenManager {
     }
     // MARK: - Initialization
     init(startupOptions: ScreenManagerStartupOptions = ScreenManagerStartupOptions()) {
+        displayRegistry = startupOptions.displayRegistry ?? DisplayRegistry()
+        powerMonitor = startupOptions.powerMonitor ?? PowerMonitor.shared
+        fullScreenDetector = startupOptions.fullScreenDetector ?? FullScreenDetector()
+        playableVideoLoader = startupOptions.playableVideoLoader ?? PlayableVideoLoader()
         restoresSavedWallpapersOnScreenRefresh = startupOptions.restoreSavedWallpapers
 
         Logger.notice("ScreenManager initializing", category: .screenManager)
@@ -450,9 +467,10 @@ final class ScreenManager {
 
         let screenID = screen.id
         let generation = bumpTransition(for: screenID)
+        let videoLoader = playableVideoLoader
         Task {
             do {
-                try await PlayableVideoLoader.validatePlayableVideo(at: url)
+                try await videoLoader.validatePlayableVideo(at: url)
                 await MainActor.run { [weak self] in
                     guard let self,
                           self.isCurrentTransition(generation, for: screenID),
@@ -1867,10 +1885,11 @@ final class ScreenManager {
 
         let screenID = screen.id
         let generation = bumpTransition(for: screenID)
+        let videoLoader = playableVideoLoader
 
         Task { [weak self] in
             do {
-                try await PlayableVideoLoader.validatePlayableVideo(at: url)
+                try await videoLoader.validatePlayableVideo(at: url)
                 await MainActor.run { [weak self] in
                     guard let self,
                           self.isCurrentTransition(generation, for: screenID),
@@ -1946,10 +1965,11 @@ final class ScreenManager {
 
         let screenID = screen.id
         let generation = bumpTransition(for: screenID)
+        let videoLoader = playableVideoLoader
 
         Task { [weak self] in
             do {
-                try await PlayableVideoLoader.validatePlayableVideo(at: url)
+                try await videoLoader.validatePlayableVideo(at: url)
                 await MainActor.run { [weak self] in
                     guard let self,
                           self.isCurrentTransition(generation, for: screenID),

--- a/LiveWallpaper/Views/ContentView.swift
+++ b/LiveWallpaper/Views/ContentView.swift
@@ -36,6 +36,8 @@ struct ContentView: View {
                             Image(systemName: "gearshape")
                         }
                         .help("Preferences")
+                        .accessibilityLabel("Preferences")
+                        .accessibilityHint("Open application preferences")
                     }
                 }
         }
@@ -164,6 +166,8 @@ struct Sidebar: View {
                 }
                 .buttonStyle(.plain)
                 .help("Reload all wallpapers")
+                .accessibilityLabel("Reload all wallpapers")
+                .accessibilityHint("Reapplies the active wallpaper on every display")
             }) {
                 if screenManager.screens.isEmpty {
                     HStack {

--- a/LiveWallpaper/Views/Onboarding/OnboardingStepDone.swift
+++ b/LiveWallpaper/Views/Onboarding/OnboardingStepDone.swift
@@ -69,6 +69,7 @@ struct OnboardingStepDone: View {
             }
             .buttonStyle(GlassCapsuleButtonStyle(fontSize: 14, horizontalPadding: 24, verticalPadding: 10))
             .keyboardShortcut(.defaultAction)
+            .accessibilityHint("Close onboarding and open LiveWallpaper")
 
             Spacer().frame(height: 28)
         }

--- a/LiveWallpaper/Views/ScreenDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetailView.swift
@@ -250,7 +250,7 @@ struct ScreenDetailView: View {
                                     HStack(spacing: 8) {
                                         ForEach(VideoFitMode.allCases) { mode in
                                             FitModeButton(mode: mode, isSelected: selectedFitMode == mode) {
-                                                withAnimation(.snappy(duration: 0.2)) {
+                                                withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.2))) {
                                                     selectedFitMode = mode
                                                 }
                                                 screenManager.updateFitMode(mode, for: screen)
@@ -384,7 +384,7 @@ struct ScreenDetailView: View {
                         HStack(spacing: 0) {
                             ForEach(WallpaperMode.allCases) { mode in
                                 Button {
-                                    withAnimation(.snappy(duration: 0.18)) {
+                                    withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.18))) {
                                             selectedWallpaperMode = mode
                                         }
                                         screenManager.updateWallpaperMode(mode, for: screen)
@@ -729,7 +729,7 @@ struct ScreenDetailView: View {
     }
 
     private func handleSelectedFile(url: URL) {
-        withAnimation(.smooth(duration: 0.2)) { isLoading = true }
+        withAnimation(DesignTokens.motion(reduceMotion, .smooth(duration: 0.2))) { isLoading = true }
         cleanupPreviewPlayer()
 
         if let bookmarkData = ResourceUtilities.createBookmark(for: url) {
@@ -743,7 +743,7 @@ struct ScreenDetailView: View {
 
         Task {
             try? await Task.sleep(for: .milliseconds(500))
-            withAnimation(.smooth(duration: 0.2)) { isLoading = false }
+            withAnimation(DesignTokens.motion(reduceMotion, .smooth(duration: 0.2))) { isLoading = false }
         }
     }
 

--- a/LiveWallpaper/Views/ScreenDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetailView.swift
@@ -222,7 +222,7 @@ struct ScreenDetailView: View {
 
             Divider()
 
-            HStack(spacing: 0) {
+            HSplitView {
                 ZStack {
                     Color(NSColor.underPageBackgroundColor)
 
@@ -310,13 +310,11 @@ struct ScreenDetailView: View {
                         WPESceneSection(screen: screen)
                     }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(minWidth: DesignTokens.PreviewArea.minWidth, maxWidth: .infinity, maxHeight: .infinity)
                 .overlay {
                     dragHintOverlay
                         .animation(.smooth(duration: 0.2), value: isDraggingOver)
                 }
-
-                Divider()
 
                 inspectorPanel
             }
@@ -528,10 +526,14 @@ struct ScreenDetailView: View {
                         .padding(.horizontal, 12)
                         .padding(.vertical, 14)
                     }
-                    .frame(width: 320)
-                    .fixedSize(horizontal: true, vertical: false)
+                    .frame(
+                        minWidth: DesignTokens.Inspector.minWidth,
+                        idealWidth: DesignTokens.Inspector.idealWidth,
+                        maxWidth: DesignTokens.Inspector.maxWidth
+                    )
                     .background(Color(NSColor.windowBackgroundColor))
                     .clipped()
+                    .accessibilityLabel("Wallpaper Properties")
         }
     }
 

--- a/LiveWallpaper/Views/Styles/DesignTokens.swift
+++ b/LiveWallpaper/Views/Styles/DesignTokens.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Centralised design tokens for spacing, corners, and visual metrics.
+/// Use these instead of inline magic numbers when building new UI.
+/// Existing call sites may migrate incrementally.
+enum DesignTokens {
+    enum Spacing {
+        static let xxs: CGFloat = 2
+        static let xs: CGFloat = 4
+        static let sm: CGFloat = 8
+        static let md: CGFloat = 12
+        static let lg: CGFloat = 16
+        static let xl: CGFloat = 24
+        static let xxl: CGFloat = 32
+    }
+
+    enum Corner {
+        static let sm: CGFloat = 6
+        static let md: CGFloat = 10
+        static let lg: CGFloat = 14
+        static let xl: CGFloat = 18
+    }
+
+    enum Inspector {
+        static let minWidth: CGFloat = 280
+        static let idealWidth: CGFloat = 320
+        static let maxWidth: CGFloat = 480
+        static let horizontalPadding: CGFloat = Spacing.md
+        static let verticalPadding: CGFloat = Spacing.lg
+    }
+
+    enum PreviewArea {
+        static let minWidth: CGFloat = 480
+    }
+
+    enum Card {
+        static let strokeOpacity: Double = 0.06
+        static let strokeWidth: CGFloat = 0.5
+        static let shadowRadius: CGFloat = 12
+        static let shadowOpacity: Double = 0.18
+        static let shadowYOffset: CGFloat = 4
+    }
+}

--- a/LiveWallpaper/Views/Styles/DesignTokens.swift
+++ b/LiveWallpaper/Views/Styles/DesignTokens.swift
@@ -40,4 +40,10 @@ enum DesignTokens {
         static let shadowOpacity: Double = 0.18
         static let shadowYOffset: CGFloat = 4
     }
+
+    /// Returns the supplied animation when motion is allowed, otherwise nil so
+    /// the change applies instantly. Pairs with `@Environment(\.accessibilityReduceMotion)`.
+    static func motion(_ reduceMotion: Bool, _ animation: Animation) -> Animation? {
+        reduceMotion ? nil : animation
+    }
 }

--- a/LiveWallpaperTests/Doubles/FakeDisplayRegistry.swift
+++ b/LiveWallpaperTests/Doubles/FakeDisplayRegistry.swift
@@ -1,0 +1,32 @@
+import AppKit
+@testable import LiveWallpaper
+
+@MainActor
+final class FakeDisplayRegistry: DisplayRegistering {
+    var screens: [Screen]
+    var nsScreensByID: [CGDirectDisplayID: NSScreen]
+
+    private(set) var currentScreensCallCount = 0
+    private(set) var findNSScreenQueries: [CGDirectDisplayID] = []
+
+    init(
+        screens: [Screen] = [],
+        nsScreensByID: [CGDirectDisplayID: NSScreen] = [:]
+    ) {
+        self.screens = screens
+        self.nsScreensByID = nsScreensByID
+    }
+
+    func currentScreens() -> [Screen] {
+        currentScreensCallCount += 1
+        return screens
+    }
+
+    func findNSScreen(for screenID: CGDirectDisplayID) -> NSScreen? {
+        findNSScreenQueries.append(screenID)
+        if let nsScreen = nsScreensByID[screenID] {
+            return nsScreen
+        }
+        return screens.first(where: { $0.id == screenID })?.nsScreen
+    }
+}

--- a/LiveWallpaperTests/Doubles/FakeFullScreenDetector.swift
+++ b/LiveWallpaperTests/Doubles/FakeFullScreenDetector.swift
@@ -1,0 +1,37 @@
+import CoreGraphics
+import Foundation
+@testable import LiveWallpaper
+
+@MainActor
+final class FakeFullScreenDetector: FullScreenDetecting {
+    private var storedHiddenScreens: [CGDirectDisplayID: Bool]
+
+    private(set) var checkNowCallCount = 0
+    private(set) var setFallbackPollingEnabledValues: [Bool] = []
+    private(set) var isDesktopHiddenQueries: [CGDirectDisplayID] = []
+
+    init(hiddenScreens: [CGDirectDisplayID: Bool] = [:]) {
+        storedHiddenScreens = hiddenScreens
+    }
+
+    var hiddenScreens: [CGDirectDisplayID: Bool] {
+        storedHiddenScreens
+    }
+
+    func setHiddenScreens(_ hiddenScreens: [CGDirectDisplayID: Bool]) {
+        storedHiddenScreens = hiddenScreens
+    }
+
+    func isDesktopHidden(for screenID: CGDirectDisplayID) -> Bool {
+        isDesktopHiddenQueries.append(screenID)
+        return storedHiddenScreens[screenID] ?? false
+    }
+
+    func checkNow() {
+        checkNowCallCount += 1
+    }
+
+    func setFallbackPollingEnabled(_ enabled: Bool) {
+        setFallbackPollingEnabledValues.append(enabled)
+    }
+}

--- a/LiveWallpaperTests/Doubles/FakePlayableVideoLoader.swift
+++ b/LiveWallpaperTests/Doubles/FakePlayableVideoLoader.swift
@@ -1,0 +1,40 @@
+import Foundation
+@testable import LiveWallpaper
+
+enum FakePlayableVideoLoaderError: Error, Equatable, Sendable {
+    case validationFailed
+    case formatFailed
+}
+
+actor FakePlayableVideoLoader: PlayableVideoLoading {
+    private(set) var validatedURLs: [URL] = []
+    private(set) var detectedURLs: [URL] = []
+    private let validationError: FakePlayableVideoLoaderError?
+    private let formatError: FakePlayableVideoLoaderError?
+    private let formatInfo: VideoFormatInfo
+
+    init(
+        validationError: FakePlayableVideoLoaderError? = nil,
+        formatError: FakePlayableVideoLoaderError? = nil,
+        formatInfo: VideoFormatInfo = VideoFormatInfo()
+    ) {
+        self.validationError = validationError
+        self.formatError = formatError
+        self.formatInfo = formatInfo
+    }
+
+    func validatePlayableVideo(at url: URL) async throws {
+        validatedURLs.append(url)
+        if let validationError {
+            throw validationError
+        }
+    }
+
+    func detectFormat(at url: URL) async throws -> VideoFormatInfo {
+        detectedURLs.append(url)
+        if let formatError {
+            throw formatError
+        }
+        return formatInfo
+    }
+}

--- a/LiveWallpaperTests/Doubles/FakePowerMonitor.swift
+++ b/LiveWallpaperTests/Doubles/FakePowerMonitor.swift
@@ -1,0 +1,34 @@
+import Combine
+import Foundation
+@testable import LiveWallpaper
+
+@MainActor
+final class FakePowerMonitor: PowerMonitoring {
+    private let subject: CurrentValueSubject<PowerMonitor.PowerSource, Never>
+
+    private(set) var powerSourcePublisherReadCount = 0
+    private(set) var currentPowerSourceReadCount = 0
+    private(set) var refreshPowerStatusCallCount = 0
+
+    init(initialPowerSource: PowerMonitor.PowerSource = .external) {
+        subject = CurrentValueSubject(initialPowerSource)
+    }
+
+    var powerSourcePublisher: AnyPublisher<PowerMonitor.PowerSource, Never> {
+        powerSourcePublisherReadCount += 1
+        return subject.eraseToAnyPublisher()
+    }
+
+    var currentPowerSource: PowerMonitor.PowerSource {
+        currentPowerSourceReadCount += 1
+        return subject.value
+    }
+
+    func send(_ powerSource: PowerMonitor.PowerSource) {
+        subject.send(powerSource)
+    }
+
+    func refreshPowerStatus() {
+        refreshPowerStatusCallCount += 1
+    }
+}

--- a/LiveWallpaperTests/ProtocolizedDependenciesTests.swift
+++ b/LiveWallpaperTests/ProtocolizedDependenciesTests.swift
@@ -1,0 +1,210 @@
+import AppKit
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+@Suite("Protocolized ScreenManager dependencies")
+@MainActor
+struct ProtocolizedDependenciesTests {
+
+    @Test("Initial refresh uses injected DisplayRegistering")
+    func initialRefreshUsesInjectedDisplayRegistry() {
+        guard let screen = Self.makeScreen() else {
+            Issue.record("No NSScreen available for dependency injection test")
+            return
+        }
+        let displayRegistry = FakeDisplayRegistry(screens: [screen])
+
+        let manager = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: FakePlayableVideoLoader(),
+            displayRegistry: displayRegistry
+        ))
+
+        #expect(manager.screens.map(\.id) == [screen.id])
+        #expect(displayRegistry.currentScreensCallCount >= 1)
+    }
+
+    @Test("Explicit refresh reuses injected DisplayRegistering")
+    func explicitRefreshReusesInjectedDisplayRegistry() {
+        guard let screen = Self.makeScreen() else {
+            Issue.record("No NSScreen available for dependency injection test")
+            return
+        }
+        let displayRegistry = FakeDisplayRegistry(screens: [screen])
+        let manager = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: FakePlayableVideoLoader(),
+            displayRegistry: displayRegistry
+        ))
+
+        let initialCount = displayRegistry.currentScreensCallCount
+        manager.refreshScreens()
+
+        #expect(displayRegistry.currentScreensCallCount > initialCount)
+        #expect(manager.screens.map(\.id) == [screen.id])
+    }
+
+    @Test("Startup full-screen pass uses injected FullScreenDetecting")
+    func startupFullScreenPassUsesInjectedDetector() {
+        guard let screen = Self.makeScreen() else {
+            Issue.record("No NSScreen available for dependency injection test")
+            return
+        }
+        let fullScreenDetector = FakeFullScreenDetector(hiddenScreens: [screen.id: true])
+
+        _ = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: fullScreenDetector,
+            playableVideoLoader: FakePlayableVideoLoader(),
+            displayRegistry: FakeDisplayRegistry(screens: [screen])
+        ))
+
+        #expect(fullScreenDetector.checkNowCallCount >= 1)
+    }
+
+    @Test("Power monitoring setup subscribes injected PowerMonitoring")
+    func powerMonitoringSetupSubscribesInjectedMonitor() {
+        let powerMonitor = FakePowerMonitor(initialPowerSource: .battery(level: 0.42))
+        _ = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: powerMonitor,
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: FakePlayableVideoLoader(),
+            displayRegistry: FakeDisplayRegistry()
+        ))
+
+        #expect(powerMonitor.powerSourcePublisherReadCount >= 1)
+        #expect(powerMonitor.currentPowerSourceReadCount >= 1)
+    }
+
+    @Test("Video selection validates through injected PlayableVideoLoading")
+    func videoSelectionUsesInjectedPlayableVideoLoader() async throws {
+        guard let screen = Self.makeScreen() else {
+            Issue.record("No NSScreen available for dependency injection test")
+            return
+        }
+        let loader = FakePlayableVideoLoader(validationError: .validationFailed)
+        let displayRegistry = FakeDisplayRegistry(screens: [screen])
+        let manager = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: loader,
+            displayRegistry: displayRegistry
+        ))
+        guard let liveScreen = manager.screens.first else {
+            Issue.record("Injected display registry did not produce a screen")
+            return
+        }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProtocolizedDependencies-\(UUID().uuidString).mov")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("not actually decoded by the fake".utf8).write(to: url)
+
+        manager.setVideo(url: url, bookmarkData: Data([0x01, 0x02]), for: liveScreen)
+
+        try await Self.waitUntil(timeout: .seconds(2)) {
+            await loader.validatedURLs.count >= 1
+        }
+        let urls = await loader.validatedURLs
+        #expect(urls.contains(url))
+    }
+
+    @Test("Validation failure does not promote the rejected bookmark to active config")
+    func videoSelectionHandlesValidationFailure() async throws {
+        guard let screen = Self.makeScreen() else {
+            Issue.record("No NSScreen available for dependency injection test")
+            return
+        }
+        let loader = FakePlayableVideoLoader(validationError: .validationFailed)
+        let manager = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: loader,
+            displayRegistry: FakeDisplayRegistry(screens: [screen])
+        ))
+        guard let liveScreen = manager.screens.first else {
+            Issue.record("Injected display registry did not produce a screen")
+            return
+        }
+
+        // Snapshot whatever active bookmark the persistent config store happens to
+        // carry on the host machine — the test must not rely on UserDefaults state.
+        let initialBookmark = Self.activeVideoBookmark(manager.getConfiguration(for: liveScreen))
+        let rejectedBookmark = Data([0xDE, 0xAD, 0xBE, 0xEF])
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ProtocolizedDependencies-Failure-\(UUID().uuidString).mov")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data("dummy data".utf8).write(to: url)
+
+        manager.setVideo(url: url, bookmarkData: rejectedBookmark, for: liveScreen)
+
+        try await Self.waitUntil(timeout: .seconds(2)) {
+            await loader.validatedURLs.count >= 1
+        }
+        // Allow the catch-branch MainActor.run to finish before asserting.
+        try await Task.sleep(for: .milliseconds(50))
+
+        let finalBookmark = Self.activeVideoBookmark(manager.getConfiguration(for: liveScreen))
+        #expect(finalBookmark != rejectedBookmark, "Rejected bookmark must not become active")
+        #expect(finalBookmark == initialBookmark, "Active bookmark should be unchanged on validation failure")
+    }
+
+    @Test("Startup options equality preserves legacy boolean semantics")
+    func startupOptionsEqualityIgnoresInjectedDependencyIdentity() {
+        let lhs = ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: FakePlayableVideoLoader(),
+            displayRegistry: FakeDisplayRegistry()
+        )
+        let rhs = ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(initialPowerSource: .battery(level: 0.1)),
+            fullScreenDetector: FakeFullScreenDetector(hiddenScreens: [123: true]),
+            playableVideoLoader: FakePlayableVideoLoader(validationError: .validationFailed),
+            displayRegistry: FakeDisplayRegistry()
+        )
+
+        #expect(lhs == rhs)
+    }
+
+    private static func makeScreen() -> Screen? {
+        NSScreen.screens.first.map(Screen.init(nsScreen:))
+    }
+
+    private static func activeVideoBookmark(_ configuration: ScreenConfiguration?) -> Data? {
+        guard case .video(let bookmark) = configuration?.activeWallpaper else { return nil }
+        return bookmark
+    }
+
+    private static func waitUntil(
+        timeout: Duration,
+        _ condition: @Sendable () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        Issue.record("Timed out waiting for async condition")
+    }
+}


### PR DESCRIPTION
## Summary

Week 4 first slice — three independent improvements landing together:

- **4.6 Protocolize ScreenManager dependencies** (`97442ab`) — introduces `PowerMonitoring` / `FullScreenDetecting` / `PlayableVideoLoading` / `DisplayRegistering`; concrete classes adopt via extensions; `PlayableVideoLoader` becomes a `Sendable` struct while keeping its static API for non-injected callers; `ScreenManagerStartupOptions` accepts injected protocol witnesses with the legacy boolean-only `Equatable`. Adds 4 fake doubles + `ProtocolizedDependenciesTests` (7 cases).
- **4.1 + 4.2 HSplitView Inspector + design tokens** (`a9ca9ae`) — replaces the fixed-width inspector `HStack` with `HSplitView` (preview ≥ 480pt, inspector 280–480pt). Centralises spacing/corner/inspector/preview metrics in `Views/Styles/DesignTokens.swift`. Adds an `accessibilityLabel("Wallpaper Properties")` to the inspector column.
- **4.3 a11y reduce-motion helper + label gaps** (`092a32c`) — `DesignTokens.motion(_:)` returns nil under Reduce Motion; the four `ScreenDetailView` animations (fit-mode, wallpaper-mode, loading on/off) route through it. Backfills `accessibilityLabel` + `accessibilityHint` on three icon-only buttons (preferences toolbar, sidebar reload, OnboardingStepDone Get Started).

## Audit summary (4.6 only)

- codex 92/100 PASS — no critical issues, two Low decoupling notes deferred.
- gemini 83/100 NEEDS_IMPROVEMENT — adopted: protocol docstrings, fake `private(set) var`, behavioural validation-failure test. Deferred: `PowerSource` namespace decoupling (cross-codebase migration).

## Known follow-ups (not in this PR)

- Onboarding step 1 (`OnboardingStepFirstWallpaper.swift`) ~17 icons still need `accessibilityLabel`.
- `MenuBarContent.swift` ~30 icons still need `accessibilityLabel`.
- Several `withAnimation(...)` call sites outside `ScreenDetailView` are not yet routed through `DesignTokens.motion(_:)`.
- Task 4.5 (ScreenManager coordinator extraction) and Task 4.4 (lifecycle integration tests) tracked in a separate branch.

## Test plan

- [x] `xcodebuild test -scheme LiveWallpaper -destination 'platform=macOS,arch=arm64'` → 430 tests / 74 suites pass in ~3.0s (baseline 423/73, +7 protocolized-injection tests).
- [ ] Manual: drag the new HSplitView splitter — preview clamps at 480pt, inspector clamps at 280–480pt.
- [ ] Manual with Reduce Motion enabled (System Settings → Accessibility → Display): fit-mode and wallpaper-mode toggles change instantly without spring animation.
- [ ] Manual VoiceOver: tab through ContentView toolbar / sidebar reload / OnboardingStepDone — each surface reports a label and a hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)