### PR TITLE
Week 4.5 slice 2: PlaybackCoordinator absorbs config setters

### DIFF
--- a/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
@@ -1,0 +1,107 @@
+import AppKit
+import Foundation
+
+/// Owns per-screen playback configuration mutations + the
+/// `PlaybackTransitionRegistry` for async-transition tracking. Second slice of
+/// Week 4 Task 4.5 — pulls the four `update*` setters and `applyFrameRateLimit`
+/// out of `ScreenManager` so the playback API surface migrates one bounded
+/// chunk at a time. ScreenManager keeps its public method signatures and
+/// forwards to the coordinator.
+@MainActor
+final class PlaybackCoordinator {
+    let transition = PlaybackTransitionRegistry()
+
+    private let configurationStore: WallpaperConfigurationStore
+    /// Hook into ScreenManager-owned effect application — kept as a callback
+    /// because `applyVideoEffects` reaches into Combine lifetimes that aren't
+    /// part of this coordinator's responsibility yet.
+    private let applyVideoEffects: @MainActor (Screen, ScreenConfiguration) -> Void
+    /// Hook for ScreenManager's cached `CGDisplayCopyDisplayMode` lookup —
+    /// avoids re-implementing the cache or paying its cost on every setter.
+    private let refreshRateLookup: @MainActor (CGDirectDisplayID) -> Int
+
+    init(
+        configurationStore: WallpaperConfigurationStore,
+        applyVideoEffects: @MainActor @escaping (Screen, ScreenConfiguration) -> Void,
+        refreshRateLookup: @MainActor @escaping (CGDirectDisplayID) -> Int
+    ) {
+        self.configurationStore = configurationStore
+        self.applyVideoEffects = applyVideoEffects
+        self.refreshRateLookup = refreshRateLookup
+    }
+
+    // MARK: - Configuration setters
+
+    func updatePlaybackSpeed(_ speed: Double, for screen: Screen) {
+        guard var configuration = configurationStore.get(for: screen.id),
+              speed != configuration.playbackSpeed else { return }
+
+        configuration.playbackSpeed = speed
+        save(configuration)
+        screen.videoPlayer?.setPlaybackSpeed(speed)
+    }
+
+    func updateMuted(_ muted: Bool, for screen: Screen) {
+        guard var configuration = configurationStore.get(for: screen.id),
+              muted != configuration.muted else { return }
+
+        configuration.muted = muted
+        save(configuration)
+        screen.videoPlayer?.setMuted(muted)
+    }
+
+    func updateFitMode(_ fitMode: VideoFitMode, for screen: Screen) {
+        guard var configuration = configurationStore.get(for: screen.id),
+              fitMode != configuration.fitMode else { return }
+
+        configuration.fitMode = fitMode
+        save(configuration)
+        screen.videoPlayer?.setVideoFitMode(fitMode)
+    }
+
+    func updateFrameRateLimit(_ frameRateLimit: FrameRateLimit, for screen: Screen) {
+        guard var configuration = configurationStore.get(for: screen.id) else {
+            Logger.warning("Cannot update frame rate limit: No configuration found for screen \(screen.id)", category: .videoPlayer)
+            return
+        }
+        guard frameRateLimit != configuration.frameRateLimit else { return }
+
+        configuration.frameRateLimit = frameRateLimit
+        save(configuration)
+        if configuration.effectConfig.hasActiveEffect {
+            applyVideoEffects(screen, configuration)
+        } else {
+            applyFrameRateLimit(frameRateLimit, to: screen)
+        }
+    }
+
+    func applyFrameRateLimit(_ frameRateLimit: FrameRateLimit, to screen: Screen) {
+        guard let player = screen.videoPlayer, player.videoFrameRate > 0 else { return }
+
+        let screenRefreshRate = refreshRateLookup(screen.id)
+        let limit = PlainVideoFrameRateCompositionPolicy.compositionLimit(
+            frameRateLimit: frameRateLimit,
+            videoFrameRate: player.videoFrameRate,
+            screenRefreshRate: Double(screenRefreshRate)
+        )
+
+        if let limit {
+            Logger.info("Applying frame rate limit of \(Int(limit)) FPS to screen \(screen.id)", category: .videoPlayer)
+            player.setFrameRateLimit(limit)
+        } else {
+            Logger.info("Using native playback path (\(Int(player.videoFrameRate)) FPS) for screen \(screen.id)", category: .videoPlayer)
+            player.setFrameRateLimit(0)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func save(_ configuration: ScreenConfiguration) {
+        configurationStore.save(configuration)
+        NotificationCenter.default.post(
+            name: .wallpaperConfigurationDidChange,
+            object: nil,
+            userInfo: ["screenID": configuration.screenID]
+        )
+    }
+}

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -67,9 +67,23 @@ final class ScreenManager {
     @ObservationIgnored private let restoresSavedWallpapersOnScreenRefresh: Bool
     @ObservationIgnored private let exclusiveRenderingCoordinator = ExclusiveRenderingCoordinator()
     @ObservationIgnored private var exclusiveRenderingObservation: NSObjectProtocol?
-    /// Owns per-screen video transition generation tokens + asset-readiness
-    /// work. First step of Week 4 Task 4.5 coordinator extraction.
-    @ObservationIgnored private let transitionRegistry = PlaybackTransitionRegistry()
+    /// Coordinates per-screen playback configuration mutations + transition
+    /// tokens. Lazy because it captures `self` for the effect-application and
+    /// refresh-rate-lookup callbacks; the stored properties used by those
+    /// callbacks (`videoEffectsApplier`, `refreshRateCache`, etc.) are already
+    /// initialised by the time the lazy var is touched.
+    @ObservationIgnored private lazy var playbackCoordinator = PlaybackCoordinator(
+        configurationStore: configurationStore,
+        applyVideoEffects: { [weak self] screen, config in
+            self?.applyVideoEffects(for: screen, config: config)
+        },
+        refreshRateLookup: { [weak self] screenID in
+            self?.getScreenRefreshRate(for: screenID) ?? 60
+        }
+    )
+    @ObservationIgnored private var transitionRegistry: PlaybackTransitionRegistry {
+        playbackCoordinator.transition
+    }
     /// Drops stale async WPE imports per screen (mirrors `transitionRegistry`).
     @ObservationIgnored private var wpeImportGeneration: [CGDirectDisplayID: Int] = [:]
     @ObservationIgnored let weatherService = WeatherReactiveService()
@@ -1255,65 +1269,23 @@ final class ScreenManager {
     }
 
     func updatePlaybackSpeed(_ speed: Double, for screen: Screen) {
-        guard var configuration = configurationStore.get(for: screen.id),
-              speed != configuration.playbackSpeed else { return }
-
-        configuration.playbackSpeed = speed
-        saveConfiguration(configuration)
-        screen.videoPlayer?.setPlaybackSpeed(speed)
+        playbackCoordinator.updatePlaybackSpeed(speed, for: screen)
     }
 
     func updateMuted(_ muted: Bool, for screen: Screen) {
-        guard var configuration = configurationStore.get(for: screen.id),
-              muted != configuration.muted else { return }
-
-        configuration.muted = muted
-        saveConfiguration(configuration)
-        screen.videoPlayer?.setMuted(muted)
+        playbackCoordinator.updateMuted(muted, for: screen)
     }
 
     func updateFitMode(_ fitMode: VideoFitMode, for screen: Screen) {
-        guard var configuration = configurationStore.get(for: screen.id),
-              fitMode != configuration.fitMode else { return }
-
-        configuration.fitMode = fitMode
-        saveConfiguration(configuration)
-        screen.videoPlayer?.setVideoFitMode(fitMode)
+        playbackCoordinator.updateFitMode(fitMode, for: screen)
     }
 
     func updateFrameRateLimit(_ frameRateLimit: FrameRateLimit, for screen: Screen) {
-        guard var configuration = configurationStore.get(for: screen.id) else {
-            Logger.warning("Cannot update frame rate limit: No configuration found for screen \(screen.id)", category: .videoPlayer)
-            return
-        }
-        guard frameRateLimit != configuration.frameRateLimit else { return }
-
-        configuration.frameRateLimit = frameRateLimit
-        saveConfiguration(configuration)
-        if configuration.effectConfig.hasActiveEffect {
-            applyVideoEffects(for: screen, config: configuration)
-        } else {
-            applyFrameRateLimit(frameRateLimit, to: screen)
-        }
+        playbackCoordinator.updateFrameRateLimit(frameRateLimit, for: screen)
     }
-    
+
     private func applyFrameRateLimit(_ frameRateLimit: FrameRateLimit, to screen: Screen) {
-        guard let player = screen.videoPlayer, player.videoFrameRate > 0 else { return }
-
-        let screenRefreshRate = getScreenRefreshRate(for: screen.id)
-        let limit = PlainVideoFrameRateCompositionPolicy.compositionLimit(
-            frameRateLimit: frameRateLimit,
-            videoFrameRate: player.videoFrameRate,
-            screenRefreshRate: Double(screenRefreshRate)
-        )
-
-        if let limit {
-            Logger.info("Applying frame rate limit of \(Int(limit)) FPS to screen \(screen.id)", category: .videoPlayer)
-            player.setFrameRateLimit(limit)
-        } else {
-            Logger.info("Using native playback path (\(Int(player.videoFrameRate)) FPS) for screen \(screen.id)", category: .videoPlayer)
-            player.setFrameRateLimit(0)
-        }
+        playbackCoordinator.applyFrameRateLimit(frameRateLimit, to: screen)
     }
     
     func getConfiguration(for screen: Screen) -> ScreenConfiguration? {


### PR DESCRIPTION
> ⚠️ **Stacked on PR #29** — base is `feat/week4-final-followup`. Merge #29 first; this PR shows only the slice-2 delta.

## Summary

Wraps the slice-1 `PlaybackTransitionRegistry` inside a new
`@MainActor PlaybackCoordinator` and migrates the four playback-config
setters + `applyFrameRateLimit` from ScreenManager. Public ScreenManager
API and call-site behaviour stay identical.

### What moved

| Method | From | To |
|--------|------|----|
| `updatePlaybackSpeed(_:for:)` | ScreenManager | PlaybackCoordinator |
| `updateMuted(_:for:)` | ScreenManager | PlaybackCoordinator |
| `updateFitMode(_:for:)` | ScreenManager | PlaybackCoordinator |
| `updateFrameRateLimit(_:for:)` | ScreenManager | PlaybackCoordinator |
| `applyFrameRateLimit(_:to:)` | ScreenManager | PlaybackCoordinator |
| `PlaybackTransitionRegistry` ownership | ScreenManager direct | `coordinator.transition` |

### Design notes

- **Lazy init** — `playbackCoordinator` captures `self` for two callbacks
  (`applyVideoEffects`, `refreshRateLookup`). Lazy lets the stored
  properties those callbacks read finish initialising first.
- **Refresh-rate callback** — coordinator reuses ScreenManager's cached
  `CGDisplayCopyDisplayMode` lookup via injection instead of paying the
  cost again or duplicating the cache.
- **Effects callback** — `applyVideoEffects` threads through Combine
  subscriptions ScreenManager still owns; lifting it would require its
  own slice.
- **Private `save(_:)` inside the coordinator** — coordinator's writes
  hit the same `configurationStore` + `wallpaperConfigurationDidChange`
  notification, but stay separate from ScreenManager's `saveConfiguration`
  helper which is consumed by 20+ other call sites in the file.

### What stayed in ScreenManager

`setVideo`, `setupVideoPlayback`, `applyConfiguration`,
`applyConfigurationWhenAssetReady`, `applyStartupPlaybackPolicy`,
`schedulePolicyAwarePlaybackStart` — the next bounded chunk for slice 3.

## Test plan

- [x] `xcodebuild test -scheme LiveWallpaper -destination 'platform=macOS,arch=arm64'` → 430 / 74 suites pass.
- [ ] Manual: change a video's playback speed in the inspector → setting persists, player picks up the new rate.
- [ ] Manual: toggle mute / fit mode / frame-rate limit on the inspector → no behavioural regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)