### PR TITLE
fix(window): .unified toolbar style + sidebar toggle item to fix safe-area collision

### DIFF
--- a/LiveWallpaper/LiveWallpaperApp.swift
+++ b/LiveWallpaper/LiveWallpaperApp.swift
@@ -194,15 +194,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // traffic-light + titlebar safe area for both the sidebar and the
         // detail body automatically; SwiftUI `.toolbar` modifiers in
         // `ContentView` / `ScreenDetailView` are then bridged into items
-        // on this NSToolbar by the hosting view. `unifiedCompact` keeps
-        // the chrome thin and pairs cleanly with `titlebarAppearsTransparent`
-        // so the Liquid Glass background still flows through.
-        // `titlebarSeparatorStyle = .none` replaces the deprecated
-        // `NSToolbar.showsBaselineSeparator` for hiding the hairline
-        // between toolbar and content.
+        // on this NSToolbar by the hosting view. `unified` is the standard
+        // height Apple uses across Xcode / Mail / System Settings — it
+        // gives the segmented type picker enough room and pairs cleanly
+        // with `titlebarAppearsTransparent` so the Liquid Glass background
+        // still flows through. `titlebarSeparatorStyle = .none` replaces
+        // the deprecated `NSToolbar.showsBaselineSeparator` for hiding the
+        // hairline between toolbar and content.
         let toolbar = NSToolbar(identifier: "LiveWallpaperSettingsWindowToolbar")
         window.toolbar = toolbar
-        window.toolbarStyle = .unifiedCompact
+        window.toolbarStyle = .unified
         window.titlebarSeparatorStyle = .none
         window.center()
         window.contentView = NSHostingView(rootView: contentView)

--- a/LiveWallpaper/Views/ContentView.swift
+++ b/LiveWallpaper/Views/ContentView.swift
@@ -222,10 +222,37 @@ struct Sidebar: View {
             }
         }
         .listStyle(.sidebar)
+        // Standard macOS sidebar toggle in the leading toolbar slot — same
+        // pattern Xcode / Mail / System Settings use. Two roles:
+        //   1. Lets users collapse the navigator (matches macOS muscle
+        //      memory: ⌘⌃S, View → Hide Sidebar).
+        //   2. Forces the sidebar column to contribute at least one item
+        //      to the global NSToolbar; without it, macOS shrinks the
+        //      sidebar's toolbar zone to zero height and the first List
+        //      row renders directly underneath the traffic-light controls.
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(action: toggleSidebar) {
+                    Image(systemName: "sidebar.leading")
+                }
+                .help(Text("Toggle Sidebar"))
+                .accessibilityLabel(Text("Toggle Sidebar"))
+            }
+        }
         .navigationSplitViewColumnWidth(
             min: SettingsWindowMetrics.sidebarColumnWidth,
             ideal: SettingsWindowMetrics.sidebarColumnWidth,
             max: SettingsWindowMetrics.sidebarColumnMaxWidth
+        )
+    }
+
+    /// Standard AppKit responder-chain sidebar toggle. Routes through
+    /// `NSSplitViewController.toggleSidebar(_:)` which the SwiftUI
+    /// `NavigationSplitView` host implements.
+    private func toggleSidebar() {
+        NSApp.keyWindow?.firstResponder?.tryToPerform(
+            #selector(NSSplitViewController.toggleSidebar(_:)),
+            with: nil
         )
     }
 


### PR DESCRIPTION
## Summary
Follow-up to [#43](https://github.com/Paradox07127/LiveWallpaper/pull/43). Visual verification revealed two regressions that the empty NSToolbar alone didn't address. This PR brings the layout in line with Apple's standard multi-column window pattern (Xcode / Mail / System Settings).

## What was wrong after #43
1. **Sidebar still overlapped traffic lights.** Empty NSToolbar reserved height only on columns that contributed at least one `ToolbarItem`. The Sidebar had none → its column toolbar zone collapsed to zero → first List row rendered under the traffic-light controls.
2. **Type segmented picker squeezed.** `.unifiedCompact` packed the gear + Apply-to-All + 4-segment Wallpaper Type picker into a compressed bar; the picker font/padding visibly shrank.

## Change
- `LiveWallpaperApp.swift` — `toolbarStyle = .unified` (was `.unifiedCompact`). Standard height across Apple's multi-column apps.
- `ContentView.swift` — add a `.navigation`-placement sidebar toggle to the `Sidebar` view's `.toolbar`. Two roles:
  - Matches Apple's universal sidebar UX (⌘⌃S muscle memory, View → Hide Sidebar).
  - Guarantees the sidebar column contributes a `ToolbarItem` so macOS reserves the standard titlebar safe area for it.
- Toggle is wired through the AppKit responder chain (`NSSplitViewController.toggleSidebar(_:)`); no extra state to manage.

## Test plan
- [x] `xcodebuild build` — succeeds.
- [x] `xcodebuild test` — 503/503 unit tests pass.
- [ ] Manual visual check:
  - [ ] Sidebar's "Displays" header sits cleanly below the traffic-light controls (no overlap).
  - [ ] Sidebar toggle button visible in the leading toolbar slot; clicking it collapses/expands the sidebar.
  - [ ] Detail toolbar items (gear / type picker / Apply to All) at proper `.unified` height; segmented type picker no longer compressed.
  - [ ] Detail body (display avatar + name + action buttons) starts cleanly below the toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)