### PR TITLE
refactor(runtime): coordinator absorbs setVideo + applyConfiguration + setupVideoPlayback (Week 4.5 slice 4)

### DIFF
--- a/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
@@ -2,11 +2,13 @@ import AppKit
 import Foundation
 
 /// Owns per-screen playback configuration mutations + the
-/// `PlaybackTransitionRegistry` for async-transition tracking. Second slice of
-/// Week 4 Task 4.5 — pulls the four `update*` setters and `applyFrameRateLimit`
-/// out of `ScreenManager` so the playback API surface migrates one bounded
-/// chunk at a time. ScreenManager keeps its public method signatures and
-/// forwards to the coordinator.
+/// `PlaybackTransitionRegistry` for async-transition tracking. Slice 4 of
+/// Week 4 Task 4.5 — absorbs `setVideo` + `applyConfiguration` +
+/// `setupVideoPlayback`, completing the playback API surface migration so
+/// ScreenManager only forwards. The remaining ScreenManager-owned hooks
+/// (releaseRuntimeSession, notifyWallpaperSessionChanged) remain as callbacks
+/// because they touch Combine lifetimes + notification surfaces outside this
+/// coordinator's responsibility.
 @MainActor
 final class PlaybackCoordinator {
     let transition = PlaybackTransitionRegistry()
@@ -15,6 +17,7 @@ final class PlaybackCoordinator {
     private let powerMonitor: any PowerMonitoring
     private let fullScreenDetector: any FullScreenDetecting
     private let powerPolicy: PowerPolicyController
+    private let playableVideoLoader: any PlayableVideoLoading
     /// Hook into ScreenManager-owned effect application — kept as a callback
     /// because `applyVideoEffects` reaches into Combine lifetimes that aren't
     /// part of this coordinator's responsibility yet.
@@ -30,25 +33,39 @@ final class PlaybackCoordinator {
     /// the deferred autoplay path so the inspector / sidebar refresh after
     /// the policy decides to start playback.
     private let markSessionStateChanged: @MainActor () -> Void
+    /// Tears down a screen's runtime session including video-effects cancel,
+    /// asset-readiness cancel, transition bump, and power-policy cleanup.
+    /// Owned by ScreenManager so the lifecycle stays single-source-of-truth.
+    private let releaseRuntimeSession: @MainActor (Screen) -> Void
+    /// Hook into ScreenManager's full session-changed pipeline (state version
+    /// bump + summary cache refresh + playback state push + full-screen
+    /// fallback re-evaluation + screensRefreshed notification).
+    private let notifyWallpaperSessionChanged: @MainActor () -> Void
 
     init(
         configurationStore: WallpaperConfigurationStore,
         powerMonitor: any PowerMonitoring,
         fullScreenDetector: any FullScreenDetecting,
         powerPolicy: PowerPolicyController,
+        playableVideoLoader: any PlayableVideoLoading,
         applyVideoEffects: @MainActor @escaping (Screen, ScreenConfiguration) -> Void,
         refreshRateLookup: @MainActor @escaping (CGDirectDisplayID) -> Int,
         screensProvider: @MainActor @escaping () -> [Screen],
-        markSessionStateChanged: @MainActor @escaping () -> Void
+        markSessionStateChanged: @MainActor @escaping () -> Void,
+        releaseRuntimeSession: @MainActor @escaping (Screen) -> Void,
+        notifyWallpaperSessionChanged: @MainActor @escaping () -> Void
     ) {
         self.configurationStore = configurationStore
         self.powerMonitor = powerMonitor
         self.fullScreenDetector = fullScreenDetector
         self.powerPolicy = powerPolicy
+        self.playableVideoLoader = playableVideoLoader
         self.applyVideoEffects = applyVideoEffects
         self.refreshRateLookup = refreshRateLookup
         self.screensProvider = screensProvider
         self.markSessionStateChanged = markSessionStateChanged
+        self.releaseRuntimeSession = releaseRuntimeSession
+        self.notifyWallpaperSessionChanged = notifyWallpaperSessionChanged
     }
 
     // MARK: - Configuration setters
@@ -117,7 +134,7 @@ final class PlaybackCoordinator {
 
     // MARK: - Asset readiness + startup playback policy
 
-    func applyConfigurationWhenAssetReady(
+    private func applyConfigurationWhenAssetReady(
         player: WallpaperVideoPlayer,
         screen: Screen,
         configuration: ScreenConfiguration
@@ -177,7 +194,7 @@ final class PlaybackCoordinator {
         }
     }
 
-    func applyStartupPlaybackPolicy(to player: WallpaperVideoPlayer, for screen: Screen) {
+    private func applyStartupPlaybackPolicy(to player: WallpaperVideoPlayer, for screen: Screen) {
         let globalSettings = SettingsManager.shared.loadGlobalSettings()
         let powerSource = powerMonitor.currentPowerSource
         let isHiddenByFullScreen = fullScreenDetector.isDesktopHidden(for: screen.id)
@@ -210,7 +227,7 @@ final class PlaybackCoordinator {
         schedulePolicyAwarePlaybackStart(to: player, screenID: screen.id)
     }
 
-    func schedulePolicyAwarePlaybackStart(to player: WallpaperVideoPlayer, screenID: CGDirectDisplayID) {
+    private func schedulePolicyAwarePlaybackStart(to player: WallpaperVideoPlayer, screenID: CGDirectDisplayID) {
         Task { @MainActor [weak self, weak player] in
             do {
                 try await Task.sleep(for: .milliseconds(200))
@@ -237,6 +254,198 @@ final class PlaybackCoordinator {
         }
     }
 
+    // MARK: - Video session lifecycle
+
+    func setVideo(url: URL, bookmarkData: Data, for screen: Screen) {
+        Logger.info("Setting video for screen \(screen.id): \(url.lastPathComponent)", category: .screenManager)
+
+        let existing = configurationStore.get(for: screen.id)
+        let isSameURL = Self.bookmarkResolves(to: url, bookmark: existing?.videoBookmarkData)
+
+        var configuration: ScreenConfiguration
+        if var prior = existing {
+            prior.replacePrimaryVideo(bookmarkData: bookmarkData)
+            configuration = prior
+        } else {
+            configuration = ScreenConfiguration(screenID: screen.id, videoBookmarkData: bookmarkData)
+        }
+        configuration.reconcileWPEOrigin()
+
+        if isSameURL, screen.videoPlayer != nil {
+            configurationStore.save(configuration)
+            applyConfiguration(configuration, to: screen, preservingState: true)
+            return
+        }
+
+        let screenID = screen.id
+        let generation = transition.bumpTransition(for: screenID)
+        let videoLoader = playableVideoLoader
+        Task {
+            do {
+                try await videoLoader.validatePlayableVideo(at: url)
+                await MainActor.run { [weak self] in
+                    guard let self,
+                          self.transition.isCurrentTransition(generation, for: screenID),
+                          let liveScreen = self.screensProvider().first(where: { $0.id == screenID }) else { return }
+                    self.configurationStore.save(configuration)
+                    guard SettingsManager.shared.validateConfiguration(for: screenID) else {
+                        Logger.error("Failed to save video configuration for screen \(screenID)", category: .screenManager)
+                        if let existing {
+                            self.configurationStore.save(existing)
+                        } else {
+                            self.configurationStore.remove(for: screenID)
+                        }
+                        return
+                    }
+                    self.setupVideoPlayback(url: url, screen: liveScreen)
+                }
+            } catch {
+                await MainActor.run {
+                    Logger.error("Failed to setup video: \(error.localizedDescription)", category: .screenManager)
+                }
+            }
+        }
+    }
+
+    func applyConfiguration(_ configuration: ScreenConfiguration, to screen: Screen, preservingState: Bool = false) {
+        do {
+            guard let bookmarkData = configuration.videoBookmarkData else {
+                throw NSError(domain: "ScreenManager", code: 400, userInfo: [
+                    NSLocalizedDescriptionKey: "No saved video bookmark is available for this screen."
+                ])
+            }
+
+            var isStale = false
+            let url = try URL(
+                resolvingBookmarkData: bookmarkData,
+                options: .withSecurityScope,
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+
+            guard url.startAccessingSecurityScopedResource() else {
+                throw NSError(domain: "ScreenManager", code: 403, userInfo: [
+                    NSLocalizedDescriptionKey: "Cannot access the video file. Permission denied."
+                ])
+            }
+            defer { url.stopAccessingSecurityScopedResource() }
+
+            if isStale {
+                do {
+                    let updatedBookmarkData = try url.bookmarkData(
+                        options: [.withSecurityScope, .securityScopeAllowOnlyReadAccess],
+                        includingResourceValuesForKeys: nil,
+                        relativeTo: nil
+                    )
+                    let updatedConfig = configuration.withUpdatedActiveBookmark(updatedBookmarkData)
+                    save(updatedConfig)
+                } catch {
+                    Logger.error("Failed to update stale bookmark: \(error.localizedDescription)", category: .fileAccess)
+                }
+            }
+
+            let needsNewPlayer = screen.videoPlayer == nil
+
+            if !needsNewPlayer, let player = screen.videoPlayer {
+                let currentTime = preservingState ? player.player?.currentTime() : .zero
+                let wasPlaying = player.isPlaying
+
+                player.setVideoFitMode(configuration.fitMode)
+
+                let currentSpeed = player.player?.defaultRate ?? 1.0
+                if abs(Float(configuration.playbackSpeed) - currentSpeed) > 0.01 {
+                    player.setPlaybackSpeed(configuration.playbackSpeed)
+                }
+
+                if player.videoFrameRate > 0 {
+                    if configuration.effectConfig.hasActiveEffect {
+                        applyVideoEffects(screen, configuration)
+                    } else {
+                        applyFrameRateLimit(configuration.frameRateLimit, to: screen)
+                    }
+                }
+
+                if let currentTime {
+                    player.player?.seek(to: currentTime)
+                }
+
+                let globalSettings = SettingsManager.shared.loadGlobalSettings()
+                let shouldPause = WallpaperPolicyEngine.shouldStartVideoPaused(
+                    globalSettings: globalSettings,
+                    powerSource: powerMonitor.currentPowerSource,
+                    isHiddenByFullScreen: fullScreenDetector.isDesktopHidden(for: screen.id)
+                )
+
+                if shouldPause {
+                    player.pause()
+                } else if !wasPlaying {
+                    schedulePolicyAwarePlaybackStart(to: player, screenID: screen.id)
+                }
+            } else {
+                let player = WallpaperVideoPlayer(
+                    url: url,
+                    frame: screen.frame,
+                    fitMode: configuration.fitMode
+                )
+                let session = VideoWallpaperSession(player: player)
+                session.onRuntimeErrorChange = { [markSessionStateChanged] in markSessionStateChanged() }
+                screen.installRuntimeSession(session)
+                notifyWallpaperSessionChanged()
+
+                player.setPlaybackSpeed(configuration.playbackSpeed)
+                applyConfigurationWhenAssetReady(player: player, screen: screen, configuration: configuration)
+                applyStartupPlaybackPolicy(to: player, for: screen)
+            }
+
+            applyPerformancePolicy(to: screen)
+        } catch let error as NSError {
+            Logger.error("Failed to apply configuration: \(error.localizedDescription) [domain=\(error.domain) code=\(error.code)]", category: .screenManager)
+            // Malformed persisted bookmark; clear it to avoid retry loops.
+            if error.domain == NSCocoaErrorDomain, error.code == NSFileReadCorruptFileError {
+                Logger.warning("Clearing unresolvable bookmark for screen \(screen.id); user must re-pick the source.", category: .screenManager)
+                configurationStore.remove(for: screen.id)
+                releaseRuntimeSession(screen)
+                notifyWallpaperSessionChanged()
+            }
+        } catch {
+            Logger.error("Failed to apply configuration: \(error.localizedDescription)", category: .screenManager)
+        }
+    }
+
+    func setupVideoPlayback(url: URL, screen: Screen) {
+        releaseRuntimeSession(screen)
+
+        let configuration = configurationStore.get(for: screen.id)
+        let player = WallpaperVideoPlayer(
+            url: url,
+            frame: screen.frame,
+            fitMode: configuration?.fitMode ?? .aspectFill
+        )
+
+        if let stored = configuration?.muted {
+            player.setMuted(stored)
+        }
+
+        guard let liveScreen = screensProvider().first(where: { $0.id == screen.id }) else {
+            Logger.warning("Screen with ID \(screen.id) not found in screens array", category: .screenManager)
+            return
+        }
+
+        let session = VideoWallpaperSession(player: player)
+        session.onRuntimeErrorChange = { [markSessionStateChanged] in markSessionStateChanged() }
+        liveScreen.installRuntimeSession(session)
+        applyPerformancePolicy(to: liveScreen)
+
+        if let configuration {
+            player.setPlaybackSpeed(configuration.playbackSpeed)
+            applyConfigurationWhenAssetReady(player: player, screen: liveScreen, configuration: configuration)
+        }
+
+        applyStartupPlaybackPolicy(to: player, for: liveScreen)
+        Logger.info("Video player setup complete for screen \(screen.id)", category: .screenManager)
+        notifyWallpaperSessionChanged()
+    }
+
     // MARK: - Helpers
 
     private func save(_ configuration: ScreenConfiguration) {
@@ -246,5 +455,29 @@ final class PlaybackCoordinator {
             object: nil,
             userInfo: ["screenID": configuration.screenID]
         )
+    }
+
+    private func applyPerformancePolicy(to screen: Screen) {
+        let globalSettings = SettingsManager.shared.loadGlobalSettings()
+        let isHiddenByFullScreen = globalSettings.pauseOnFullScreen &&
+            fullScreenDetector.isDesktopHidden(for: screen.id)
+        let profile = WallpaperPolicyEngine.performanceProfile(
+            globalSettings: globalSettings,
+            powerSource: powerMonitor.currentPowerSource,
+            isHiddenByFullScreen: isHiddenByFullScreen
+        )
+        screen.runtimeSession?.applyPerformanceProfile(profile)
+    }
+
+    private static func bookmarkResolves(to url: URL, bookmark: Data?) -> Bool {
+        guard let bookmark else { return false }
+        var isStale = false
+        let resolved = try? URL(
+            resolvingBookmarkData: bookmark,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        )
+        return resolved == url
     }
 }

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -77,6 +77,7 @@ final class ScreenManager {
         powerMonitor: powerMonitor,
         fullScreenDetector: fullScreenDetector,
         powerPolicy: powerPolicy,
+        playableVideoLoader: playableVideoLoader,
         applyVideoEffects: { [weak self] screen, config in
             self?.applyVideoEffects(for: screen, config: config)
         },
@@ -88,6 +89,12 @@ final class ScreenManager {
         },
         markSessionStateChanged: { [weak self] in
             self?.markWallpaperSessionStateChanged()
+        },
+        releaseRuntimeSession: { [weak self] screen in
+            self?.releaseRuntimeSession(screen)
+        },
+        notifyWallpaperSessionChanged: { [weak self] in
+            self?.notifyWallpaperSessionChanged()
         }
     )
     @ObservationIgnored private var transitionRegistry: PlaybackTransitionRegistry {
@@ -438,67 +445,7 @@ final class ScreenManager {
 
     /// Replaces the primary video while preserving per-screen settings.
     func setVideo(url: URL, bookmarkData: Data, for screen: Screen) {
-        Logger.info("Setting video for screen \(screen.id): \(url.lastPathComponent)", category: .screenManager)
-
-        let existing = configurationStore.get(for: screen.id)
-
-        let isSameURL: Bool = {
-            guard let existingBookmark = existing?.videoBookmarkData else { return false }
-            var isStale = false
-            let resolved = try? URL(
-                resolvingBookmarkData: existingBookmark,
-                options: .withSecurityScope,
-                relativeTo: nil,
-                bookmarkDataIsStale: &isStale
-            )
-            return resolved == url
-        }()
-
-        var configuration: ScreenConfiguration
-        if var prior = existing {
-            prior.replacePrimaryVideo(bookmarkData: bookmarkData)
-            configuration = prior
-        } else {
-            configuration = ScreenConfiguration(
-                screenID: screen.id,
-                videoBookmarkData: bookmarkData
-            )
-        }
-        configuration.reconcileWPEOrigin()
-        if isSameURL, screen.videoPlayer != nil {
-            configurationStore.save(configuration)
-            applyConfiguration(configuration, to: screen, preservingState: true)
-            return
-        }
-
-        let screenID = screen.id
-        let generation = bumpTransition(for: screenID)
-        let videoLoader = playableVideoLoader
-        Task {
-            do {
-                try await videoLoader.validatePlayableVideo(at: url)
-                await MainActor.run { [weak self] in
-                    guard let self,
-                          self.isCurrentTransition(generation, for: screenID),
-                          let liveScreen = self.screens.first(where: { $0.id == screenID }) else { return }
-                    self.configurationStore.save(configuration)
-                    guard SettingsManager.shared.validateConfiguration(for: screenID) else {
-                        Logger.error("Failed to save video configuration for screen \(screenID)", category: .screenManager)
-                        if let existing {
-                            self.configurationStore.save(existing)
-                        } else {
-                            self.configurationStore.remove(for: screenID)
-                        }
-                        return
-                    }
-                    self.setupVideoPlayback(url: url, screen: liveScreen)
-                }
-            } catch {
-                await MainActor.run {
-                    Logger.error("Failed to setup video: \(error.localizedDescription)", category: .screenManager)
-                }
-            }
-        }
+        playbackCoordinator.setVideo(url: url, bookmarkData: bookmarkData, for: screen)
     }
 
     @discardableResult
@@ -511,184 +458,13 @@ final class ScreenManager {
     }
 
     private func applyConfiguration(_ configuration: ScreenConfiguration, to screen: Screen, preservingState: Bool = false) {
-        do {
-            guard let bookmarkData = configuration.videoBookmarkData else {
-                throw NSError(domain: "ScreenManager", code: 400, userInfo: [
-                    NSLocalizedDescriptionKey: "No saved video bookmark is available for this screen."
-                ])
-            }
-
-            var isStale = false
-            let url = try URL(
-                resolvingBookmarkData: bookmarkData,
-                options: .withSecurityScope,
-                relativeTo: nil,
-                bookmarkDataIsStale: &isStale
-            )
-            
-            guard url.startAccessingSecurityScopedResource() else {
-                throw NSError(domain: "ScreenManager", code: 403, userInfo: [
-                    NSLocalizedDescriptionKey: "Cannot access the video file. Permission denied."
-                ])
-            }
-            
-            defer {
-                url.stopAccessingSecurityScopedResource()
-            }
-            
-            if isStale {
-                do {
-                    let updatedBookmarkData = try url.bookmarkData(
-                        options: [.withSecurityScope, .securityScopeAllowOnlyReadAccess],
-                        includingResourceValuesForKeys: nil,
-                        relativeTo: nil
-                    )
-                    let updatedConfig = configuration.withUpdatedActiveBookmark(updatedBookmarkData)
-                    saveConfiguration(updatedConfig)
-                } catch {
-                    Logger.error("Failed to update stale bookmark: \(error.localizedDescription)", category: .fileAccess)
-                }
-            }
-            
-            let needsNewPlayer = screen.videoPlayer == nil
-            
-            if !needsNewPlayer {
-                let currentTime = preservingState ? screen.videoPlayer?.player?.currentTime() : .zero
-                let wasPlaying = screen.videoPlayer?.isPlaying ?? false
-                
-                if let player = screen.videoPlayer {
-                    player.setVideoFitMode(configuration.fitMode)
-                    
-                    let currentSpeed = player.player?.defaultRate ?? 1.0
-                    if abs(Float(configuration.playbackSpeed) - currentSpeed) > 0.01 {
-                        player.setPlaybackSpeed(configuration.playbackSpeed)
-                    }
-                    
-                    if player.videoFrameRate > 0 {
-                        if configuration.effectConfig.hasActiveEffect {
-                            applyVideoEffects(for: screen, config: configuration)
-                        } else {
-                            applyFrameRateLimit(configuration.frameRateLimit, to: screen)
-                        }
-                    }
-                    
-                    if let currentTime = currentTime {
-                        player.player?.seek(to: currentTime)
-                    }
-                    
-                    let globalSettings = SettingsManager.shared.loadGlobalSettings()
-                    let shouldPause = WallpaperPolicyEngine.shouldStartVideoPaused(
-                        globalSettings: globalSettings,
-                        powerSource: powerMonitor.currentPowerSource,
-                        isHiddenByFullScreen: fullScreenDetector.isDesktopHidden(for: screen.id)
-                    )
-
-                    if shouldPause {
-                        player.pause()
-                    } else if !wasPlaying {
-                        schedulePolicyAwarePlaybackStart(to: player, screenID: screen.id)
-                    }
-                }
-            } else {
-                let player = WallpaperVideoPlayer(
-                    url: url,
-                    frame: screen.frame,
-                    fitMode: configuration.fitMode
-                )
-                let session = VideoWallpaperSession(player: player)
-                observeRuntimeErrors(for: session)
-                screen.installRuntimeSession(session)
-                notifyWallpaperSessionChanged()
-
-                player.setPlaybackSpeed(configuration.playbackSpeed)
-
-                applyConfigurationWhenAssetReady(player: player, screen: screen, configuration: configuration)
-
-                applyStartupPlaybackPolicy(to: player, for: screen)
-            }
-
-            let globalSettings = SettingsManager.shared.loadGlobalSettings()
-            applyPerformancePolicy(
-                to: screen,
-                globalSettings: globalSettings,
-                powerSource: powerMonitor.currentPowerSource,
-                isHiddenByFullScreen: globalSettings.pauseOnFullScreen &&
-                    fullScreenDetector.isDesktopHidden(for: screen.id)
-            )
-
-        } catch let error as NSError {
-            Logger.error("Failed to apply configuration: \(error.localizedDescription) [domain=\(error.domain) code=\(error.code)]", category: .screenManager)
-            // Malformed persisted bookmark; clear it to avoid retry loops.
-            if error.domain == NSCocoaErrorDomain, error.code == NSFileReadCorruptFileError {
-                Logger.warning("Clearing unresolvable bookmark for screen \(screen.id); user must re-pick the source.", category: .screenManager)
-                configurationStore.remove(for: screen.id)
-                releaseRuntimeSession(screen)
-                notifyWallpaperSessionChanged()
-            }
-        } catch {
-            Logger.error("Failed to apply configuration: \(error.localizedDescription)", category: .screenManager)
-        }
-    }
-    
-    private func applyConfigurationWhenAssetReady(
-        player: WallpaperVideoPlayer,
-        screen: Screen,
-        configuration: ScreenConfiguration
-    ) {
-        playbackCoordinator.applyConfigurationWhenAssetReady(player: player, screen: screen, configuration: configuration)
+        playbackCoordinator.applyConfiguration(configuration, to: screen, preservingState: preservingState)
     }
 
     private func setupVideoPlayback(url: URL, screen: Screen) {
-        releaseRuntimeSession(screen)
-
-        let configuration = configurationStore.get(for: screen.id)
-        let player = WallpaperVideoPlayer(
-            url: url,
-            frame: screen.frame,
-            fitMode: configuration?.fitMode ?? .aspectFill
-        )
-
-        if let stored = configuration?.muted {
-            player.setMuted(stored)
-        }
-
-        if let index = screens.firstIndex(where: { $0.id == screen.id }) {
-            let session = VideoWallpaperSession(player: player)
-            observeRuntimeErrors(for: session)
-            screens[index].installRuntimeSession(session)
-            let liveScreen = screens[index]
-            let globalSettings = SettingsManager.shared.loadGlobalSettings()
-            applyPerformancePolicy(
-                to: liveScreen,
-                globalSettings: globalSettings,
-                powerSource: powerMonitor.currentPowerSource,
-                isHiddenByFullScreen: globalSettings.pauseOnFullScreen &&
-                    fullScreenDetector.isDesktopHidden(for: liveScreen.id)
-            )
-
-            if let configuration {
-                player.setPlaybackSpeed(configuration.playbackSpeed)
-                applyConfigurationWhenAssetReady(player: player, screen: liveScreen, configuration: configuration)
-            }
-
-            applyStartupPlaybackPolicy(to: player, for: liveScreen)
-
-            Logger.info("Video player setup complete for screen \(screen.id)", category: .screenManager)
-            notifyWallpaperSessionChanged()
-        } else {
-            Logger.warning("Screen with ID \(screen.id) not found in screens array", category: .screenManager)
-        }
+        playbackCoordinator.setupVideoPlayback(url: url, screen: screen)
     }
 
-    private func applyStartupPlaybackPolicy(to player: WallpaperVideoPlayer, for screen: Screen) {
-        playbackCoordinator.applyStartupPlaybackPolicy(to: player, for: screen)
-    }
-
-    private func schedulePolicyAwarePlaybackStart(to player: WallpaperVideoPlayer, screenID: CGDirectDisplayID) {
-        playbackCoordinator.schedulePolicyAwarePlaybackStart(to: player, screenID: screenID)
-    }
-
-    
     // MARK: - Icon Management
     var playbackStatePublisher: AnyPublisher<Bool, Never> {
         playbackStateSubject.eraseToAnyPublisher()


### PR DESCRIPTION
## Summary
Final slice of Task 4.5 — migrates the three heavy video session methods (~220 lines) from \`ScreenManager\` to \`PlaybackCoordinator\`. Adds two new lifecycle callbacks (\`releaseRuntimeSession\`, \`notifyWallpaperSessionChanged\`) plus passes \`playableVideoLoader\` directly into the coordinator. Removes three orphaned forwarder helpers in ScreenManager.

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| ScreenManager.swift | 1869 | 1645 | **−224** |
| PlaybackCoordinator.swift | 250 | 483 | +232 |
| Tests | 470 ✅ | 470 ✅ | 0 |

## Migrated methods
1. \`setVideo(url:bookmarkData:for:)\` — async validation + transition-token guarded persist + setup
2. \`applyConfiguration(_:to:preservingState:)\` — security-scoped bookmark resolution, stale-bookmark refresh, fast-path vs new-player branching, startup pause policy
3. \`setupVideoPlayback(url:screen:)\` — release prior session → install new player → apply performance policy → defer autoplay

## Audit
- **codex** — \`91/100 PASS\`. Verified behavior parity (live-screen reference resolution, observeRuntimeErrors equivalence, applyPerformancePolicy placement, no retain cycles), no Critical/High/Medium issues. Sole Nit (private-ize three internal helpers) **applied** in this commit.

## Test plan
- [x] \`xcodebuild build\` — succeeds with no warnings
- [x] Full suite: 470/470 in 79 suites in 4.289s
- [x] codex audit pass (91/100, all P0/P1 clear)

## Follow-up
After merge, ScreenManager is a thin facade for the playback path; remaining size budget (≤500 line target) requires future slices for Effect/Import/Schedule coordinators (out of scope for Task 4.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)