### PR TITLE
revert: undo PR #37 (single-owner header) and PR #43 (NSToolbar)

### DIFF
--- a/LiveWallpaper/LiveWallpaperApp.swift
+++ b/LiveWallpaper/LiveWallpaperApp.swift
@@ -190,20 +190,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.title = L10n.Window.settingsTitle
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
-        // Empty NSToolbar (rather than `nil`) lets macOS reserve the
-        // traffic-light + titlebar safe area for both the sidebar and the
-        // detail body automatically; SwiftUI `.toolbar` modifiers in
-        // `ContentView` / `ScreenDetailView` are then bridged into items
-        // on this NSToolbar by the hosting view. `unifiedCompact` keeps
-        // the chrome thin and pairs cleanly with `titlebarAppearsTransparent`
-        // so the Liquid Glass background still flows through.
-        // `titlebarSeparatorStyle = .none` replaces the deprecated
-        // `NSToolbar.showsBaselineSeparator` for hiding the hairline
-        // between toolbar and content.
-        let toolbar = NSToolbar(identifier: "LiveWallpaperSettingsWindowToolbar")
-        window.toolbar = toolbar
-        window.toolbarStyle = .unifiedCompact
-        window.titlebarSeparatorStyle = .none
+        window.toolbar = nil
         window.center()
         window.contentView = NSHostingView(rootView: contentView)
         window.delegate = self

--- a/LiveWallpaper/Views/ContentView.swift
+++ b/LiveWallpaper/Views/ContentView.swift
@@ -222,6 +222,13 @@ struct Sidebar: View {
             }
         }
         .listStyle(.sidebar)
+        // Reserve the standard ~28pt titlebar height as a top safe area so
+        // the first sidebar row never renders under the window's
+        // traffic-light controls. `.fullSizeContentView` lets content
+        // bleed under the transparent titlebar otherwise.
+        .safeAreaInset(edge: .top, spacing: 0) {
+            Color.clear.frame(height: 28)
+        }
         .navigationSplitViewColumnWidth(
             min: SettingsWindowMetrics.sidebarColumnWidth,
             ideal: SettingsWindowMetrics.sidebarColumnWidth,

--- a/LiveWallpaper/Views/ScreenDetail/EmptyStateGuideView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/EmptyStateGuideView.swift
@@ -1,94 +1,124 @@
 import SwiftUI
 
-/// Focal 2×2 card grid shown on a fresh display that has no saved
-/// configuration. Mirrors `WallpaperType` 1:1 so users build a single
-/// mental model — pick ONE of four types, the rest of the UI follows.
+/// First-impression card grid shown on a display that has no saved
+/// configuration. Mirrors the toolbar's segmented control 1:1 — exactly
+/// four cards (Video / HTML / Shader / Scene) so users build a single
+/// mental model for "wallpaper type" instead of competing
+/// type-vs-source vocabularies.
 ///
-/// Compact by design: the layout fits inside the minimum window content
-/// height (650pt) without scrolling, so first-time users on small windows
-/// see the entire palette at a glance.
+/// Once any card is clicked the screen leaves this guide:
+/// the Video card opens the file picker; the other three flip the
+/// `selectedWallpaperType` and let the per-type empty state take over.
 struct EmptyStateGuideView: View {
-    let onChoose: (WallpaperType) -> Void
+    let onChooseVideo: () -> Void
+    let onChooseHTML: () -> Void
+    let onChooseShader: () -> Void
+    let onChooseScene: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    private static let cards: [GuideCardModel] = [
-        GuideCardModel(
-            type: .video,
-            iconTint: .blue,
-            subtitle: "MP4 / MOV with playlists and schedules.",
-            actionLabel: "Pick Video…",
-            actionIcon: "folder"
-        ),
-        GuideCardModel(
-            type: .html,
-            iconTint: .green,
-            subtitle: "Web page or local HTML file.",
-            actionLabel: "Use HTML",
-            actionIcon: "arrow.right"
-        ),
-        GuideCardModel(
-            type: .metalShader,
-            iconTint: .orange,
-            subtitle: "Built-in animated GPU shaders.",
-            actionLabel: "Use Shader",
-            actionIcon: "arrow.right"
-        ),
-        GuideCardModel(
-            type: .scene,
-            iconTint: .purple,
-            subtitle: "Imported Steam Workshop scenes.",
-            actionLabel: "Use Scene",
-            actionIcon: "arrow.right"
-        )
-    ]
-
     var body: some View {
-        VStack(spacing: 14) {
-            LazyVGrid(
-                columns: [GridItem(.adaptive(minimum: 240, maximum: 320), spacing: 12)],
-                spacing: 12
-            ) {
-                ForEach(Self.cards, id: \.type) { card in
-                    GuideCard(model: card) { onChoose(card.type) }
-                }
-            }
+        ScrollView {
+            VStack(spacing: 24) {
+                header
 
-            hint
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 240, maximum: 320), spacing: 16)],
+                    spacing: 16
+                ) {
+                    GuideCard(
+                        icon: "film",
+                        iconTint: .blue,
+                        title: "Video",
+                        subtitle: "MP4 / MOV files. Supports playlists and time-of-day schedules.",
+                        actionTitle: "Pick Video…",
+                        actionSystemImage: "folder",
+                        action: onChooseVideo
+                    )
+
+                    GuideCard(
+                        icon: "globe",
+                        iconTint: .green,
+                        title: "HTML",
+                        subtitle: "Any web page or local HTML file. Particles and weather still apply.",
+                        actionTitle: "Use HTML",
+                        actionSystemImage: "arrow.right",
+                        action: onChooseHTML
+                    )
+
+                    GuideCard(
+                        icon: "wand.and.stars",
+                        iconTint: .orange,
+                        title: "Shader",
+                        subtitle: "Built-in animated GPU shaders. Lightweight on the battery.",
+                        actionTitle: "Use Shader",
+                        actionSystemImage: "arrow.right",
+                        action: onChooseShader
+                    )
+
+                    GuideCard(
+                        icon: "cube.transparent",
+                        iconTint: .purple,
+                        title: "Scene",
+                        subtitle: "Steam Workshop scenes imported from Wallpaper Engine.",
+                        actionTitle: "Use Scene",
+                        actionSystemImage: "arrow.right",
+                        action: onChooseScene
+                    )
+                }
+                .padding(.horizontal, 4)
+
+                hint
+            }
+            .padding(.horizontal, 28)
+            .padding(.vertical, 32)
+            .frame(maxWidth: 760)
+            .frame(maxWidth: .infinity)
         }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 20)
-        .frame(maxWidth: 720)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    private var header: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 36, weight: .light))
+                .foregroundStyle(Color.accentColor)
+                .symbolRenderingMode(.hierarchical)
+                .accessibilityHidden(true)
+
+            Text("Choose a wallpaper type")
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .accessibilityAddTraits(.isHeader)
+
+            Text("Each display can run a different type. You can switch from the toolbar after picking one.")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 540)
+        }
+    }
+
     private var hint: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 8) {
             Image(systemName: "arrow.down.doc")
-                .font(.system(size: 11, weight: .medium))
+                .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.tertiary)
                 .accessibilityHidden(true)
-            Text("Or drag a video, HTML file, or folder onto this window.")
-                .font(.system(size: 10))
+            Text("Or drag a video, HTML file, or folder anywhere on this window.")
+                .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
         }
+        .padding(.top, 8)
     }
 }
 
-// MARK: - Card model
-
-private struct GuideCardModel {
-    let type: WallpaperType
-    let iconTint: Color
-    let subtitle: String
-    let actionLabel: String
-    let actionIcon: String
-}
-
-// MARK: - Card view
-
 private struct GuideCard: View {
-    let model: GuideCardModel
+    let icon: String
+    let iconTint: Color
+    let title: String
+    let subtitle: String
+    let actionTitle: String
+    let actionSystemImage: String
     let action: () -> Void
 
     @State private var isHovering = false
@@ -99,41 +129,42 @@ private struct GuideCard: View {
 
     var body: some View {
         Button(action: action) {
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 12) {
                 ZStack {
                     Circle()
-                        .fill(model.iconTint.opacity(0.15))
-                        .frame(width: 36, height: 36)
-                    Image(systemName: model.type.iconName)
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundStyle(model.iconTint)
+                        .fill(iconTint.opacity(0.15))
+                        .frame(width: 44, height: 44)
+                    Image(systemName: icon)
+                        .font(.system(size: 20, weight: .medium))
+                        .foregroundStyle(iconTint)
                         .symbolRenderingMode(.hierarchical)
                 }
                 .accessibilityHidden(true)
 
-                Text(model.type.rawValue)
-                    .font(.system(size: 14, weight: .semibold))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 15, weight: .semibold))
+                    Text(subtitle)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-                Text(model.subtitle)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 6)
 
-                Spacer(minLength: 4)
-
-                Label(model.actionLabel, systemImage: model.actionIcon)
-                    .font(.system(size: 11, weight: .semibold))
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
+                Label(actionTitle, systemImage: actionSystemImage)
+                    .font(.system(size: 12, weight: .semibold))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
                     .background(
                         Capsule()
                             .fill(Color.accentColor.opacity(isActive ? 0.30 : 0.18))
                     )
                     .foregroundStyle(Color.accentColor)
             }
-            .padding(DesignTokens.Spacing.md)
-            .frame(minHeight: 124, alignment: .topLeading)
+            .padding(DesignTokens.Spacing.lg)
+            .frame(minHeight: 168, alignment: .topLeading)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(RoundedRectangle(cornerRadius: DesignTokens.Corner.lg, style: .continuous))
             .background(
@@ -162,8 +193,7 @@ private struct GuideCard: View {
         .animation(DesignTokens.motion(reduceMotion, .spring(response: 0.32, dampingFraction: 0.86)), value: isHovering)
         .animation(DesignTokens.motion(reduceMotion, .spring(response: 0.32, dampingFraction: 0.86)), value: isFocused)
         .onHover { isHovering = $0 }
-        .accessibilityLabel(Text("\(model.type.rawValue) wallpaper type"))
-        .accessibilityHint(model.subtitle)
-        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel("\(title) wallpaper type")
+        .accessibilityHint(subtitle)
     }
 }

--- a/LiveWallpaper/Views/ScreenDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetailView.swift
@@ -36,133 +36,15 @@ struct ScreenDetailView: View {
         }
     }
 
-    /// Body-level header — identity (avatar + name + reload + badges +
-    /// status pill) on the left, per-display action buttons on the right.
-    /// Toolbar items (type picker, Apply-to-All, Back) live separately in
-    /// `screenDetailToolbar` so they get the toolbar's natural width
-    /// without competing with these inline controls.
-    @ViewBuilder
-    private var inlineBodyHeader: some View {
-        HStack(alignment: .center, spacing: 14) {
-            ZStack {
-                Circle().fill(Color.accentColor.opacity(0.15)).frame(width: 44, height: 44)
-                Image(systemName: "display").font(.system(size: 18)).foregroundStyle(Color.accentColor)
-            }
-            .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 8) {
-                    Text(screen.name).font(.system(size: 18, weight: .semibold)).lineLimit(1)
-
-                    if isConfigured {
-                        Button(action: { screenManager.reloadWallpaperForScreen(screen) }) {
-                            Image(systemName: "arrow.clockwise")
-                                .font(.system(size: 12, weight: .bold))
-                                .foregroundStyle(.secondary)
-                        }
-                        .buttonStyle(.plain)
-                        .help(Text("Reload display content"))
-                        .accessibilityLabel(Text("Reload display"))
-                        .accessibilityHint(Text("Reloads the wallpaper content for this screen"))
-                    }
-                }
-                HStack(spacing: 8) {
-                    InfoBadge(icon: "arrow.up.left.and.arrow.down.right", text: "\(Int(screen.frame.width))×\(Int(screen.frame.height))")
-                    InfoBadge(icon: "gauge.medium", text: "\(getScreenRefreshRate()) Hz")
-                    if isConfigured, wallpaperSessionSummary.isConfigured {
-                        sessionStatusPill
-                    }
-                }
-            }
-            Spacer()
-
-            if isConfigured {
-                Button {
-                    showBookmarks = true
-                } label: {
-                    Label("Bookmarks", systemImage: "bookmark.fill")
-                }
-                .buttonStyle(.glass)
-                .controlSize(.regular)
-                .help(Text("Saved video / HTML / shader shortcuts"))
-                .accessibilityLabel(Text("Bookmarks"))
-                .popover(isPresented: $showBookmarks, arrowEdge: .bottom) {
-                    BookmarksPopover(screen: screen)
-                        .environment(screenManager)
-                }
-
-                if selectedWallpaperType == .video {
-                    HStack(spacing: 8) {
-                        Button(action: showFilePicker) {
-                            Label("Select Video", systemImage: "folder.badge.plus")
-                        }
-                        .buttonStyle(.glassProminent)
-                        .controlSize(.regular)
-                        .help(Text("Choose a video file for this display"))
-                        .accessibilityLabel(Text("Select video"))
-                        .accessibilityHint(Text("Opens a file picker to choose a wallpaper video"))
-
-                        Button(role: .destructive, action: clearVideo) {
-                            Image(systemName: "trash")
-                        }
-                        .buttonStyle(.glass)
-                        .controlSize(.regular)
-                        .help(Text("Remove wallpaper video"))
-                        .accessibilityLabel(Text("Clear video"))
-                        .accessibilityHint(Text("Removes the current wallpaper video from this screen"))
-                    }
-                }
-            }
-        }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 14)
-    }
-
-    private var sessionStatusPill: some View {
-        HStack(spacing: 4) {
-            Image(systemName: "circle.fill")
-                .font(.system(size: 6))
-                .foregroundStyle(sessionStatusColor)
-                .symbolEffect(.pulse, options: .repeat(.continuous), isActive: wallpaperSessionSummary.activity == .active)
-            Text(sessionStatusText).font(.caption).foregroundStyle(.secondary)
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Text("Status: \(sessionStatusText)"))
-    }
-
-    private var sessionStatusText: String {
-        switch wallpaperSessionSummary.wallpaperType {
-        case .html:        return "HTML Active"
-        case .metalShader: return "Shader Active"
-        case .video:       return wallpaperSessionSummary.activity == .active ? "Playing" : "Paused"
-        case .scene:       return "Scene"
-        case nil:          return "Not configured"
-        }
-    }
-
-    private var sessionStatusColor: Color {
-        switch wallpaperSessionSummary.activity {
-        case .active:   return .green
-        case .paused:   return .orange
-        case .inactive: return .secondary
-        }
-    }
-
-    /// Toolbar items — stage-gated. Type picker + Apply-to-All belong here
-    /// (not in the body header) so they get the toolbar's natural width
-    /// without crowding the inline action buttons.
     @ToolbarContentBuilder
     private var screenDetailToolbar: some ToolbarContent {
-        if case .pickContent = stage {
-            ToolbarItem(placement: .navigation) {
-                Button(action: backToChooseType) {
-                    Label("Back", systemImage: "chevron.left")
-                }
-                .help(Text("Return to wallpaper type selection"))
-                .accessibilityLabel(Text("Back to wallpaper type selection"))
-            }
-        }
-        if case .configured = stage {
-            ToolbarItem(placement: .automatic) {
+        // Hide the type segmented control while the empty-state guide is
+        // visible — the guide IS the type picker for unconfigured screens.
+        // Showing both at once produced two parallel paths to do the same
+        // thing (toolbar `.html` segment vs. guide "HTML" card) which was
+        // confusing for first-time users on a fresh display.
+        if !shouldShowGuideEmptyState {
+            ToolbarItem(placement: .principal) {
                 Picker("Wallpaper Type", selection: $selectedWallpaperType) {
                     ForEach(WallpaperType.allCases) { type in
                         Text(type.rawValue).tag(type)
@@ -170,43 +52,31 @@ struct ScreenDetailView: View {
                 }
                 .pickerStyle(.segmented)
                 .fixedSize(horizontal: true, vertical: false)
-                .accessibilityLabel(Text("Wallpaper type"))
-                .accessibilityHint(Text("Switch between video, HTML, shader, or scene wallpaper"))
+                .accessibilityLabel("Wallpaper type")
+                .accessibilityHint("Choose between video, HTML, or Metal shader wallpaper")
                 .onChange(of: selectedWallpaperType) { _, newType in
-                    guard case .configured(let activeType) = stage,
-                          newType != activeType else { return }
                     switch newType {
                     case .video:
                         screenManager.switchToVideoWallpaper(for: screen)
                     case .html:
                         screenManager.switchToHTMLWallpaper(for: screen)
                     case .metalShader, .scene:
-                        break
+                        break // pickers drive activation themselves
                     }
-                }
-            }
-            if screenManager.screens.count > 1 {
-                ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        showApplyToAllConfirm = true
-                    } label: {
-                        Label("Apply to All", systemImage: "square.on.square")
-                    }
-                    .help(Text("Copy this display's wallpaper and settings to every other display"))
-                    .accessibilityLabel(Text("Apply to all displays"))
-                    .accessibilityHint(Text("Copies the current wallpaper and settings to every other connected display"))
-                    .disabled(runtimeError != nil)
                 }
             }
         }
-    }
-
-    /// Resets `pickContent` back to the 4-card guide. Wired to the
-    /// toolbar's Back button. Does NOT touch `selectedWallpaperType` —
-    /// that remains a configured-screen toolbar control, decoupled from
-    /// the empty-state journey.
-    private func backToChooseType() {
-        draftWallpaperType = nil
+        ToolbarItem(placement: .primaryAction) {
+            Button {
+                showApplyToAllConfirm = true
+            } label: {
+                Label("Apply to All", systemImage: "square.on.square")
+            }
+            .help("Copy this display's wallpaper and settings to every other display")
+            .accessibilityLabel("Apply to all displays")
+            .accessibilityHint("Copies the current wallpaper and settings to every other connected display")
+            .disabled(screenManager.screens.count <= 1 || screenManager.getConfiguration(for: screen) == nil)
+        }
     }
     /// Resolved Wallpaper Engine origin metadata for the active wallpaper, or
     /// nil when the user picked content directly. Recomputed on every body
@@ -215,55 +85,32 @@ struct ScreenDetailView: View {
         screenManager.getConfiguration(for: screen)?.wpeOrigin
     }
 
-    /// Stages of the unconfigured-to-configured journey.
-    /// `runtimeError` is orthogonal — surfaced as a banner overlay without
-    /// changing the underlying stage.
-    enum Stage: Equatable {
-        case chooseType
-        case pickContent(WallpaperType)
-        case configured(WallpaperType)
+    private var sessionStatusText: String {
+        switch wallpaperSessionSummary.wallpaperType {
+        case .html:
+            return "HTML Active"
+        case .metalShader:
+            return "Shader Active"
+        case .video:
+            return wallpaperSessionSummary.activity == .active ? "Playing" : "Paused"
+        case .scene:
+            return "Scene"
+        case nil:
+            return "Not configured"
+        }
     }
-
-    private var stage: Stage {
-        // Configuration is the authoritative signal. A live runtime session
-        // (rare without a config, but possible during transitions) also
-        // counts. Crucially, an in-flight preview is NOT configured —
-        // `setVideo` validation can fail and leave `hasPreviewSource` true
-        // without ever committing a configuration. Treating that as
-        // configured would expose Bookmarks / Apply-to-All / inspector
-        // before the user had any saved state to act on.
-        if let config = screenManager.getConfiguration(for: screen) {
-            return .configured(config.wallpaperType)
+    private var sessionStatusColor: Color {
+        switch wallpaperSessionSummary.activity {
+        case .active:
+            return .green
+        case .paused:
+            return .orange
+        case .inactive:
+            return .secondary
         }
-        if let runtime = screen.runtimeSession {
-            return .configured(runtime.wallpaperType)
-        }
-        if let draft = draftWallpaperType {
-            return .pickContent(draft)
-        }
-        // Preview without a config implies the user picked a file that's
-        // still being validated. Render as pickContent so the in-flight
-        // path doesn't briefly flash configured affordances.
-        if hasPreviewSource || previewController.hasPreviewContent {
-            return .pickContent(selectedWallpaperType)
-        }
-        return .chooseType
     }
-
-    private var isConfigured: Bool {
-        if case .configured = stage { return true }
-        return false
-    }
-
-    /// True when the right-side inspector panel should appear. Hidden in
-    /// chooseType / pickContent. For now, only Video and HTML have a
-    /// fully-realised inspector; Shader and Scene get just `Common
-    /// PlaybackInspector` once the broader capability-filter refactor
-    /// lands. Until then, gating on configured-AND-(video|html) prevents
-    /// an orphan resize handle from appearing for Shader / Scene.
     private var showsInspector: Bool {
-        guard isConfigured else { return false }
-        return selectedWallpaperType == .video || selectedWallpaperType == .html
+        selectedWallpaperType == .video || selectedWallpaperType == .html
     }
     @State private var showErrorAlert = false
     @State private var errorMessage = ""
@@ -273,12 +120,6 @@ struct ScreenDetailView: View {
     @State private var hasPreviewSource = false
 
     @State private var selectedWallpaperType: WallpaperType = .video
-    /// Pre-commit selection — set when the user clicks an HTML / Shader /
-    /// Scene card on the empty-state guide. Drives the `pickContent` stage
-    /// (Video uses a modal NSOpenPanel and skips this state). Cleared when
-    /// the user goes Back, when a configuration commits, or when the
-    /// wallpaper is cleared.
-    @State private var draftWallpaperType: WallpaperType? = nil
     @State private var selectedWallpaperMode: WallpaperMode = .single
     @State private var selectedParticleEffect: ParticleEffect = .none
     @State private var effectConfig = VideoEffectConfig.default
@@ -301,11 +142,7 @@ struct ScreenDetailView: View {
 
     @AppStorage("Inspector.PlaylistExpanded") private var isPlaylistExpanded = false
     @AppStorage("Inspector.ScheduleExpanded") private var isScheduleExpanded = false
-    // Default `false` so a freshly-configured display shows a tight inspector;
-    // power users can pin it expanded once they discover it. Changed from
-    // `true` during the IA redesign — Environment is type-specific
-    // (particles / weather) and shouldn't dominate vertical space by default.
-    @AppStorage("Inspector.EnvironmentExpanded") private var isEnvironmentExpanded = false
+    @AppStorage("Inspector.EnvironmentExpanded") private var isEnvironmentExpanded = true
     @AppStorage("Inspector.ColorExpanded") private var isColorExpanded = false
     @AppStorage("Inspector.Width") private var inspectorWidth = Double(DesignTokens.Inspector.defaultWidth)
     @State private var liveInspectorWidth: Double?
@@ -315,16 +152,99 @@ struct ScreenDetailView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            inlineBodyHeader
+            HStack(alignment: .center, spacing: 14) {
+                ZStack {
+                    Circle().fill(Color.accentColor.opacity(0.15)).frame(width: 44, height: 44)
+                    Image(systemName: "display").font(.system(size: 18)).foregroundStyle(Color.accentColor)
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 8) {
+                        Text(screen.name).font(.system(size: 18, weight: .semibold)).lineLimit(1)
+
+                        Button(action: { screenManager.reloadWallpaperForScreen(screen) }) {
+                            Image(systemName: "arrow.clockwise")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Reload display content")
+                        .accessibilityLabel("Reload display")
+                        .accessibilityHint("Reloads the wallpaper content for this screen")
+                    }
+                    HStack(spacing: 8) {
+                        InfoBadge(icon: "arrow.up.left.and.arrow.down.right", text: "\(Int(screen.frame.width))×\(Int(screen.frame.height))")
+                        InfoBadge(icon: "gauge.medium", text: "\(getScreenRefreshRate()) Hz")
+                        if wallpaperSessionSummary.isConfigured {
+                            HStack(spacing: 4) {
+                                Image(systemName: "circle.fill")
+                                    .font(.system(size: 6))
+                                    .foregroundStyle(sessionStatusColor)
+                                    .symbolEffect(.pulse, options: .repeat(.continuous), isActive: wallpaperSessionSummary.activity == .active)
+                                Text(sessionStatusText).font(.caption).foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+                Spacer()
+
+                Button {
+                    showBookmarks = true
+                } label: {
+                    Label("Bookmarks", systemImage: "bookmark.fill")
+                }
+                .buttonStyle(.glass)
+                .controlSize(.regular)
+                .help("Saved video / HTML / shader shortcuts")
+                .accessibilityLabel("Bookmarks")
+                .popover(isPresented: $showBookmarks, arrowEdge: .bottom) {
+                    BookmarksPopover(screen: screen)
+                        .environment(screenManager)
+                }
+
+                if selectedWallpaperType == .video {
+                    HStack(spacing: 8) {
+                        Button {
+                            showFilePicker()
+                        } label: {
+                            Label("Select Video", systemImage: "folder.badge.plus")
+                        }
+                        .buttonStyle(.glassProminent)
+                        .controlSize(.regular)
+                        .help("Choose a video file for this display")
+                        .accessibilityLabel("Select video")
+                        .accessibilityHint("Opens a file picker to choose a wallpaper video")
+
+                        Button(role: .destructive) {
+                            clearVideo()
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.glass)
+                        .controlSize(.regular)
+                        .help("Remove wallpaper video")
+                        .accessibilityLabel("Clear video")
+                        .accessibilityHint("Removes the current wallpaper video from this screen")
+                    }
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 14)
+
             runtimeErrorBannerView
+
             Divider()
 
             HStack(spacing: 0) {
                 ZStack {
                     Color(NSColor.underPageBackgroundColor)
 
-                    if case .chooseType = stage {
-                        EmptyStateGuideView(onChoose: handleGuideCardTap)
+                    if shouldShowGuideEmptyState {
+                        EmptyStateGuideView(
+                            onChooseVideo: triggerVideoGuideAction,
+                            onChooseHTML: triggerHTMLGuideAction,
+                            onChooseShader: triggerShaderGuideAction,
+                            onChooseScene: triggerSceneGuideAction
+                        )
                     } else if selectedWallpaperType == .video {
                         if isLoading {
                             ScreenDetailLoadingView()
@@ -478,11 +398,7 @@ struct ScreenDetailView: View {
 
     @ViewBuilder
     private var inspectorPanel: some View {
-        // Stage-aligned: defer to `showsInspector` instead of re-checking
-        // the type here. Without this, the inspector would render during
-        // pickContent (e.g. user clicked HTML card → selectedWallpaperType
-        // == .html → inspector appeared before content was committed).
-        if showsInspector {
+        if selectedWallpaperType == .video || selectedWallpaperType == .html {
             ScrollView {
                 GlassEffectContainer(spacing: 16) {
                     VStack(spacing: 16) {
@@ -516,7 +432,7 @@ struct ScreenDetailView: View {
                                                 .contentShape(Capsule())
                                         }
                                         .buttonStyle(.plain)
-                                        .accessibilityLabel(Text("\(mode.label) mode"))
+                                        .accessibilityLabel("\(mode.label) mode")
                                     }
                                 }
                                 .padding(2)
@@ -584,10 +500,10 @@ struct ScreenDetailView: View {
                                                 .onChange(of: selectedParticleEffect) { _, newValue in
                                                     screenManager.updateParticleEffect(newValue, for: screen)
                                                 }
-                                                .accessibilityLabel(Text("Particle effect"))
+                                                .accessibilityLabel("Particle effect")
                                                 .accessibilityValue(selectedParticleEffect.rawValue)
-                                                .accessibilityHint(Text("Choose a particle overlay effect"))
-                                                .help(Text("Overlay particle effects on the wallpaper"))
+                                                .accessibilityHint("Choose a particle overlay effect")
+                                                .help("Overlay particle effects on the wallpaper")
                                             }
 
                                             if selectedParticleEffect != .none {
@@ -599,7 +515,7 @@ struct ScreenDetailView: View {
                                                             .onChange(of: particleDensity) { _, newValue in
                                                                 screenManager.updateParticleDensity(newValue, for: screen)
                                                             }
-                                                            .accessibilityLabel(Text("Particle density"))
+                                                            .accessibilityLabel("Particle density")
                                                             .accessibilityValue(String(format: "%.1f×", particleDensity))
                                                         Text(String(format: "%.1f", particleDensity))
                                                             .font(.system(size: 12, design: .monospaced))
@@ -618,9 +534,9 @@ struct ScreenDetailView: View {
                                                     .onChange(of: effectConfig.weatherReactive) { _, newValue in
                                                         screenManager.setWeatherReactive(newValue, for: screen)
                                                     }
-                                                    .help(Text("Adjust effects based on real-time weather conditions"))
-                                                    .accessibilityLabel(Text("Weather-reactive effects"))
-                                                    .accessibilityHint(Text("Automatically adjust particles and color based on real-time weather"))
+                                                    .help("Adjust effects based on real-time weather conditions")
+                                                    .accessibilityLabel("Weather-reactive effects")
+                                                    .accessibilityHint("Automatically adjust particles and color based on real-time weather")
                                             }
 
                                             if effectConfig.weatherReactive {
@@ -655,7 +571,7 @@ struct ScreenDetailView: View {
             .fixedSize(horizontal: true, vertical: false)
             .background(Color(NSColor.windowBackgroundColor))
             .clipped()
-            .accessibilityLabel(Text("Wallpaper Properties"))
+            .accessibilityLabel("Wallpaper Properties")
         }
     }
 
@@ -786,9 +702,6 @@ struct ScreenDetailView: View {
         lockScreenExtracted = false
 
         if let config = screenManager.getConfiguration(for: screen) {
-            // Configuration committed → clear any in-flight draft so the
-            // stage transitions to `.configured` cleanly.
-            draftWallpaperType = nil
             if playbackSpeed != config.playbackSpeed { playbackSpeed = config.playbackSpeed }
             if selectedFitMode != config.fitMode { selectedFitMode = config.fitMode }
 
@@ -821,19 +734,12 @@ struct ScreenDetailView: View {
             shufflePlaylist = false
             playlistRotationMinutes = nil
             scheduleSlots = []
-            // Reset selected type to default — the user will re-pick via
-            // the empty-state guide. Don't carry over the prior config's
-            // type as the "default": the IA decision is that clearing
-            // returns to chooseType, not the last-known type.
             selectedWallpaperType = .video
             selectedWallpaperMode = .single
             htmlSource = nil
             htmlConfig = .default
             hasPreviewSource = screen.videoPlayer?.videoURL != nil
             loadPreviewPosterIfNeeded()
-            // Wallpaper went away (cleared, deleted, never set) — drop any
-            // stale draft so the screen re-enters chooseType cleanly.
-            draftWallpaperType = nil
         }
     }
 
@@ -849,7 +755,7 @@ struct ScreenDetailView: View {
         panel.allowsMultipleSelection = false
         panel.allowedContentTypes = [.movie, .video, .quickTimeMovie, .mpeg4Movie, .avi]
         panel.directoryURL = SettingsManager.shared.getLastUsedDirectory()
-        panel.prompt = L10n.Panel.useAsWallpaper
+        panel.prompt = "Use as Wallpaper"
         guard panel.runModal() == .OK, let url = panel.url else { return }
         SettingsManager.shared.saveLastUsedDirectory(url.deletingLastPathComponent())
         handleSelectedFile(url: url)
@@ -876,7 +782,7 @@ struct ScreenDetailView: View {
         panel.canChooseFiles = true
         panel.canChooseDirectories = true
         panel.allowsMultipleSelection = false
-        panel.prompt = L10n.Panel.useAsWallpaper
+        panel.prompt = "Use as Wallpaper"
         guard panel.runModal() == .OK, let url = panel.url else { return }
         guard isHTMLDrop(url) else {
             errorMessage = "Choose an HTML file or folder."
@@ -947,24 +853,41 @@ struct ScreenDetailView: View {
 
     // MARK: - Empty State Guide
 
-    /// Routes a card tap from `EmptyStateGuideView` to the correct flow.
-    /// Video uses a modal NSOpenPanel — no draft state needed; modal cancel
-    /// returns the user to chooseType automatically. Other types stage a
-    /// `draftWallpaperType` so the per-type section view (HTMLSourceSection
-    /// / ShaderWallpaperSection / WPESceneSection) takes over until the
-    /// user either picks something (commits config → `configured`) or hits
-    /// the toolbar Back button (clears draft → `chooseType`).
-    private func handleGuideCardTap(_ type: WallpaperType) {
-        switch type {
-        case .video:
-            showFilePicker()
-        case .html, .metalShader, .scene:
-            // Set both: draft drives stage; selectedWallpaperType drives
-            // the existing main-content if/else cascade and the inspector
-            // capability filters once configured.
-            draftWallpaperType = type
-            selectedWallpaperType = type
-        }
+    /// True when this screen has no persisted configuration AND no live
+    /// runtime session AND the user is currently looking at the default
+    /// `.video` tab. Switching the toolbar segmented control to .html /
+    /// .scene / .metalShader exits the guide so those tabs can show their
+    /// own configuration UI — clicking any non-Video guide card does the
+    /// same flip and lands on that type's existing empty state.
+    private var shouldShowGuideEmptyState: Bool {
+        if isLoading { return false }
+        if selectedWallpaperType != .video { return false }
+        if screenManager.getConfiguration(for: screen) != nil { return false }
+        if screen.runtimeSession != nil { return false }
+        if hasPreviewSource || previewController.hasPreviewContent { return false }
+        return true
+    }
+
+    /// Video card → already on `.video`, so just open the existing file
+    /// picker. Cancellation returns the user to the guide unchanged.
+    private func triggerVideoGuideAction() {
+        showFilePicker()
+    }
+
+    /// HTML / Shader / Scene cards → flip the toolbar's selected type so
+    /// `shouldShowGuideEmptyState` returns false and that type's existing
+    /// empty state takes over (URL/file/folder picker, shader presets,
+    /// Workshop browser respectively).
+    private func triggerHTMLGuideAction() {
+        selectedWallpaperType = .html
+    }
+
+    private func triggerShaderGuideAction() {
+        selectedWallpaperType = .metalShader
+    }
+
+    private func triggerSceneGuideAction() {
+        selectedWallpaperType = .scene
     }
 }
 
@@ -1022,9 +945,9 @@ private struct InspectorResizeHandle: View {
                 }
         )
         .onHover { isHovering = $0 }
-        .help(Text("Drag to resize properties panel"))
-        .accessibilityLabel(Text("Resize properties panel"))
-        .accessibilityHint(Text("Drag horizontally to change the properties panel width"))
+        .help("Drag to resize properties panel")
+        .accessibilityLabel("Resize properties panel")
+        .accessibilityHint("Drag horizontally to change the properties panel width")
     }
 
     private var isActive: Bool {


### PR DESCRIPTION
## Summary
Revert the two PRs I landed tonight that didn't pan out, while keeping i18n bootstrap (#39), the menu-bar redesign + revert pair (#38 / #41 — net zero), and the menu-bar GlobalSettings field-loss fix (#42).

## What this reverts
- **PR #43** (`52c215f`) — empty NSToolbar + `.unifiedCompact` style. Did not actually clear the sidebar's traffic-light overlap (sidebar column had no SwiftUI `ToolbarItem` so its toolbar zone collapsed to zero) and squeezed the segmented type picker. Two follow-up attempts to fix it (the closed PR #44 and earlier patching) introduced more regressions, including breaking the carefully-optimised sidebar collapse animation.
- **PR #37** (`d242d03`) — "single-owner" `ScreenDetailHeader` + Stage state machine + 4-card guide refactor. Restores the inline body header, the original toolbar-based layout, and the `EmptyStateGuideView.swift` file that pre-existed in the user's `Week5` commit.

## What this preserves
- `b82a39b i18n` — String Catalog translations
- `da9aaa3` PR #39 — i18n bootstrap (50-file wrapping)
- `8a90561` — i18n / main merge resolution
- `ad1c422` PR #42 — menu-bar `commitGlobalToggles` data-loss fix (independent of UI work)
- `b2fcb70` / `f3f0057` PR #41 / #38 — net zero (menu-bar redesign + revert), preserved for git history continuity

## Conflict resolution
- `LiveWallpaper/Views/ScreenDetailView.swift` and `LiveWallpaper/Views/ScreenDetail/EmptyStateGuideView.swift` had conflicts because PR #39 (i18n) wrapped strings in files PR #37 had refactored. Both files restored byte-exact from commit `5b65322 UI animation fix` (the user's last commit before PR #37 landed). The i18n catalog will keep a few orphan strings for code paths that no longer exist — harmless, no compile errors.

## Verified
- [x] `xcodebuild build` — succeeds
- [x] `xcodebuild test` — 503/503 pass
- [x] `diff` — `ScreenDetailView.swift` and `EmptyStateGuideView.swift` are byte-exact matches with `5b65322`
- [x] sidebar collapse animation restored (no more `NSSplitViewController.toggleSidebar(_:)` AppKit responder-chain interception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)