### PR TITLE
a11y: reduce-motion gating + MenuBarContent label gaps (Week 4 follow-up)

### DIFF
--- a/LiveWallpaper/Views/CollapsibleSection.swift
+++ b/LiveWallpaper/Views/CollapsibleSection.swift
@@ -7,10 +7,12 @@ struct CollapsibleSection<Content: View>: View {
     @Binding var isExpanded: Bool
     @ViewBuilder var content: () -> Content
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                withAnimation(.snappy(duration: 0.28)) {
+                withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.28))) {
                     isExpanded.toggle()
                 }
             } label: {
@@ -23,7 +25,7 @@ struct CollapsibleSection<Content: View>: View {
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(.secondary)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
-                        .animation(.snappy(duration: 0.28), value: isExpanded)
+                        .animation(reduceMotion ? nil : .snappy(duration: 0.28), value: isExpanded)
                 }
                 .contentShape(Rectangle())
             }

--- a/LiveWallpaper/Views/ContentView.swift
+++ b/LiveWallpaper/Views/ContentView.swift
@@ -151,6 +151,7 @@ enum Navigation: Hashable {
 struct Sidebar: View {
     @Binding var selection: Navigation?
     @Environment(ScreenManager.self) private var screenManager
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isReloading = false
     @State private var workshopLibraryAvailable = false
 
@@ -248,7 +249,7 @@ struct Sidebar: View {
     }
 
     private func reloadWallpapers() {
-        withAnimation(.snappy(duration: 0.2)) {
+        withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.2))) {
             isReloading = true
         }
 
@@ -256,7 +257,7 @@ struct Sidebar: View {
 
         Task {
             try? await Task.sleep(for: .milliseconds(500))
-            withAnimation(.snappy(duration: 0.2)) {
+            withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.2))) {
                 isReloading = false
             }
         }
@@ -276,6 +277,7 @@ struct Sidebar: View {
 struct ScreenRow: View {
     var screen: Screen
     @Environment(ScreenManager.self) private var screenManager
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var hasEffectBadge: Bool = false
 
@@ -325,7 +327,7 @@ struct ScreenRow: View {
         .onReceive(NotificationCenter.default.publisher(for: .wallpaperConfigurationDidChange)) { notification in
             if let changedID = notification.userInfo?["screenID"] as? CGDirectDisplayID,
                changedID == screen.id {
-                withAnimation(.snappy(duration: 0.2)) { refreshEffectBadge() }
+                withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.2))) { refreshEffectBadge() }
             }
         }
         .accessibilityElement(children: .combine)

--- a/LiveWallpaper/Views/MenuBarContent.swift
+++ b/LiveWallpaper/Views/MenuBarContent.swift
@@ -22,6 +22,7 @@ struct MenuBarContent: View {
     @State private var isWebURLEntryExpanded: Bool = false
     @State private var webURLDraft: String = ""
     @State private var showBookmarksPopover = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var monitor: SystemMonitor { .shared }
     private var ramPercent: Double {
@@ -34,7 +35,7 @@ struct MenuBarContent: View {
     @ViewBuilder
     private func ramScopeButton(label: String, value: String) -> some View {
         Button {
-            withAnimation(.snappy(duration: 0.18)) { ramScopeRaw = value }
+            withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.18))) { ramScopeRaw = value }
         } label: {
             Text(label)
                 .font(.system(size: 10, weight: ramScopeRaw == value ? .semibold : .regular))
@@ -75,12 +76,14 @@ struct MenuBarContent: View {
             Image(systemName: "play.rectangle.fill")
                 .font(.system(size: 16))
                 .foregroundStyle(Color.accentColor)
+                .accessibilityHidden(true)
             Text("LiveWallpaper")
                 .font(.system(size: 14, weight: .semibold))
             Spacer()
             Text(versionString)
                 .font(.system(size: 10, design: .monospaced))
                 .foregroundStyle(.secondary)
+                .accessibilityLabel("Version \(versionString)")
         }
     }
 
@@ -89,7 +92,7 @@ struct MenuBarContent: View {
     private var miniDashboard: some View {
         VStack(alignment: .leading, spacing: 6) {
             Button {
-                withAnimation(.snappy(duration: 0.18)) { dashboardExpanded.toggle() }
+                withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.18))) { dashboardExpanded.toggle() }
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "chevron.right")
@@ -187,7 +190,7 @@ struct MenuBarContent: View {
 
             HStack(spacing: 6) {
                 QuickActionButton(label: "Web Page", systemImage: "globe") {
-                    withAnimation(.snappy(duration: 0.18)) { isWebURLEntryExpanded.toggle() }
+                    withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.18))) { isWebURLEntryExpanded.toggle() }
                 }
                 QuickActionButton(label: "HTML File", systemImage: "doc.richtext") {
                     requestAddWallpaper(kind: "html-file")
@@ -231,6 +234,8 @@ struct MenuBarContent: View {
             .buttonStyle(.plain)
             .disabled(webURLDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             .help("Use as wallpaper for the first display")
+            .accessibilityLabel("Apply web URL")
+            .accessibilityHint("Use the URL above as wallpaper for the first display")
         }
     }
 
@@ -321,7 +326,7 @@ struct MenuBarContent: View {
               let target = screenManager.screens.first else { return }
         screenManager.setHTMLWallpaperPreservingConfig(source: source, for: target)
         webURLDraft = ""
-        withAnimation(.snappy(duration: 0.18)) { isWebURLEntryExpanded = false }
+        withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.18))) { isWebURLEntryExpanded = false }
     }
 
     /// Hands the picker off to the main window via a synchronous closure

--- a/LiveWallpaper/Views/ScreenDetail/CommonPlaybackInspector.swift
+++ b/LiveWallpaper/Views/ScreenDetail/CommonPlaybackInspector.swift
@@ -16,6 +16,7 @@ struct CommonPlaybackInspector: View {
     var wallpaperType: WallpaperType
 
     @Environment(ScreenManager.self) private var screenManager
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @Binding var muted: Bool
     @Binding var frameRateLimit: FrameRateLimit
@@ -129,10 +130,10 @@ struct CommonPlaybackInspector: View {
                         screenManager.updateSetAsDesktopPicture(newValue, for: screen)
                         guard newValue else { return }
                         screenManager.extractLockScreenFrame(for: screen)
-                        withAnimation(.snappy(duration: 0.25)) { lockScreenExtracted = true }
+                        withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.25))) { lockScreenExtracted = true }
                         Task {
                             try? await Task.sleep(for: .seconds(2))
-                            withAnimation(.snappy(duration: 0.25)) { lockScreenExtracted = false }
+                            withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.25))) { lockScreenExtracted = false }
                         }
                     }
                     .accessibilityLabel("Set current frame as desktop picture")


### PR DESCRIPTION
## Summary

Extends Week 4.3 a11y work to the high-traffic surfaces that were left out of PR #27.

### Reduce Motion gating

Routes `withAnimation(.snappy/.spring)` through `DesignTokens.motion(_:)` so Reduce Motion suppresses them. Affected files:

| File | Sites | Notes |
|------|-------|-------|
| `Views/CollapsibleSection.swift` | 2 | Shared toggle + chevron rotation — every GroupBox on inspector/settings benefits |
| `Views/MenuBarContent.swift` | 4 | RAM scope picker, dashboard expand, web URL expand/collapse |
| `Views/ContentView.swift` | 3 | Sidebar reload symbolEffect on/off, ScreenRow effect-badge refresh |
| `Views/ScreenDetail/CommonPlaybackInspector.swift` | 2 | Lock-screen extraction confirmation |

### A11y label backfill

`Views/MenuBarContent.swift`:
- Header `Image("play.rectangle.fill")` → `accessibilityHidden(true)` (decorative)
- Version `Text` → explicit "Version vX.Y" label
- Web URL submit button (icon-only `Image("arrow.right.circle.fill")`) → `accessibilityLabel("Apply web URL")` + `accessibilityHint`

### Out of scope (deferred follow-up)

- `OnboardingStepFirstWallpaper.swift` (~17 icons)
- `Views/ScheduleSection.swift` (4 sites)
- `Views/WallpaperSections.swift` / `SystemMonitorView.swift` / `WPESceneDetailView.swift` / `ScreenDetailControls.swift` (1 site each)
- Task 4.5 ScreenManager coordinator extraction — first codex prototype came back built against an outdated ScreenManager surface (wrong `setVideo` signature, dropped `videoBookmarkData`/`activeWallpaper` fields). Needs a fresh planning pass before retrying.

## Test plan

- [x] `xcodebuild test -scheme LiveWallpaper -destination 'platform=macOS,arch=arm64'` → 430 / 74 suites pass.
- [ ] Manual: enable Reduce Motion (System Settings → Accessibility → Display) and confirm CollapsibleSection / MenuBar dashboard / sidebar reload / lock-screen extraction all switch states instantly without spring.
- [ ] Manual VoiceOver: focus the MenuBar web URL submit button → reads "Apply web URL".

🤖 Generated with [Claude Code](https://claude.com/claude-code)