### PR TITLE
Week 4 final: a11y polish + PlaybackTransitionRegistry first slice (4.5)

### DIFF
--- a/LiveWallpaper/Runtime/Coordinators/PlaybackTransitionRegistry.swift
+++ b/LiveWallpaper/Runtime/Coordinators/PlaybackTransitionRegistry.swift
@@ -1,0 +1,72 @@
+import AppKit
+import Combine
+
+/// Per-screen Combine subscription + fallback Task pair that the wallpaper
+/// pipeline uses to wait for `AVPlayer` to report a real frame rate before
+/// applying frame-rate-sensitive effects. Owned exclusively by
+/// `PlaybackTransitionRegistry`. Intentionally not actor-isolated because
+/// the registry's MainActor isolation already serialises access, and the
+/// nonisolated cancellation lets `deinit` clean up safely.
+final class AssetReadinessWork {
+    var frameRateSubscription: AnyCancellable?
+    var fallbackTask: Task<Void, Never>?
+
+    func cancel() {
+        frameRateSubscription?.cancel()
+        frameRateSubscription = nil
+        fallbackTask?.cancel()
+        fallbackTask = nil
+    }
+
+    deinit {
+        cancel()
+    }
+}
+
+/// Tracks per-screen async video transitions so stale completions get
+/// dropped, and owns the per-screen asset-readiness work used by
+/// `applyConfigurationWhenAssetReady`. Extracted from `ScreenManager` as
+/// the first step of Week 4 Task 4.5 PlaybackCoordinator extraction —
+/// the goal is to validate the extraction pattern (handing one piece of
+/// state at a time to a coordinator) on a low-risk surface before tackling
+/// the full playback API surface.
+@MainActor
+final class PlaybackTransitionRegistry {
+    private var generationByScreen: [CGDirectDisplayID: Int] = [:]
+    private var assetReadinessByScreen: [CGDirectDisplayID: AssetReadinessWork] = [:]
+
+    @discardableResult
+    func bumpTransition(for screenID: CGDirectDisplayID) -> Int {
+        let next = (generationByScreen[screenID] ?? 0) &+ 1
+        generationByScreen[screenID] = next
+        return next
+    }
+
+    func isCurrentTransition(_ generation: Int, for screenID: CGDirectDisplayID) -> Bool {
+        generationByScreen[screenID] == generation
+    }
+
+    func cancelAssetReadiness(for screenID: CGDirectDisplayID) {
+        assetReadinessByScreen[screenID]?.cancel()
+        assetReadinessByScreen[screenID] = nil
+    }
+
+    /// Replaces the screen's pending asset-readiness work, cancelling any
+    /// in-flight work first. Returns the freshly stored value so callers can
+    /// hold a reference for `clearAssetReadinessIfMatch`.
+    @discardableResult
+    func setAssetReadiness(_ work: AssetReadinessWork, for screenID: CGDirectDisplayID) -> AssetReadinessWork {
+        assetReadinessByScreen[screenID]?.cancel()
+        assetReadinessByScreen[screenID] = work
+        return work
+    }
+
+    /// Used when an asset-readiness callback finishes naturally — only
+    /// removes the slot if the same work instance is still installed (a
+    /// later transition may have replaced it).
+    func clearAssetReadinessIfMatch(_ work: AssetReadinessWork, for screenID: CGDirectDisplayID) {
+        if assetReadinessByScreen[screenID] === work {
+            assetReadinessByScreen[screenID] = nil
+        }
+    }
+}

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -2,22 +2,6 @@ import SwiftUI
 import Combine
 import Observation
 
-private final class WallpaperAssetReadinessWork {
-    var frameRateSubscription: AnyCancellable?
-    var fallbackTask: Task<Void, Never>?
-
-    func cancel() {
-        frameRateSubscription?.cancel()
-        frameRateSubscription = nil
-        fallbackTask?.cancel()
-        fallbackTask = nil
-    }
-
-    deinit {
-        cancel()
-    }
-}
-
 struct WallpaperSessionSummaryCache: Equatable {
     private var summariesByScreenID: [CGDirectDisplayID: WallpaperSessionSummary] = [:]
 
@@ -83,11 +67,11 @@ final class ScreenManager {
     @ObservationIgnored private let restoresSavedWallpapersOnScreenRefresh: Bool
     @ObservationIgnored private let exclusiveRenderingCoordinator = ExclusiveRenderingCoordinator()
     @ObservationIgnored private var exclusiveRenderingObservation: NSObjectProtocol?
-    /// Drops stale async video transitions.
-    @ObservationIgnored private var transitionGeneration: [CGDirectDisplayID: Int] = [:]
-    /// Drops stale async WPE imports per screen (mirrors `transitionGeneration`).
+    /// Owns per-screen video transition generation tokens + asset-readiness
+    /// work. First step of Week 4 Task 4.5 coordinator extraction.
+    @ObservationIgnored private let transitionRegistry = PlaybackTransitionRegistry()
+    /// Drops stale async WPE imports per screen (mirrors `transitionRegistry`).
     @ObservationIgnored private var wpeImportGeneration: [CGDirectDisplayID: Int] = [:]
-    @ObservationIgnored private var assetReadinessWork: [CGDirectDisplayID: WallpaperAssetReadinessWork] = [:]
     @ObservationIgnored let weatherService = WeatherReactiveService()
     @ObservationIgnored private lazy var lockScreenSnapshotCoordinator = LockScreenSnapshotCoordinator { [weak self] in
         self?.captureDesktopSnapshotsForLockIfNeeded()
@@ -357,8 +341,7 @@ final class ScreenManager {
         // before instantiating a player against a now-dead screen.
         bumpTransition(for: screen.id)
         videoEffectsApplier.cancelInflight(for: screen.id)
-        assetReadinessWork[screen.id]?.cancel()
-        assetReadinessWork[screen.id] = nil
+        transitionRegistry.cancelAssetReadiness(for: screen.id)
         screen.resetRuntimeSession()
         powerPolicy.clearTracking(for: screen.id)
     }
@@ -497,13 +480,11 @@ final class ScreenManager {
 
     @discardableResult
     private func bumpTransition(for screenID: CGDirectDisplayID) -> Int {
-        let next = (transitionGeneration[screenID] ?? 0) &+ 1
-        transitionGeneration[screenID] = next
-        return next
+        transitionRegistry.bumpTransition(for: screenID)
     }
 
     private func isCurrentTransition(_ generation: Int, for screenID: CGDirectDisplayID) -> Bool {
-        transitionGeneration[screenID] == generation
+        transitionRegistry.isCurrentTransition(generation, for: screenID)
     }
 
     private func applyConfiguration(_ configuration: ScreenConfiguration, to screen: Screen, preservingState: Bool = false) {
@@ -632,8 +613,7 @@ final class ScreenManager {
         configuration: ScreenConfiguration
     ) {
         let screenID = screen.id
-        assetReadinessWork[screenID]?.cancel()
-        assetReadinessWork[screenID] = nil
+        transitionRegistry.cancelAssetReadiness(for: screenID)
 
         let apply: @MainActor () -> Void = { [weak self] in
             guard let self,
@@ -656,8 +636,8 @@ final class ScreenManager {
             return
         }
 
-        let work = WallpaperAssetReadinessWork()
-        assetReadinessWork[screenID] = work
+        let work = AssetReadinessWork()
+        transitionRegistry.setAssetReadiness(work, for: screenID)
         var didApply = false
 
         let finish: @MainActor () -> Void = { [weak self, weak work] in
@@ -665,8 +645,8 @@ final class ScreenManager {
             didApply = true
             apply()
             work?.cancel()
-            if self.assetReadinessWork[screenID] === work {
-                self.assetReadinessWork[screenID] = nil
+            if let work {
+                self.transitionRegistry.clearAssetReadinessIfMatch(work, for: screenID)
             }
         }
 

--- a/LiveWallpaper/Views/Onboarding/OnboardingStepFirstWallpaper.swift
+++ b/LiveWallpaper/Views/Onboarding/OnboardingStepFirstWallpaper.swift
@@ -3,6 +3,7 @@ import AppKit
 import UniformTypeIdentifiers
 
 struct OnboardingStepFirstWallpaper: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let nextStep: () -> Void
     let skip: () -> Void
 
@@ -119,7 +120,7 @@ struct OnboardingStepFirstWallpaper: View {
                 Spacer()
 
                 Button("Continue") {
-                    withAnimation { stage = .sourcePicker }
+                    withAnimation(reduceMotion ? nil : .default) { stage = .sourcePicker }
                 }
                 .buttonStyle(.borderedProminent)
                 .keyboardShortcut(.defaultAction)
@@ -224,6 +225,7 @@ struct OnboardingStepFirstWallpaper: View {
                         Image(systemName: "globe")
                             .font(.system(size: 64))
                             .foregroundStyle(.tertiary)
+                            .accessibilityHidden(true)
                         Text("Web Preview Not Available")
                             .font(.system(size: 14, weight: .medium))
                             .foregroundStyle(.secondary)
@@ -240,7 +242,7 @@ struct OnboardingStepFirstWallpaper: View {
             HStack(spacing: 12) {
                 Button("Pick Different Source") {
                     previewController.cleanup()
-                    withAnimation { stage = .sourcePicker }
+                    withAnimation(reduceMotion ? nil : .default) { stage = .sourcePicker }
                 }
                 .keyboardShortcut(.cancelAction)
 
@@ -340,12 +342,12 @@ struct OnboardingStepFirstWallpaper: View {
         guard response == .OK, let url = panel.url,
               let bookmark = ResourceUtilities.createBookmark(for: url) else { return }
         SettingsManager.shared.saveLastUsedDirectory(url.deletingLastPathComponent())
-        withAnimation { stage = .livePreview(.video(url, bookmark)) }
+        withAnimation(reduceMotion ? nil : .default) { stage = .livePreview(.video(url, bookmark)) }
     }
 
     private func applyHTML(_ source: HTMLSource) {
         showHTMLSheet = false
-        withAnimation { stage = .livePreview(.html(source)) }
+        withAnimation(reduceMotion ? nil : .default) { stage = .livePreview(.html(source)) }
     }
 
     private func chooseWPEFolder() {
@@ -457,6 +459,7 @@ private struct HTMLPickerSheet: View {
                 HStack {
                     Image(systemName: "doc.richtext")
                         .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
                     Text(pickedFileName.isEmpty ? "No file chosen" : pickedFileName)
                         .font(.system(size: 12, design: .monospaced))
                         .lineLimit(1)
@@ -474,6 +477,7 @@ private struct HTMLPickerSheet: View {
                 HStack {
                     Image(systemName: "folder")
                         .foregroundStyle(.secondary)
+                        .accessibilityHidden(true)
                     Text(pickedFolderName.isEmpty ? "No folder chosen" : pickedFolderName)
                         .font(.system(size: 12, design: .monospaced))
                         .lineLimit(1)

--- a/LiveWallpaper/Views/ScheduleSection.swift
+++ b/LiveWallpaper/Views/ScheduleSection.swift
@@ -16,6 +16,8 @@ struct ScheduleSection: View {
     @State private var addSlotErrorMessage: String?
     @State private var conflictMessage: String?
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             if scheduleSlots.isEmpty {
@@ -174,7 +176,7 @@ struct ScheduleSection: View {
             scheduleSlots[index].startHour = start
             scheduleSlots[index].endHour = end
             screenManager.updateScheduleSlots(scheduleSlots, for: screen)
-            withAnimation(.snappy(duration: 0.2)) { conflictMessage = nil }
+            withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.2))) { conflictMessage = nil }
             return
         }
         // Conflict: revert stepper change, show persistent banner, flash outline 1.5s.
@@ -182,15 +184,15 @@ struct ScheduleSection: View {
             .filter { conflicts.contains($0.id) }
             .map(\.label)
             .joined(separator: ", ")
-        withAnimation(.snappy(duration: 0.2)) {
+        withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.2))) {
             conflictMessage = "Time range overlaps with: \(conflictingLabels)"
         }
         var highlighted = conflicts
         highlighted.insert(slotID)
-        withAnimation(.snappy(duration: 0.18)) { conflictHighlight = highlighted }
+        withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.18))) { conflictHighlight = highlighted }
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(1500))
-            withAnimation(.snappy(duration: 0.2)) { conflictHighlight.removeAll() }
+            withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.2))) { conflictHighlight.removeAll() }
         }
     }
 

--- a/LiveWallpaper/Views/ScreenDetail/ScreenDetailControls.swift
+++ b/LiveWallpaper/Views/ScreenDetail/ScreenDetailControls.swift
@@ -20,13 +20,14 @@ struct SegmentedSpeedPicker: View {
     @Binding var selectedSpeed: Double
     var onChange: (Double) -> Void
     private let speeds: [Double] = [0.5, 0.75, 1.0, 1.5, 2.0]
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         GlassEffectContainer(spacing: 2) {
             HStack(spacing: 2) {
                 ForEach(speeds, id: \.self) { speed in
                     Button(action: {
-                        withAnimation(.snappy(duration: 0.2)) {
+                        withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.2))) {
                             selectedSpeed = speed
                         }
                         onChange(speed)

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
@@ -227,7 +227,7 @@ struct WPESceneDetailView: View {
         // become a no-op and only Option-clicks toggle the panel.
         .onTapGesture {
             guard NSEvent.modifierFlags.contains(.option) else { return }
-            withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+            withAnimation(DesignTokens.motion(reduceMotion, .spring(response: 0.35, dampingFraction: 0.85))) {
                 showDiagnostics.toggle()
             }
         }

--- a/LiveWallpaper/Views/SystemMonitorView.swift
+++ b/LiveWallpaper/Views/SystemMonitorView.swift
@@ -4,6 +4,7 @@ struct SystemMonitorView: View {
     private var monitor = SystemMonitor.shared
     @State private var powerSource: PowerMonitor.PowerSource = PowerMonitor.shared.currentPowerSource
     @AppStorage("Dashboard.RAMScope") private var ramScopeRaw: String = "system"
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var ramPercent: Double {
         ramScopeRaw == "app" ? monitor.memoryPercentage() : monitor.systemMemoryUsage * 100
@@ -16,7 +17,7 @@ struct SystemMonitorView: View {
     @ViewBuilder
     private func ramScopeButton(label: String, value: String) -> some View {
         Button {
-            withAnimation(.snappy(duration: 0.18)) { ramScopeRaw = value }
+            withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.18))) { ramScopeRaw = value }
         } label: {
             Text(label)
                 .font(.system(size: 10, weight: ramScopeRaw == value ? .semibold : .regular))

--- a/LiveWallpaper/Views/WallpaperSections.swift
+++ b/LiveWallpaper/Views/WallpaperSections.swift
@@ -29,6 +29,7 @@ struct ShaderWallpaperSection: View {
     var screen: Screen
     @Binding var selectedShaderPreset: MetalShaderPreset
     @Environment(ScreenManager.self) private var screenManager
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         GroupBox {
@@ -46,7 +47,7 @@ struct ShaderWallpaperSection: View {
                     HStack(spacing: 10) {
                         ForEach(MetalShaderPreset.allCases) { preset in
                             Button {
-                                withAnimation(.snappy(duration: 0.2)) {
+                                withAnimation(DesignTokens.motion(reduceMotion, .snappy(duration: 0.2))) {
                                     selectedShaderPreset = preset
                                 }
                                 screenManager.setShaderWallpaper(preset: preset, for: screen)


### PR DESCRIPTION
## Summary

Closes the remaining Week 4 todo with two slices on the same branch:

### 1. A11y polish (`51c8227`)

Wraps every remaining `withAnimation(.snappy/.spring)` in the codebase
through `DesignTokens.motion(_:)` so Reduce Motion suppresses them, plus
hides three decorative icons whose accompanying labels carry the meaning.

| File | Changes |
|------|---------|
| `Views/ScheduleSection.swift` | 4 sites (conflict banner show/hide + highlight pulse + auto-clear) |
| `Views/SystemMonitorView.swift` | 1 site (RAM scope picker) |
| `Views/WallpaperSections.swift` | 1 site (shader preset selection) |
| `Views/ScreenDetail/ScreenDetailControls.swift` | 1 site (speed picker) |
| `Views/ScreenDetail/WPESceneDetailView.swift` | 1 site (.spring → motion helper) |
| `Views/Onboarding/OnboardingStepFirstWallpaper.swift` | 4 sites — previously implicit `withAnimation { … }` with no animation literal — plus 3 decorative `Image` icons hidden from VoiceOver |

### 2. PlaybackTransitionRegistry — Week 4.5 first slice (`40e9d64`)

Hands the per-screen video-transition generation counter + asset-readiness
work (Combine + fallback Task) to a dedicated `@MainActor`
`PlaybackTransitionRegistry`. **Every public ScreenManager API is unchanged.**

New file: `LiveWallpaper/Runtime/Coordinators/PlaybackTransitionRegistry.swift`
- `bumpTransition(for:) -> Int` / `isCurrentTransition(_:for:) -> Bool`
- `cancelAssetReadiness(for:)` / `setAssetReadiness(_:for:)` / `clearAssetReadinessIfMatch(_:for:)`
- `AssetReadinessWork` (renamed from the file-private `WallpaperAssetReadinessWork`) — intentionally non-actor-isolated so `deinit` can clean up; the registry's MainActor isolation already serialises access.

ScreenManager:
- Drops the `transitionGeneration` + `assetReadinessWork` dictionaries plus the local `WallpaperAssetReadinessWork` class definition.
- `bumpTransition` / `isCurrentTransition` now forward to the registry — every internal call site (setVideo, applyConfiguration, playlist + schedule transitions) keeps working unchanged.
- `releaseRuntimeSession` and `applyConfigurationWhenAssetReady` use the registry's lifecycle API instead of poking dictionaries.

#### Why a single-state slice and not the full PlaybackCoordinator

The earlier `/ccg:execute` attempt asked codex to extract `setVideo` /
`setupVideoPlayback` / `updatePlaybackSpeed` / etc. in one pass. The
returned diff was built against an outdated ScreenManager surface (wrong
`setVideo` signature, dropped `videoBookmarkData` + `activeWallpaper`).
This slice validates the extraction pattern (handing one bounded piece
of state at a time) on a low-risk surface so the rest of the playback
API can migrate chunk by chunk.

## Out of scope

- Remaining playback APIs (`setVideo`, `setupVideoPlayback`,
  `applyConfiguration`, `applyStartupPlaybackPolicy`,
  `schedulePolicyAwarePlaybackStart`, `update*` helpers) → Week 4.5 next slice.
- Effect / Import / Schedule coordinators (Tasks 4.5-B/C/D).
- Task 4.4 lifecycle integration tests — depend on coordinator extraction completion.
- LICENSE / README metadata (Task 4.7) — protocol decision still pending.

## Test plan

- [x] `xcodebuild test -scheme LiveWallpaper -destination 'platform=macOS,arch=arm64'` → 430 / 74 suites pass.
- [ ] Manual: enable Reduce Motion → schedule conflict highlight, system-monitor RAM scope picker, shader preset switch, speed picker, WPE option-click diagnostics, onboarding stage transitions all change instantly without spring.
- [ ] Manual VoiceOver: HTML file/folder pickers no longer announce a leading `doc.richtext` / `folder` icon — only the labels.
- [ ] Manual smoke: pick a video → effect applies once playback begins, switch to a different video → asset-readiness cancels cleanly, no orphan timers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)