### PR TITLE
fix(ui): polish playlist/schedule reveal + widen sidebar to prevent truncation

### DIFF
--- a/LiveWallpaper/Views/ContentView.swift
+++ b/LiveWallpaper/Views/ContentView.swift
@@ -224,8 +224,10 @@ struct Sidebar: View {
             }
         }
         .listStyle(.sidebar)
-        // Ideal == min so sidebar opens compact; user can drag to 280.
-        .navigationSplitViewColumnWidth(min: 200, ideal: 200, max: 280)
+        // 220 lets "Built-in Retina Display" + dimensions + status fit on one
+        // row at minimum width; previous 200 caused tail truncation that
+        // looked like content overflow on tight layouts.
+        .navigationSplitViewColumnWidth(min: 220, ideal: 220, max: 300)
         .onAppear { refreshWorkshopAvailability() }
         .onReceive(NotificationCenter.default.publisher(for: .wallpaperConfigurationDidChange)) { _ in
             refreshWorkshopAvailability()

--- a/LiveWallpaper/Views/ScreenDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetailView.swift
@@ -423,6 +423,10 @@ struct ScreenDetailView: View {
                                 }
                             }
                             .groupBoxStyle(ContainerGroupBoxStyle())
+                            .transition(reduceMotion ? .opacity : .asymmetric(
+                                insertion: .opacity.combined(with: .scale(scale: 0.96, anchor: .top)),
+                                removal: .opacity
+                            ))
                             }
 
                             if selectedWallpaperMode == .schedule {
@@ -440,6 +444,10 @@ struct ScreenDetailView: View {
                                 }
                             }
                             .groupBoxStyle(ContainerGroupBoxStyle())
+                            .transition(reduceMotion ? .opacity : .asymmetric(
+                                insertion: .opacity.combined(with: .scale(scale: 0.96, anchor: .top)),
+                                removal: .opacity
+                            ))
                             }
 
                             GroupBox {


### PR DESCRIPTION
## Summary
Two small UI polish fixes in response to user-reported issues:

1. **Playlist/Schedule mode reveal** — switching the Single/Playlist/Schedule picker triggered the SwiftUI default if-block transition, which surfaced as a "drop from top" jolt. Now uses an explicit asymmetric transition (\`opacity + scale 0.96 from top\` insertion, plain \`opacity\` removal) so the section grows in smoothly. Reduce Motion path stays plain \`.opacity\`.

2. **Sidebar truncation** — the sidebar's min column width of 200pt caused "Built-in Retina Display" + dimensions + status to truncate at the edge, which appeared as content overflowing the window frame in tight layouts. Bumped to **220pt min / 220 ideal / 300 max** so the row fits on one line at minimum width.

## Log noise — intentionally NOT fixed
The user's diagnostic log included several warnings I evaluated and **deliberately left alone**:

| Log line | Why ignored |
|---|---|
| \`PRECONDITION FAILURE: ... 'com.apple.audioanalyticsd'\` | Benign CoreAudio internal check; suppression requires Apple-approved \`temporary-exception.mach-lookup.global-name\` |
| \`os_unix.c open(/private/var/db/DetachedSignatures)\` | sqlite sandbox cache miss; harmless |
| \`FigFilePlayer/VRP -12852/-12860\` | VideoToolbox loop-boundary state; emitted by every AVFoundation app |
| \`HALC_ProxyIOContext::IOWorkLoop: skipping cycle\` | System audio overload; not app-side |
| \`NSXPCDecoder validateAllowedClass\` / \`<decode: bad range>\` | System OSLog decoder warnings |

None are actionable from app code without an entitlement exception that's not worth the review-process burden.

## Test plan
- [x] \`xcodebuild build\` — succeeds, no warnings
- [x] Full suite: 470/470 in 79 suites in 3.574s
- [ ] Visual verification of new transition (deferred to merge — needs running app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)