### PR TITLE
Week 4.5 slice 3: PlaybackCoordinator absorbs asset readiness + startup policy

### DIFF
--- a/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
@@ -12,6 +12,9 @@ final class PlaybackCoordinator {
     let transition = PlaybackTransitionRegistry()
 
     private let configurationStore: WallpaperConfigurationStore
+    private let powerMonitor: any PowerMonitoring
+    private let fullScreenDetector: any FullScreenDetecting
+    private let powerPolicy: PowerPolicyController
     /// Hook into ScreenManager-owned effect application — kept as a callback
     /// because `applyVideoEffects` reaches into Combine lifetimes that aren't
     /// part of this coordinator's responsibility yet.
@@ -19,15 +22,33 @@ final class PlaybackCoordinator {
     /// Hook for ScreenManager's cached `CGDisplayCopyDisplayMode` lookup —
     /// avoids re-implementing the cache or paying its cost on every setter.
     private let refreshRateLookup: @MainActor (CGDirectDisplayID) -> Int
+    /// Snapshot of the current registered screens; matches
+    /// `ScreenManager.screens` so the coordinator can resolve a live
+    /// reference after async work returns.
+    private let screensProvider: @MainActor () -> [Screen]
+    /// Hook into `ScreenManager.markWallpaperSessionStateChanged` — used by
+    /// the deferred autoplay path so the inspector / sidebar refresh after
+    /// the policy decides to start playback.
+    private let markSessionStateChanged: @MainActor () -> Void
 
     init(
         configurationStore: WallpaperConfigurationStore,
+        powerMonitor: any PowerMonitoring,
+        fullScreenDetector: any FullScreenDetecting,
+        powerPolicy: PowerPolicyController,
         applyVideoEffects: @MainActor @escaping (Screen, ScreenConfiguration) -> Void,
-        refreshRateLookup: @MainActor @escaping (CGDirectDisplayID) -> Int
+        refreshRateLookup: @MainActor @escaping (CGDirectDisplayID) -> Int,
+        screensProvider: @MainActor @escaping () -> [Screen],
+        markSessionStateChanged: @MainActor @escaping () -> Void
     ) {
         self.configurationStore = configurationStore
+        self.powerMonitor = powerMonitor
+        self.fullScreenDetector = fullScreenDetector
+        self.powerPolicy = powerPolicy
         self.applyVideoEffects = applyVideoEffects
         self.refreshRateLookup = refreshRateLookup
+        self.screensProvider = screensProvider
+        self.markSessionStateChanged = markSessionStateChanged
     }
 
     // MARK: - Configuration setters
@@ -91,6 +112,128 @@ final class PlaybackCoordinator {
         } else {
             Logger.info("Using native playback path (\(Int(player.videoFrameRate)) FPS) for screen \(screen.id)", category: .videoPlayer)
             player.setFrameRateLimit(0)
+        }
+    }
+
+    // MARK: - Asset readiness + startup playback policy
+
+    func applyConfigurationWhenAssetReady(
+        player: WallpaperVideoPlayer,
+        screen: Screen,
+        configuration: ScreenConfiguration
+    ) {
+        let screenID = screen.id
+        transition.cancelAssetReadiness(for: screenID)
+
+        let apply: @MainActor () -> Void = { [weak self] in
+            guard let self,
+                  let liveScreen = self.screensProvider().first(where: { $0.id == screenID }) else { return }
+            if configuration.particleEffect != .none {
+                player.setParticleEffect(
+                    configuration.particleEffect,
+                    density: configuration.effectConfig.particleDensity
+                )
+            }
+            if configuration.effectConfig.hasActiveEffect {
+                self.applyVideoEffects(liveScreen, configuration)
+            } else {
+                self.applyFrameRateLimit(configuration.frameRateLimit, to: liveScreen)
+            }
+        }
+
+        if player.videoFrameRate > 0 {
+            apply()
+            return
+        }
+
+        let work = AssetReadinessWork()
+        transition.setAssetReadiness(work, for: screenID)
+        var didApply = false
+
+        let finish: @MainActor () -> Void = { [weak self, weak work] in
+            guard let self, !didApply else { return }
+            didApply = true
+            apply()
+            work?.cancel()
+            if let work {
+                self.transition.clearAssetReadinessIfMatch(work, for: screenID)
+            }
+        }
+
+        work.frameRateSubscription = player.$videoFrameRate
+            .first(where: { $0 > 0 })
+            .receive(on: DispatchQueue.main)
+            .sink { _ in
+                finish()
+            }
+
+        work.fallbackTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: .seconds(5))
+            } catch {
+                return
+            }
+            finish()
+        }
+    }
+
+    func applyStartupPlaybackPolicy(to player: WallpaperVideoPlayer, for screen: Screen) {
+        let globalSettings = SettingsManager.shared.loadGlobalSettings()
+        let powerSource = powerMonitor.currentPowerSource
+        let isHiddenByFullScreen = fullScreenDetector.isDesktopHidden(for: screen.id)
+
+        let pauseForPower = WallpaperPolicyEngine.shouldPauseForPower(
+            globalSettings: globalSettings,
+            powerSource: powerSource
+        )
+        let pauseForFullScreen = WallpaperPolicyEngine.shouldApplyFullScreenPolicy(
+            globalSettings: globalSettings,
+            isHiddenByFullScreen: isHiddenByFullScreen
+        )
+
+        if pauseForPower {
+            powerPolicy.markPausedByPower(screen.id)
+        }
+        if pauseForFullScreen {
+            powerPolicy.markPausedByFullScreen(screen.id)
+        }
+
+        if WallpaperPolicyEngine.shouldStartVideoPaused(
+            globalSettings: globalSettings,
+            powerSource: powerSource,
+            isHiddenByFullScreen: isHiddenByFullScreen
+        ) {
+            player.pause()
+            return
+        }
+
+        schedulePolicyAwarePlaybackStart(to: player, screenID: screen.id)
+    }
+
+    func schedulePolicyAwarePlaybackStart(to player: WallpaperVideoPlayer, screenID: CGDirectDisplayID) {
+        Task { @MainActor [weak self, weak player] in
+            do {
+                try await Task.sleep(for: .milliseconds(200))
+            } catch {
+                return
+            }
+
+            guard let self, let player else { return }
+
+            let globalSettings = SettingsManager.shared.loadGlobalSettings()
+            let shouldPause = WallpaperPolicyEngine.shouldStartVideoPaused(
+                globalSettings: globalSettings,
+                powerSource: self.powerMonitor.currentPowerSource,
+                isHiddenByFullScreen: self.fullScreenDetector.isDesktopHidden(for: screenID)
+            )
+
+            guard !shouldPause else {
+                player.pause()
+                return
+            }
+
+            player.play()
+            self.markSessionStateChanged()
         }
     }
 

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -74,11 +74,20 @@ final class ScreenManager {
     /// initialised by the time the lazy var is touched.
     @ObservationIgnored private lazy var playbackCoordinator = PlaybackCoordinator(
         configurationStore: configurationStore,
+        powerMonitor: powerMonitor,
+        fullScreenDetector: fullScreenDetector,
+        powerPolicy: powerPolicy,
         applyVideoEffects: { [weak self] screen, config in
             self?.applyVideoEffects(for: screen, config: config)
         },
         refreshRateLookup: { [weak self] screenID in
             self?.getScreenRefreshRate(for: screenID) ?? 60
+        },
+        screensProvider: { [weak self] in
+            self?.screens ?? []
+        },
+        markSessionStateChanged: { [weak self] in
+            self?.markWallpaperSessionStateChanged()
         }
     )
     @ObservationIgnored private var transitionRegistry: PlaybackTransitionRegistry {
@@ -626,59 +635,7 @@ final class ScreenManager {
         screen: Screen,
         configuration: ScreenConfiguration
     ) {
-        let screenID = screen.id
-        transitionRegistry.cancelAssetReadiness(for: screenID)
-
-        let apply: @MainActor () -> Void = { [weak self] in
-            guard let self,
-                  let liveScreen = self.screens.first(where: { $0.id == screenID }) else { return }
-            if configuration.particleEffect != .none {
-                player.setParticleEffect(
-                    configuration.particleEffect,
-                    density: configuration.effectConfig.particleDensity
-                )
-            }
-            if configuration.effectConfig.hasActiveEffect {
-                self.applyVideoEffects(for: liveScreen, config: configuration)
-            } else {
-                self.applyFrameRateLimit(configuration.frameRateLimit, to: liveScreen)
-            }
-        }
-
-        if player.videoFrameRate > 0 {
-            apply()
-            return
-        }
-
-        let work = AssetReadinessWork()
-        transitionRegistry.setAssetReadiness(work, for: screenID)
-        var didApply = false
-
-        let finish: @MainActor () -> Void = { [weak self, weak work] in
-            guard let self, !didApply else { return }
-            didApply = true
-            apply()
-            work?.cancel()
-            if let work {
-                self.transitionRegistry.clearAssetReadinessIfMatch(work, for: screenID)
-            }
-        }
-
-        work.frameRateSubscription = player.$videoFrameRate
-            .first(where: { $0 > 0 })
-            .receive(on: DispatchQueue.main)
-            .sink { _ in
-                finish()
-            }
-
-        work.fallbackTask = Task { @MainActor in
-            do {
-                try await Task.sleep(for: .seconds(5))
-            } catch {
-                return
-            }
-            finish()
-        }
+        playbackCoordinator.applyConfigurationWhenAssetReady(player: player, screen: screen, configuration: configuration)
     }
 
     private func setupVideoPlayback(url: URL, screen: Screen) {
@@ -724,63 +681,11 @@ final class ScreenManager {
     }
 
     private func applyStartupPlaybackPolicy(to player: WallpaperVideoPlayer, for screen: Screen) {
-        let globalSettings = SettingsManager.shared.loadGlobalSettings()
-        let powerSource = powerMonitor.currentPowerSource
-        let isHiddenByFullScreen = fullScreenDetector.isDesktopHidden(for: screen.id)
-
-        let pauseForPower = WallpaperPolicyEngine.shouldPauseForPower(
-            globalSettings: globalSettings,
-            powerSource: powerSource
-        )
-        let pauseForFullScreen = WallpaperPolicyEngine.shouldApplyFullScreenPolicy(
-            globalSettings: globalSettings,
-            isHiddenByFullScreen: isHiddenByFullScreen
-        )
-
-        if pauseForPower {
-            powerPolicy.markPausedByPower(screen.id)
-        }
-        if pauseForFullScreen {
-            powerPolicy.markPausedByFullScreen(screen.id)
-        }
-
-        if WallpaperPolicyEngine.shouldStartVideoPaused(
-            globalSettings: globalSettings,
-            powerSource: powerSource,
-            isHiddenByFullScreen: isHiddenByFullScreen
-        ) {
-            player.pause()
-            return
-        }
-
-        schedulePolicyAwarePlaybackStart(to: player, screenID: screen.id)
+        playbackCoordinator.applyStartupPlaybackPolicy(to: player, for: screen)
     }
 
     private func schedulePolicyAwarePlaybackStart(to player: WallpaperVideoPlayer, screenID: CGDirectDisplayID) {
-        Task { @MainActor [weak self, weak player] in
-            do {
-                try await Task.sleep(for: .milliseconds(200))
-            } catch {
-                return
-            }
-
-            guard let self, let player else { return }
-
-            let globalSettings = SettingsManager.shared.loadGlobalSettings()
-            let shouldPause = WallpaperPolicyEngine.shouldStartVideoPaused(
-                globalSettings: globalSettings,
-                powerSource: self.powerMonitor.currentPowerSource,
-                isHiddenByFullScreen: self.fullScreenDetector.isDesktopHidden(for: screenID)
-            )
-
-            guard !shouldPause else {
-                player.pause()
-                return
-            }
-
-            player.play()
-            self.markWallpaperSessionStateChanged()
-        }
+        playbackCoordinator.schedulePolicyAwarePlaybackStart(to: player, screenID: screenID)
     }
 
     


### PR DESCRIPTION
## Summary

Third slice of the Task 4.5 ScreenManager coordinator extraction. Moves
all "wait for first decoded frame + decide whether to play" logic into
the same coordinator that already owns the transition tokens gating it.
Public ScreenManager API and call-site behaviour stay identical.

### Migrated to PlaybackCoordinator

| Method | Lines | Notes |
|--------|-------|-------|
| `applyConfigurationWhenAssetReady(player:screen:configuration:)` | ~60 | Uses `screensProvider`, `applyVideoEffects`, `applyFrameRateLimit` already in coord |
| `applyStartupPlaybackPolicy(to:for:)` | ~30 | WallpaperPolicyEngine + PowerPolicy reason marking |
| `schedulePolicyAwarePlaybackStart(to:screenID:)` | ~25 | 200ms delayed re-evaluation; calls back via `markSessionStateChanged` |

### Coordinator init growth

Four new dependencies + one notification callback:

- `powerMonitor: any PowerMonitoring`
- `fullScreenDetector: any FullScreenDetecting`
- `powerPolicy: PowerPolicyController`
- `screensProvider: () -> [Screen]`
- `markSessionStateChanged: () -> Void`

ScreenManager's lazy init wires them through; production paths still
construct the same concrete witnesses.

### What stayed in ScreenManager (slice 4 candidates)

`setVideo` / `applyConfiguration` / `setupVideoPlayback` — these depend
on five more callbacks (`saveConfiguration`, `releaseRuntimeSession`,
`observeRuntimeErrors`, `applyPerformancePolicy`,
`notifyWallpaperSessionChanged`). Splitting them into a dedicated PR
keeps each diff scannable.

## Net diff size

- ScreenManager.swift: -119 / +11 (108 lines removed)
- PlaybackCoordinator.swift: +145
- Three private forwarders shrink to 6 lines total.

## Test plan

- [x] `xcodebuild test -scheme LiveWallpaper -destination 'platform=macOS,arch=arm64'` → 430 / 74 suites pass.
- [ ] Manual: pick a fresh video → first decoded frame triggers effects/frame-rate apply.
- [ ] Manual: enable "Pause on Battery" while plugged in → switch to battery → playback pauses; switch back → playback resumes.
- [ ] Manual: full-screen another app → wallpaper pauses; exit full screen → wallpaper resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)