### PR TITLE
refactor(screen-detail): single-owner header + 3-stage IA

### DIFF
--- a/LiveWallpaper/Views/ScreenDetail/EmptyStateGuideView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/EmptyStateGuideView.swift
@@ -1,124 +1,94 @@
 import SwiftUI
 
-/// First-impression card grid shown on a display that has no saved
-/// configuration. Mirrors the toolbar's segmented control 1:1 — exactly
-/// four cards (Video / HTML / Shader / Scene) so users build a single
-/// mental model for "wallpaper type" instead of competing
-/// type-vs-source vocabularies.
+/// Focal 2×2 card grid shown on a fresh display that has no saved
+/// configuration. Mirrors `WallpaperType` 1:1 so users build a single
+/// mental model — pick ONE of four types, the rest of the UI follows.
 ///
-/// Once any card is clicked the screen leaves this guide:
-/// the Video card opens the file picker; the other three flip the
-/// `selectedWallpaperType` and let the per-type empty state take over.
+/// Compact by design: the layout fits inside the minimum window content
+/// height (650pt) without scrolling, so first-time users on small windows
+/// see the entire palette at a glance.
 struct EmptyStateGuideView: View {
-    let onChooseVideo: () -> Void
-    let onChooseHTML: () -> Void
-    let onChooseShader: () -> Void
-    let onChooseScene: () -> Void
+    let onChoose: (WallpaperType) -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    private static let cards: [GuideCardModel] = [
+        GuideCardModel(
+            type: .video,
+            iconTint: .blue,
+            subtitle: "MP4 / MOV with playlists and schedules.",
+            actionLabel: "Pick Video…",
+            actionIcon: "folder"
+        ),
+        GuideCardModel(
+            type: .html,
+            iconTint: .green,
+            subtitle: "Web page or local HTML file.",
+            actionLabel: "Use HTML",
+            actionIcon: "arrow.right"
+        ),
+        GuideCardModel(
+            type: .metalShader,
+            iconTint: .orange,
+            subtitle: "Built-in animated GPU shaders.",
+            actionLabel: "Use Shader",
+            actionIcon: "arrow.right"
+        ),
+        GuideCardModel(
+            type: .scene,
+            iconTint: .purple,
+            subtitle: "Imported Steam Workshop scenes.",
+            actionLabel: "Use Scene",
+            actionIcon: "arrow.right"
+        )
+    ]
+
     var body: some View {
-        ScrollView {
-            VStack(spacing: 24) {
-                header
-
-                LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: 240, maximum: 320), spacing: 16)],
-                    spacing: 16
-                ) {
-                    GuideCard(
-                        icon: "film",
-                        iconTint: .blue,
-                        title: "Video",
-                        subtitle: "MP4 / MOV files. Supports playlists and time-of-day schedules.",
-                        actionTitle: "Pick Video…",
-                        actionSystemImage: "folder",
-                        action: onChooseVideo
-                    )
-
-                    GuideCard(
-                        icon: "globe",
-                        iconTint: .green,
-                        title: "HTML",
-                        subtitle: "Any web page or local HTML file. Particles and weather still apply.",
-                        actionTitle: "Use HTML",
-                        actionSystemImage: "arrow.right",
-                        action: onChooseHTML
-                    )
-
-                    GuideCard(
-                        icon: "wand.and.stars",
-                        iconTint: .orange,
-                        title: "Shader",
-                        subtitle: "Built-in animated GPU shaders. Lightweight on the battery.",
-                        actionTitle: "Use Shader",
-                        actionSystemImage: "arrow.right",
-                        action: onChooseShader
-                    )
-
-                    GuideCard(
-                        icon: "cube.transparent",
-                        iconTint: .purple,
-                        title: "Scene",
-                        subtitle: "Steam Workshop scenes imported from Wallpaper Engine.",
-                        actionTitle: "Use Scene",
-                        actionSystemImage: "arrow.right",
-                        action: onChooseScene
-                    )
+        VStack(spacing: 14) {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 240, maximum: 320), spacing: 12)],
+                spacing: 12
+            ) {
+                ForEach(Self.cards, id: \.type) { card in
+                    GuideCard(model: card) { onChoose(card.type) }
                 }
-                .padding(.horizontal, 4)
-
-                hint
             }
-            .padding(.horizontal, 28)
-            .padding(.vertical, 32)
-            .frame(maxWidth: 760)
-            .frame(maxWidth: .infinity)
+
+            hint
         }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 20)
+        .frame(maxWidth: 720)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private var header: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 36, weight: .light))
-                .foregroundStyle(Color.accentColor)
-                .symbolRenderingMode(.hierarchical)
-                .accessibilityHidden(true)
-
-            Text("Choose a wallpaper type")
-                .font(.system(size: 22, weight: .semibold, design: .rounded))
-                .accessibilityAddTraits(.isHeader)
-
-            Text("Each display can run a different type. You can switch from the toolbar after picking one.")
-                .font(.system(size: 13))
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 540)
-        }
-    }
-
     private var hint: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 6) {
             Image(systemName: "arrow.down.doc")
-                .font(.system(size: 12, weight: .medium))
+                .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(.tertiary)
                 .accessibilityHidden(true)
-            Text("Or drag a video, HTML file, or folder anywhere on this window.")
-                .font(.system(size: 11))
+            Text("Or drag a video, HTML file, or folder onto this window.")
+                .font(.system(size: 10))
                 .foregroundStyle(.tertiary)
         }
-        .padding(.top, 8)
     }
 }
 
-private struct GuideCard: View {
-    let icon: String
+// MARK: - Card model
+
+private struct GuideCardModel {
+    let type: WallpaperType
     let iconTint: Color
-    let title: String
     let subtitle: String
-    let actionTitle: String
-    let actionSystemImage: String
+    let actionLabel: String
+    let actionIcon: String
+}
+
+// MARK: - Card view
+
+private struct GuideCard: View {
+    let model: GuideCardModel
     let action: () -> Void
 
     @State private var isHovering = false
@@ -129,42 +99,41 @@ private struct GuideCard: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
                 ZStack {
                     Circle()
-                        .fill(iconTint.opacity(0.15))
-                        .frame(width: 44, height: 44)
-                    Image(systemName: icon)
-                        .font(.system(size: 20, weight: .medium))
-                        .foregroundStyle(iconTint)
+                        .fill(model.iconTint.opacity(0.15))
+                        .frame(width: 36, height: 36)
+                    Image(systemName: model.type.iconName)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(model.iconTint)
                         .symbolRenderingMode(.hierarchical)
                 }
                 .accessibilityHidden(true)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
-                        .font(.system(size: 15, weight: .semibold))
-                    Text(subtitle)
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                Text(model.type.rawValue)
+                    .font(.system(size: 14, weight: .semibold))
 
-                Spacer(minLength: 6)
+                Text(model.subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
 
-                Label(actionTitle, systemImage: actionSystemImage)
-                    .font(.system(size: 12, weight: .semibold))
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
+                Spacer(minLength: 4)
+
+                Label(model.actionLabel, systemImage: model.actionIcon)
+                    .font(.system(size: 11, weight: .semibold))
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
                     .background(
                         Capsule()
                             .fill(Color.accentColor.opacity(isActive ? 0.30 : 0.18))
                     )
                     .foregroundStyle(Color.accentColor)
             }
-            .padding(DesignTokens.Spacing.lg)
-            .frame(minHeight: 168, alignment: .topLeading)
+            .padding(DesignTokens.Spacing.md)
+            .frame(minHeight: 124, alignment: .topLeading)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(RoundedRectangle(cornerRadius: DesignTokens.Corner.lg, style: .continuous))
             .background(
@@ -193,7 +162,8 @@ private struct GuideCard: View {
         .animation(DesignTokens.motion(reduceMotion, .spring(response: 0.32, dampingFraction: 0.86)), value: isHovering)
         .animation(DesignTokens.motion(reduceMotion, .spring(response: 0.32, dampingFraction: 0.86)), value: isFocused)
         .onHover { isHovering = $0 }
-        .accessibilityLabel("\(title) wallpaper type")
-        .accessibilityHint(subtitle)
+        .accessibilityLabel("\(model.type.rawValue) wallpaper type")
+        .accessibilityHint(model.subtitle)
+        .accessibilityAddTraits(.isButton)
     }
 }

--- a/LiveWallpaper/Views/ScreenDetail/ScreenDetailHeader.swift
+++ b/LiveWallpaper/Views/ScreenDetail/ScreenDetailHeader.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+/// Single owner of `ScreenDetailView`'s top header zone.
+///
+/// Why a dedicated component: the previous design split header rendering
+/// across three layers (parent toolbar gear icon, child toolbar items,
+/// inline body HStack), each with its own visibility logic. Stage
+/// transitions kept producing visual collisions in the transparent
+/// titlebar zone. Centralising the header here means every stage
+/// produces a deterministic layout, owned by one switch.
+///
+/// Layout: identity block (avatar + name + reload + badges) is always
+/// shown — `ScreenDetailView` body's top-padding is what keeps it clear
+/// of the parent toolbar's `.navigation` gear icon. Right-side actions
+/// vary per stage:
+/// - `chooseType`   → empty (focus is the 4-card grid below)
+/// - `pickContent`  → ◀ Back
+/// - `configured`   → type picker + Bookmarks + (video: Select Video /
+///                    Trash) + (multi-display: Apply to All)
+struct ScreenDetailHeader: View {
+    var screen: Screen
+    var stage: ScreenDetailView.Stage
+    var wallpaperSessionSummary: WallpaperSessionSummary
+    var isMultipleScreens: Bool
+    var hasRuntimeError: Bool
+    @Binding var selectedWallpaperType: WallpaperType
+    @Binding var showBookmarks: Bool
+    var refreshRateHz: Int
+
+    let onReload: () -> Void
+    let onPickVideo: () -> Void
+    let onClearVideo: () -> Void
+    let onBack: () -> Void
+    let onApplyToAll: () -> Void
+
+    @Environment(ScreenManager.self) private var screenManager
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 14) {
+            if case .pickContent = stage {
+                backButton
+            }
+            identity
+            Spacer()
+            actions
+        }
+        .padding(.horizontal, DesignTokens.Spacing.xl)
+        .padding(.vertical, 14)
+    }
+
+    /// Leading-edge Back affordance for `pickContent`. Plain chevron with
+    /// `.plain` button style — macOS-idiomatic for back navigation, lighter
+    /// than a `.glass` capsule so it doesn't compete with the page title.
+    private var backButton: some View {
+        Button(action: onBack) {
+            Image(systemName: "chevron.left")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Return to wallpaper type selection")
+        .accessibilityLabel("Back to wallpaper type selection")
+    }
+
+    // MARK: - Identity (left of Spacer, always visible)
+
+    private var identity: some View {
+        HStack(alignment: .center, spacing: 14) {
+            ZStack {
+                Circle().fill(Color.accentColor.opacity(0.15)).frame(width: 44, height: 44)
+                Image(systemName: "display").font(.system(size: 18)).foregroundStyle(Color.accentColor)
+            }
+            .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: DesignTokens.Spacing.sm) {
+                    Text(screen.name)
+                        .font(.system(size: 18, weight: .semibold))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    if case .configured = stage {
+                        Button(action: onReload) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Reload display content")
+                        .accessibilityLabel("Reload display")
+                        .accessibilityHint("Reloads the wallpaper content for this screen")
+                    }
+                }
+                HStack(spacing: DesignTokens.Spacing.sm) {
+                    InfoBadge(
+                        icon: "arrow.up.left.and.arrow.down.right",
+                        text: "\(Int(screen.frame.width))×\(Int(screen.frame.height))"
+                    )
+                    InfoBadge(icon: "gauge.medium", text: "\(refreshRateHz) Hz")
+                    if case .configured = stage, wallpaperSessionSummary.isConfigured {
+                        sessionStatusPill
+                    }
+                }
+            }
+        }
+    }
+
+    private var sessionStatusPill: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "circle.fill")
+                .font(.system(size: 6))
+                .foregroundStyle(sessionStatusColor)
+                .symbolEffect(
+                    .pulse,
+                    options: .repeat(.continuous),
+                    isActive: wallpaperSessionSummary.activity == .active
+                )
+            Text(sessionStatusText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        // Treat the dot + text as one cohesive a11y element so VoiceOver
+        // doesn't read "circle, image" before the actual status text.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Status: \(sessionStatusText)")
+    }
+
+    // MARK: - Stage-aware right-side actions
+
+    @ViewBuilder
+    private var actions: some View {
+        // chooseType + pickContent → no trailing actions. The Back button
+        // for pickContent lives at the leading edge (see `body`).
+        if case .configured = stage {
+            configuredActions
+        }
+    }
+
+    /// Configured-stage trailing actions, ordered left → right by
+    /// scope: per-display tweaks (type / bookmarks / video re-pick / clear)
+    /// → cross-display global action (Apply to All) anchored far-right so
+    /// it's never confused with local controls.
+    private var configuredActions: some View {
+        HStack(spacing: DesignTokens.Spacing.md) {
+            Picker("Wallpaper Type", selection: $selectedWallpaperType) {
+                ForEach(WallpaperType.allCases) { type in
+                    Text(type.rawValue).tag(type)
+                }
+            }
+            .pickerStyle(.segmented)
+            .fixedSize(horizontal: true, vertical: false)
+            .accessibilityLabel("Wallpaper type")
+            .accessibilityHint("Switch between video, HTML, shader, or scene wallpaper")
+
+            Button {
+                showBookmarks = true
+            } label: {
+                Label("Bookmarks", systemImage: "bookmark.fill")
+            }
+            .buttonStyle(.glass)
+            .controlSize(.regular)
+            .help("Saved video / HTML / shader shortcuts")
+            .accessibilityLabel("Bookmarks")
+            .popover(isPresented: $showBookmarks, arrowEdge: .bottom) {
+                BookmarksPopover(screen: screen)
+                    .environment(screenManager)
+            }
+
+            if selectedWallpaperType == .video {
+                HStack(spacing: DesignTokens.Spacing.sm) {
+                    Button(action: onPickVideo) {
+                        Label("Select Video", systemImage: "folder.badge.plus")
+                    }
+                    .buttonStyle(.glassProminent)
+                    .controlSize(.regular)
+                    .help("Choose a video file for this display")
+                    .accessibilityLabel("Select video")
+                    .accessibilityHint("Opens a file picker to choose a wallpaper video")
+
+                    Button(role: .destructive, action: onClearVideo) {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.glass)
+                    .controlSize(.regular)
+                    .help("Remove wallpaper video")
+                    .accessibilityLabel("Clear video")
+                    .accessibilityHint("Removes the current wallpaper video from this screen")
+                }
+            }
+
+            if isMultipleScreens {
+                Button(action: onApplyToAll) {
+                    Label("Apply to All", systemImage: "square.on.square")
+                }
+                .buttonStyle(.glass)
+                .controlSize(.regular)
+                .help("Copy this display's wallpaper and settings to every other display")
+                .accessibilityLabel("Apply to all displays")
+                .accessibilityHint("Copies the current wallpaper and settings to every other connected display")
+                .disabled(hasRuntimeError)
+            }
+        }
+    }
+
+    // MARK: - Status text / color
+
+    private var sessionStatusText: String {
+        switch wallpaperSessionSummary.wallpaperType {
+        case .html:        return "HTML Active"
+        case .metalShader: return "Shader Active"
+        case .video:       return wallpaperSessionSummary.activity == .active ? "Playing" : "Paused"
+        case .scene:       return "Scene"
+        case nil:          return "Not configured"
+        }
+    }
+
+    private var sessionStatusColor: Color {
+        switch wallpaperSessionSummary.activity {
+        case .active:   return .green
+        case .paused:   return .orange
+        case .inactive: return .secondary
+        }
+    }
+}

--- a/LiveWallpaper/Views/ScreenDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetailView.swift
@@ -36,47 +36,12 @@ struct ScreenDetailView: View {
         }
     }
 
-    @ToolbarContentBuilder
-    private var screenDetailToolbar: some ToolbarContent {
-        // Hide the type segmented control while the empty-state guide is
-        // visible — the guide IS the type picker for unconfigured screens.
-        // Showing both at once produced two parallel paths to do the same
-        // thing (toolbar `.html` segment vs. guide "HTML" card) which was
-        // confusing for first-time users on a fresh display.
-        if !shouldShowGuideEmptyState {
-            ToolbarItem(placement: .principal) {
-                Picker("Wallpaper Type", selection: $selectedWallpaperType) {
-                    ForEach(WallpaperType.allCases) { type in
-                        Text(type.rawValue).tag(type)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .fixedSize(horizontal: true, vertical: false)
-                .accessibilityLabel("Wallpaper type")
-                .accessibilityHint("Choose between video, HTML, or Metal shader wallpaper")
-                .onChange(of: selectedWallpaperType) { _, newType in
-                    switch newType {
-                    case .video:
-                        screenManager.switchToVideoWallpaper(for: screen)
-                    case .html:
-                        screenManager.switchToHTMLWallpaper(for: screen)
-                    case .metalShader, .scene:
-                        break // pickers drive activation themselves
-                    }
-                }
-            }
-        }
-        ToolbarItem(placement: .primaryAction) {
-            Button {
-                showApplyToAllConfirm = true
-            } label: {
-                Label("Apply to All", systemImage: "square.on.square")
-            }
-            .help("Copy this display's wallpaper and settings to every other display")
-            .accessibilityLabel("Apply to all displays")
-            .accessibilityHint("Copies the current wallpaper and settings to every other connected display")
-            .disabled(screenManager.screens.count <= 1 || screenManager.getConfiguration(for: screen) == nil)
-        }
+    /// Resets `pickContent` back to the 4-card guide. Wired to the
+    /// header's Back button. Does NOT touch `selectedWallpaperType` —
+    /// that remains a configured-screen toolbar control, decoupled from
+    /// the empty-state journey.
+    private func backToChooseType() {
+        draftWallpaperType = nil
     }
     /// Resolved Wallpaper Engine origin metadata for the active wallpaper, or
     /// nil when the user picked content directly. Recomputed on every body
@@ -85,32 +50,55 @@ struct ScreenDetailView: View {
         screenManager.getConfiguration(for: screen)?.wpeOrigin
     }
 
-    private var sessionStatusText: String {
-        switch wallpaperSessionSummary.wallpaperType {
-        case .html:
-            return "HTML Active"
-        case .metalShader:
-            return "Shader Active"
-        case .video:
-            return wallpaperSessionSummary.activity == .active ? "Playing" : "Paused"
-        case .scene:
-            return "Scene"
-        case nil:
-            return "Not configured"
-        }
+    /// Stages of the unconfigured-to-configured journey.
+    /// `runtimeError` is orthogonal — surfaced as a banner overlay without
+    /// changing the underlying stage.
+    enum Stage: Equatable {
+        case chooseType
+        case pickContent(WallpaperType)
+        case configured(WallpaperType)
     }
-    private var sessionStatusColor: Color {
-        switch wallpaperSessionSummary.activity {
-        case .active:
-            return .green
-        case .paused:
-            return .orange
-        case .inactive:
-            return .secondary
+
+    private var stage: Stage {
+        // Configuration is the authoritative signal. A live runtime session
+        // (rare without a config, but possible during transitions) also
+        // counts. Crucially, an in-flight preview is NOT configured —
+        // `setVideo` validation can fail and leave `hasPreviewSource` true
+        // without ever committing a configuration. Treating that as
+        // configured would expose Bookmarks / Apply-to-All / inspector
+        // before the user had any saved state to act on.
+        if let config = screenManager.getConfiguration(for: screen) {
+            return .configured(config.wallpaperType)
         }
+        if let runtime = screen.runtimeSession {
+            return .configured(runtime.wallpaperType)
+        }
+        if let draft = draftWallpaperType {
+            return .pickContent(draft)
+        }
+        // Preview without a config implies the user picked a file that's
+        // still being validated. Render as pickContent so the in-flight
+        // path doesn't briefly flash configured affordances.
+        if hasPreviewSource || previewController.hasPreviewContent {
+            return .pickContent(selectedWallpaperType)
+        }
+        return .chooseType
     }
+
+    private var isConfigured: Bool {
+        if case .configured = stage { return true }
+        return false
+    }
+
+    /// True when the right-side inspector panel should appear. Hidden in
+    /// chooseType / pickContent. For now, only Video and HTML have a
+    /// fully-realised inspector; Shader and Scene get just `Common
+    /// PlaybackInspector` once the broader capability-filter refactor
+    /// lands. Until then, gating on configured-AND-(video|html) prevents
+    /// an orphan resize handle from appearing for Shader / Scene.
     private var showsInspector: Bool {
-        selectedWallpaperType == .video || selectedWallpaperType == .html
+        guard isConfigured else { return false }
+        return selectedWallpaperType == .video || selectedWallpaperType == .html
     }
     @State private var showErrorAlert = false
     @State private var errorMessage = ""
@@ -120,6 +108,12 @@ struct ScreenDetailView: View {
     @State private var hasPreviewSource = false
 
     @State private var selectedWallpaperType: WallpaperType = .video
+    /// Pre-commit selection — set when the user clicks an HTML / Shader /
+    /// Scene card on the empty-state guide. Drives the `pickContent` stage
+    /// (Video uses a modal NSOpenPanel and skips this state). Cleared when
+    /// the user goes Back, when a configuration commits, or when the
+    /// wallpaper is cleared.
+    @State private var draftWallpaperType: WallpaperType? = nil
     @State private var selectedWallpaperMode: WallpaperMode = .single
     @State private var selectedParticleEffect: ParticleEffect = .none
     @State private var effectConfig = VideoEffectConfig.default
@@ -142,7 +136,11 @@ struct ScreenDetailView: View {
 
     @AppStorage("Inspector.PlaylistExpanded") private var isPlaylistExpanded = false
     @AppStorage("Inspector.ScheduleExpanded") private var isScheduleExpanded = false
-    @AppStorage("Inspector.EnvironmentExpanded") private var isEnvironmentExpanded = true
+    // Default `false` so a freshly-configured display shows a tight inspector;
+    // power users can pin it expanded once they discover it. Changed from
+    // `true` during the IA redesign — Environment is type-specific
+    // (particles / weather) and shouldn't dominate vertical space by default.
+    @AppStorage("Inspector.EnvironmentExpanded") private var isEnvironmentExpanded = false
     @AppStorage("Inspector.ColorExpanded") private var isColorExpanded = false
     @AppStorage("Inspector.Width") private var inspectorWidth = Double(DesignTokens.Inspector.defaultWidth)
     @State private var liveInspectorWidth: Double?
@@ -152,99 +150,39 @@ struct ScreenDetailView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(alignment: .center, spacing: 14) {
-                ZStack {
-                    Circle().fill(Color.accentColor.opacity(0.15)).frame(width: 44, height: 44)
-                    Image(systemName: "display").font(.system(size: 18)).foregroundStyle(Color.accentColor)
-                }
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 8) {
-                        Text(screen.name).font(.system(size: 18, weight: .semibold)).lineLimit(1)
+            // Single-owner header for the entire top zone. Always rendered
+            // so the page structure stays identical across stages — only
+            // the right-side actions vary. The body's `.padding(.top, 8)`
+            // below keeps the header's avatar circle clear of the parent
+            // `ContentView`'s `.navigation`-placement gear icon, which
+            // lives in the transparent-titlebar zone.
+            ScreenDetailHeader(
+                screen: screen,
+                stage: stage,
+                wallpaperSessionSummary: wallpaperSessionSummary,
+                isMultipleScreens: screenManager.screens.count > 1,
+                hasRuntimeError: runtimeError != nil,
+                selectedWallpaperType: $selectedWallpaperType,
+                showBookmarks: $showBookmarks,
+                refreshRateHz: getScreenRefreshRate(),
+                onReload: { screenManager.reloadWallpaperForScreen(screen) },
+                onPickVideo: showFilePicker,
+                onClearVideo: clearVideo,
+                onBack: backToChooseType,
+                onApplyToAll: { showApplyToAllConfirm = true }
+            )
 
-                        Button(action: { screenManager.reloadWallpaperForScreen(screen) }) {
-                            Image(systemName: "arrow.clockwise")
-                                .font(.system(size: 12, weight: .bold))
-                                .foregroundStyle(.secondary)
-                        }
-                        .buttonStyle(.plain)
-                        .help("Reload display content")
-                        .accessibilityLabel("Reload display")
-                        .accessibilityHint("Reloads the wallpaper content for this screen")
-                    }
-                    HStack(spacing: 8) {
-                        InfoBadge(icon: "arrow.up.left.and.arrow.down.right", text: "\(Int(screen.frame.width))×\(Int(screen.frame.height))")
-                        InfoBadge(icon: "gauge.medium", text: "\(getScreenRefreshRate()) Hz")
-                        if wallpaperSessionSummary.isConfigured {
-                            HStack(spacing: 4) {
-                                Image(systemName: "circle.fill")
-                                    .font(.system(size: 6))
-                                    .foregroundStyle(sessionStatusColor)
-                                    .symbolEffect(.pulse, options: .repeat(.continuous), isActive: wallpaperSessionSummary.activity == .active)
-                                Text(sessionStatusText).font(.caption).foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                }
-                Spacer()
-
-                Button {
-                    showBookmarks = true
-                } label: {
-                    Label("Bookmarks", systemImage: "bookmark.fill")
-                }
-                .buttonStyle(.glass)
-                .controlSize(.regular)
-                .help("Saved video / HTML / shader shortcuts")
-                .accessibilityLabel("Bookmarks")
-                .popover(isPresented: $showBookmarks, arrowEdge: .bottom) {
-                    BookmarksPopover(screen: screen)
-                        .environment(screenManager)
-                }
-
-                if selectedWallpaperType == .video {
-                    HStack(spacing: 8) {
-                        Button {
-                            showFilePicker()
-                        } label: {
-                            Label("Select Video", systemImage: "folder.badge.plus")
-                        }
-                        .buttonStyle(.glassProminent)
-                        .controlSize(.regular)
-                        .help("Choose a video file for this display")
-                        .accessibilityLabel("Select video")
-                        .accessibilityHint("Opens a file picker to choose a wallpaper video")
-
-                        Button(role: .destructive) {
-                            clearVideo()
-                        } label: {
-                            Image(systemName: "trash")
-                        }
-                        .buttonStyle(.glass)
-                        .controlSize(.regular)
-                        .help("Remove wallpaper video")
-                        .accessibilityLabel("Clear video")
-                        .accessibilityHint("Removes the current wallpaper video from this screen")
-                    }
-                }
+            if isConfigured {
+                runtimeErrorBannerView
+                Divider()
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 14)
-
-            runtimeErrorBannerView
-
-            Divider()
 
             HStack(spacing: 0) {
                 ZStack {
                     Color(NSColor.underPageBackgroundColor)
 
-                    if shouldShowGuideEmptyState {
-                        EmptyStateGuideView(
-                            onChooseVideo: triggerVideoGuideAction,
-                            onChooseHTML: triggerHTMLGuideAction,
-                            onChooseShader: triggerShaderGuideAction,
-                            onChooseScene: triggerSceneGuideAction
-                        )
+                    if case .chooseType = stage {
+                        EmptyStateGuideView(onChoose: handleGuideCardTap)
                     } else if selectedWallpaperType == .video {
                         if isLoading {
                             ScreenDetailLoadingView()
@@ -351,7 +289,31 @@ struct ScreenDetailView: View {
             .transaction(value: selectedWallpaperType) { $0.animation = nil }
             .transaction(value: liveInspectorWidth) { $0.animation = nil }
         }
-        .toolbar { screenDetailToolbar }
+        // The header's type Picker fires this onChange. Gated by both
+        // `.configured` AND `newType != activeType` because
+        // `loadScreenConfiguration()` programmatically syncs
+        // `selectedWallpaperType = config.wallpaperType` after a config
+        // load, which would otherwise re-fire `switchToVideoWallpaper`
+        // and trigger redundant runtime restore + visible flicker.
+        .onChange(of: selectedWallpaperType) { _, newType in
+            guard case .configured(let activeType) = stage,
+                  newType != activeType else { return }
+            switch newType {
+            case .video:
+                screenManager.switchToVideoWallpaper(for: screen)
+            case .html:
+                screenManager.switchToHTMLWallpaper(for: screen)
+            case .metalShader, .scene:
+                break // pickers drive activation themselves
+            }
+        }
+        // Top padding clears the parent toolbar zone. macOS
+        // `.fullSizeContentView` lets body content render under the
+        // transparent titlebar, so we must reserve the standard ~28pt
+        // toolbar height to keep the header's avatar from colliding with
+        // ContentView's `.navigation`-placement gear icon and the
+        // window's traffic-light controls.
+        .padding(.top, 28)
         .confirmationDialog(
             "Apply this wallpaper to every other display?",
             isPresented: $showApplyToAllConfirm
@@ -398,7 +360,11 @@ struct ScreenDetailView: View {
 
     @ViewBuilder
     private var inspectorPanel: some View {
-        if selectedWallpaperType == .video || selectedWallpaperType == .html {
+        // Stage-aligned: defer to `showsInspector` instead of re-checking
+        // the type here. Without this, the inspector would render during
+        // pickContent (e.g. user clicked HTML card → selectedWallpaperType
+        // == .html → inspector appeared before content was committed).
+        if showsInspector {
             ScrollView {
                 GlassEffectContainer(spacing: 16) {
                     VStack(spacing: 16) {
@@ -702,6 +668,9 @@ struct ScreenDetailView: View {
         lockScreenExtracted = false
 
         if let config = screenManager.getConfiguration(for: screen) {
+            // Configuration committed → clear any in-flight draft so the
+            // stage transitions to `.configured` cleanly.
+            draftWallpaperType = nil
             if playbackSpeed != config.playbackSpeed { playbackSpeed = config.playbackSpeed }
             if selectedFitMode != config.fitMode { selectedFitMode = config.fitMode }
 
@@ -734,12 +703,19 @@ struct ScreenDetailView: View {
             shufflePlaylist = false
             playlistRotationMinutes = nil
             scheduleSlots = []
+            // Reset selected type to default — the user will re-pick via
+            // the empty-state guide. Don't carry over the prior config's
+            // type as the "default": the IA decision is that clearing
+            // returns to chooseType, not the last-known type.
             selectedWallpaperType = .video
             selectedWallpaperMode = .single
             htmlSource = nil
             htmlConfig = .default
             hasPreviewSource = screen.videoPlayer?.videoURL != nil
             loadPreviewPosterIfNeeded()
+            // Wallpaper went away (cleared, deleted, never set) — drop any
+            // stale draft so the screen re-enters chooseType cleanly.
+            draftWallpaperType = nil
         }
     }
 
@@ -853,41 +829,24 @@ struct ScreenDetailView: View {
 
     // MARK: - Empty State Guide
 
-    /// True when this screen has no persisted configuration AND no live
-    /// runtime session AND the user is currently looking at the default
-    /// `.video` tab. Switching the toolbar segmented control to .html /
-    /// .scene / .metalShader exits the guide so those tabs can show their
-    /// own configuration UI — clicking any non-Video guide card does the
-    /// same flip and lands on that type's existing empty state.
-    private var shouldShowGuideEmptyState: Bool {
-        if isLoading { return false }
-        if selectedWallpaperType != .video { return false }
-        if screenManager.getConfiguration(for: screen) != nil { return false }
-        if screen.runtimeSession != nil { return false }
-        if hasPreviewSource || previewController.hasPreviewContent { return false }
-        return true
-    }
-
-    /// Video card → already on `.video`, so just open the existing file
-    /// picker. Cancellation returns the user to the guide unchanged.
-    private func triggerVideoGuideAction() {
-        showFilePicker()
-    }
-
-    /// HTML / Shader / Scene cards → flip the toolbar's selected type so
-    /// `shouldShowGuideEmptyState` returns false and that type's existing
-    /// empty state takes over (URL/file/folder picker, shader presets,
-    /// Workshop browser respectively).
-    private func triggerHTMLGuideAction() {
-        selectedWallpaperType = .html
-    }
-
-    private func triggerShaderGuideAction() {
-        selectedWallpaperType = .metalShader
-    }
-
-    private func triggerSceneGuideAction() {
-        selectedWallpaperType = .scene
+    /// Routes a card tap from `EmptyStateGuideView` to the correct flow.
+    /// Video uses a modal NSOpenPanel — no draft state needed; modal cancel
+    /// returns the user to chooseType automatically. Other types stage a
+    /// `draftWallpaperType` so the per-type section view (HTMLSourceSection
+    /// / ShaderWallpaperSection / WPESceneSection) takes over until the
+    /// user either picks something (commits config → `configured`) or hits
+    /// the toolbar Back button (clears draft → `chooseType`).
+    private func handleGuideCardTap(_ type: WallpaperType) {
+        switch type {
+        case .video:
+            showFilePicker()
+        case .html, .metalShader, .scene:
+            // Set both: draft drives stage; selectedWallpaperType drives
+            // the existing main-content if/else cascade and the inspector
+            // capability filters once configured.
+            draftWallpaperType = type
+            selectedWallpaperType = type
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace the split-ownership top region of `ScreenDetailView` with a single `ScreenDetailHeader` component. The previous design had 3 layers (parent toolbar, child toolbar, body header HStack) competing for the same titlebar pixel zone, which kept producing visual collisions whenever stage-conditional visibility logic was edited.
- Each user-journey stage now produces a deterministic layout owned by one switch:
  - **chooseType** — identity block (avatar + name + InfoBadges) only; empty trailing edge keeps the focal 4-card grid uncluttered.
  - **pickContent** — leading-edge ◀ Back chevron + identity; no competing trailing actions.
  - **configured** — full identity + reload + status pill, plus a trailing action bar in scope order: type picker → Bookmarks → video Select / Trash → Apply to All anchored far-right.
- `ScreenDetailView.toolbar` is now empty. The body owns the entire top region and reserves 28pt safe-area padding to clear the parent toolbar's gear icon and traffic-light controls on `.fullSizeContentView` windows.

## Why
On macOS 26 with `.fullSizeContentView` + transparent titlebar, body content renders under the titlebar. The previous design coordinated visibility across 3 owners by hand, so every stage edit risked a visual collision (the most recent example: the gear icon appearing to overlap the display avatar in chooseType). Centralising ownership makes this class of bug structurally unrepresentable.

The user explicitly asked for the display avatar + name + badges to remain visible across all 3 stages so the page structure stays identical and only the right-side actions vary.

## Multi-model audit results
- **codex** (75/100 → patched): hard-coded 8pt padding lifted to 28pt to match the macOS toolbar zone; `onChange(selectedWallpaperType)` now requires `newType != activeType` to avoid redundant `switchTo*` runtime restore calls during programmatic config sync.
- **gemini** (88/100 → patched): Back button moved to the leading edge with a `.plain` chevron (was a `.glass` capsule on the trailing edge); Apply to All anchored far-right; avatar `.accessibilityHidden(true)`; status pill collapsed to a single VoiceOver utterance (`Status: Playing`).

## Test plan
- [x] `xcodebuild test` — 502/502 unit tests pass.
- [ ] Manual screenshot verification (macOS Screen Recording permission was unavailable for automated capture):
  - [ ] **chooseType**: header avatar/name visible without overlapping the parent gear icon — at least 28pt clearance.
  - [ ] **pickContent**: ◀ Back appears at the leading edge, identity follows; clicking returns to chooseType.
  - [ ] **configured**: trailing actions render in order `[type] [Bookmarks] [Video / Trash] [Apply to All]`.
  - [ ] Min window 1080×650: 4-card grid + header on screen with no scrolling.
  - [ ] Multi-display → single-display hot-unplug: Apply to All disappears without the layout jumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)