### PR TITLE
fix(window): install empty NSToolbar to fix sidebar/detail safe-area collisions

### DIFF
--- a/LiveWallpaper/LiveWallpaperApp.swift
+++ b/LiveWallpaper/LiveWallpaperApp.swift
@@ -190,7 +190,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.title = L10n.Window.settingsTitle
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
-        window.toolbar = nil
+        // Empty NSToolbar (rather than `nil`) lets macOS reserve the
+        // traffic-light + titlebar safe area for both the sidebar and the
+        // detail body automatically; SwiftUI `.toolbar` modifiers in
+        // `ContentView` / `ScreenDetailView` are then bridged into items
+        // on this NSToolbar by the hosting view. `unifiedCompact` keeps
+        // the chrome thin and pairs cleanly with `titlebarAppearsTransparent`
+        // so the Liquid Glass background still flows through.
+        // `titlebarSeparatorStyle = .none` replaces the deprecated
+        // `NSToolbar.showsBaselineSeparator` for hiding the hairline
+        // between toolbar and content.
+        let toolbar = NSToolbar(identifier: "LiveWallpaperSettingsWindowToolbar")
+        window.toolbar = toolbar
+        window.toolbarStyle = .unifiedCompact
+        window.titlebarSeparatorStyle = .none
         window.center()
         window.contentView = NSHostingView(rootView: contentView)
         window.delegate = self

--- a/LiveWallpaper/Views/ContentView.swift
+++ b/LiveWallpaper/Views/ContentView.swift
@@ -222,13 +222,6 @@ struct Sidebar: View {
             }
         }
         .listStyle(.sidebar)
-        // Reserve the standard ~28pt titlebar height as a top safe area so
-        // the first sidebar row never renders under the window's
-        // traffic-light controls. `.fullSizeContentView` lets content
-        // bleed under the transparent titlebar otherwise.
-        .safeAreaInset(edge: .top, spacing: 0) {
-            Color.clear.frame(height: 28)
-        }
         .navigationSplitViewColumnWidth(
             min: SettingsWindowMetrics.sidebarColumnWidth,
             ideal: SettingsWindowMetrics.sidebarColumnWidth,


### PR DESCRIPTION
## Summary
Install an empty `NSToolbar` on the Settings window so macOS reserves the titlebar safe area for both sidebar and detail body automatically. Removes the brittle `.safeAreaInset(.top, 28)` workaround on the sidebar's `List`.

## Why
The Settings window combined `.fullSizeContentView` + `titlebarAppearsTransparent` + `window.toolbar = nil`. With no NSToolbar, macOS does NOT reserve a titlebar safe area for body content, so:
- Sidebar `List` rendered its first row directly under the traffic-light controls (red/yellow/green dots overlapping the BenQ entry).
- Detail content needed multi-step manual padding to clear the parent gear icon, which kept producing visual collisions whenever stage-conditional visibility changed.

This was the structural root cause behind several previous "fix it / break it / fix it again" passes.

## Change
- `LiveWallpaperApp.swift` — `window.toolbar = NSToolbar(identifier: …)`, `toolbarStyle = .unifiedCompact`, `titlebarSeparatorStyle = .none` (modern replacement for the deprecated `NSToolbar.showsBaselineSeparator`).
- `ContentView.swift` — drop the now-redundant `.safeAreaInset(.top, 28)` from the sidebar `List`.

SwiftUI `.toolbar { }` modifiers in `ContentView` (gear icon) and `ScreenDetailView` (Back / type picker / Apply to All) automatically bridge into `NSToolbarItem`s on the new toolbar; no other changes required.

## Multi-model audit
- **codex 91/100 PASS** — one Low (deprecated `showsBaselineSeparator`) → applied (now `titlebarSeparatorStyle = .none`).
- **gemini 100/100 PASS** — confirms `.unifiedCompact` integrates with the Liquid Glass titlebar without a chrome stripe; the empty toolbar area becomes natively draggable so we don't need `isMovableByWindowBackground`.

## Test plan
- [x] `xcodebuild build` — succeeds.
- [x] `xcodebuild test` — 503/503 unit tests pass.
- [ ] Manual visual check (since automated screenshot was unavailable):
  - [ ] Settings window opens — traffic lights sit cleanly above the sidebar's "Displays" header (no overlap).
  - [ ] Detail toolbar items (gear / Back / type picker / Apply to All) sit horizontally in the titlebar zone, **not** overlapping the body's display avatar / name.
  - [ ] Body header and split-view content begin clean below the toolbar with no extra gap.
  - [ ] Window can be dragged from the empty toolbar area (replaces the previous `isMovableByWindowBackground` reliance).
  - [ ] Visual style is still Liquid Glass (transparent titlebar, no hairline separator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)