### PR TITLE
WPE engine assets fallback + scene preflight wiring

### DIFF
--- a/LiveWallpaper/Infrastructure/WPEEngineAssetsLibrary.swift
+++ b/LiveWallpaper/Infrastructure/WPEEngineAssetsLibrary.swift
@@ -1,0 +1,244 @@
+import AppKit
+import Foundation
+import Observation
+
+/// Owns the one-time security-scoped grant to the Wallpaper Engine install
+/// root so the scene renderer can fall through to WPE's bundled framework
+/// assets (`<root>/assets/materials`, `<root>/assets/models`, etc.) when a
+/// project references shared utility files (`materials/util/composelayer.json`,
+/// `models/util/*.json`).
+///
+/// Mirrors `AppleAerialsLibrary` — single observable owner of the bookmark,
+/// caller-driven security-scope start/stop, preserves the bookmark across
+/// transient resolution failures.
+@MainActor
+@Observable
+final class WPEEngineAssetsLibrary {
+    static let shared = WPEEngineAssetsLibrary()
+
+    private(set) var isAuthorized: Bool
+    private(set) var lastError: String?
+    private(set) var engineRootDisplayName: String?
+
+    init() {
+        self.isAuthorized = false
+        self.lastError = nil
+        self.engineRootDisplayName = nil
+        // Resolve once at boot so observers see the right `isAuthorized`
+        // without having to wait for the first runtime read.
+        _ = resolveAuthorizedRoot()
+    }
+
+    func requestAccess() async -> Bool {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = false
+        panel.showsHiddenFiles = true
+        panel.directoryURL = Self.suggestedDirectoryToGrant()
+        panel.prompt = L10n.Panel.grantAccess
+        panel.message = String(
+            localized: "Choose your Wallpaper Engine install folder. It must contain an assets folder.",
+            defaultValue: "Choose your Wallpaper Engine install folder. It must contain an assets folder.",
+            comment: "Wallpaper Engine assets folder access panel message."
+        )
+
+        guard panel.runModal() == .OK, let selectedURL = panel.url else {
+            return false
+        }
+
+        guard let engineRoot = Self.validatedEngineRoot(from: selectedURL) else {
+            let message = String(
+                localized: "The selected folder doesn't contain Wallpaper Engine assets. Choose the wallpaper_engine install folder or Wallpaper Engine.app.",
+                defaultValue: "The selected folder doesn't contain Wallpaper Engine assets. Choose the wallpaper_engine install folder or Wallpaper Engine.app.",
+                comment: "Wallpaper Engine assets folder validation error."
+            )
+            Logger.warning(message, category: .fileAccess)
+            lastError = message
+            return false
+        }
+
+        do {
+            let bookmarkData = try Self.createReadOnlyBookmark(for: engineRoot)
+            SettingsManager.shared.saveWPEEngineAssetsBookmark(bookmarkData)
+            isAuthorized = true
+            engineRootDisplayName = engineRoot.lastPathComponent
+            lastError = nil
+            return true
+        } catch {
+            let message = "Failed to save Wallpaper Engine assets access: \(error.localizedDescription)"
+            Logger.error(message, category: .fileAccess)
+            lastError = message
+            return false
+        }
+    }
+
+    /// Resolves the saved bookmark to a usable URL. Callers (runtime scene
+    /// renderers) hold the URL for the lifetime of one playback session and
+    /// own the `startAccessingSecurityScopedResource()` / `stop...` balance.
+    ///
+    /// Returns `nil` when no bookmark has been saved OR resolution failed.
+    /// Transient resolution failures DO NOT clear the bookmark — see the
+    /// `5b0e006` commit ("Preserve Workshop + Aerials bookmarks across
+    /// transient scan failures") for the same defensive pattern.
+    func resolveAuthorizedRoot() -> URL? {
+        resolveAuthorizedRoot(using: Self.resolveDirectoryBookmark)
+    }
+
+    func clearAccess() {
+        SettingsManager.shared.clearWPEEngineAssetsBookmark()
+        isAuthorized = false
+        engineRootDisplayName = nil
+        lastError = nil
+    }
+}
+
+// MARK: - Bookmark Resolution
+
+extension WPEEngineAssetsLibrary {
+    struct DirectoryBookmarkResolution {
+        let url: URL
+        let isStale: Bool
+    }
+
+    typealias DirectoryBookmarkResolver = (Data) throws -> DirectoryBookmarkResolution
+
+    func resolveAuthorizedRoot(using resolver: DirectoryBookmarkResolver) -> URL? {
+        guard let bookmarkData = SettingsManager.shared.loadWPEEngineAssetsBookmark() else {
+            isAuthorized = false
+            engineRootDisplayName = nil
+            return nil
+        }
+
+        do {
+            let resolution = try resolver(bookmarkData)
+            // If the user originally picked the .app bundle, the resolved
+            // URL still points at it; re-validate so callers receive the
+            // canonical root that contains `assets/`.
+            let rootURL = Self.validatedEngineRoot(from: resolution.url) ?? resolution.url
+
+            if resolution.isStale {
+                // Apple recommends re-creating the bookmark from the
+                // resolved URL when `isStale=true`. The URL is still good
+                // for this run; the stored Data needs a fresh copy so
+                // future relaunches don't trip the flag again.
+                Logger.info(
+                    "Wallpaper Engine assets bookmark is stale; refreshing in place",
+                    category: .fileAccess
+                )
+                if let fresh = try? Self.createReadOnlyBookmark(for: rootURL) {
+                    SettingsManager.shared.saveWPEEngineAssetsBookmark(fresh)
+                }
+            }
+
+            if !Self.hasAssetsSubdirectory(rootURL) {
+                Logger.warning(
+                    "Resolved Wallpaper Engine root has no assets folder: \(rootURL.path(percentEncoded: false))",
+                    category: .fileAccess
+                )
+            }
+
+            isAuthorized = true
+            engineRootDisplayName = rootURL.lastPathComponent
+            lastError = nil
+            return rootURL
+        } catch {
+            // Resolution failed — could be transient (sandbox not warmed,
+            // home directory moved by Migration Assistant). Surface the
+            // error but KEEP the saved bookmark so the next launch /
+            // explicit retry can resolve it.
+            let message = "Failed to resolve Wallpaper Engine assets bookmark: \(error.localizedDescription)"
+            Logger.error(message, category: .fileAccess)
+            isAuthorized = false
+            engineRootDisplayName = nil
+            lastError = message
+            return nil
+        }
+    }
+
+    nonisolated static func resolveDirectoryBookmark(_ bookmarkData: Data) throws -> DirectoryBookmarkResolution {
+        var isStale = false
+        let url = try URL(
+            resolvingBookmarkData: bookmarkData,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        )
+        return DirectoryBookmarkResolution(url: url, isStale: isStale)
+    }
+
+    nonisolated static func createReadOnlyBookmark(for url: URL) throws -> Data {
+        let options: URL.BookmarkCreationOptions = [.withSecurityScope, .securityScopeAllowOnlyReadAccess]
+        let noKeys: Set<URLResourceKey>? = nil
+        let noRelativeURL: URL? = nil
+        return try url.bookmarkData(
+            options: options,
+            includingResourceValuesForKeys: noKeys,
+            relativeTo: noRelativeURL
+        )
+    }
+}
+
+// MARK: - Location Helpers
+
+extension WPEEngineAssetsLibrary {
+    nonisolated static func suggestedDirectoryToGrant(fileManager: FileManager = .default) -> URL? {
+        let steamRoot = fileManager
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Steam", isDirectory: true)
+            .appendingPathComponent("steamapps", isDirectory: true)
+            .appendingPathComponent("common", isDirectory: true)
+            .appendingPathComponent("wallpaper_engine", isDirectory: true)
+        let appRoot = URL(fileURLWithPath: "/Applications/Wallpaper Engine.app", isDirectory: true)
+        let appResources = appRoot
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+
+        let candidates = [steamRoot, appResources, appRoot]
+        // Prefer a validated WPE root (we can confirm `assets/` exists).
+        if let valid = candidates.compactMap({ validatedEngineRoot(from: $0, fileManager: fileManager) }).first {
+            return valid
+        }
+        // Otherwise point at whichever candidate exists as a directory.
+        if let existing = candidates.first(where: { directoryExists($0, fileManager: fileManager) }) {
+            return existing
+        }
+        // Last resort: the parent of the Steam path so the user can
+        // navigate. Returns nil only if even the home directory is gone.
+        return steamRoot.deletingLastPathComponent()
+    }
+
+    /// Walks the selected URL — and one common app-bundle relative
+    /// (`Contents/Resources/`) — to find the canonical WPE root that
+    /// contains an `assets/` subdirectory. Returns nil when no candidate
+    /// validates so the caller can surface a precise error.
+    nonisolated static func validatedEngineRoot(from selectedURL: URL, fileManager: FileManager = .default) -> URL? {
+        let root = selectedURL.standardizedFileURL.resolvingSymlinksInPath()
+        if hasAssetsSubdirectory(root, fileManager: fileManager) {
+            return root
+        }
+
+        let appResources = root
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        if hasAssetsSubdirectory(appResources, fileManager: fileManager) {
+            return appResources
+        }
+        return nil
+    }
+
+    nonisolated static func hasAssetsSubdirectory(_ rootURL: URL, fileManager: FileManager = .default) -> Bool {
+        directoryExists(rootURL.appendingPathComponent("assets", isDirectory: true), fileManager: fileManager)
+    }
+
+    nonisolated private static func directoryExists(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDirectory: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: url.path(percentEncoded: false), isDirectory: &isDirectory)
+        return exists && isDirectory.boolValue
+    }
+}

--- a/LiveWallpaper/Infrastructure/WPEMultiRootResourceResolver.swift
+++ b/LiveWallpaper/Infrastructure/WPEMultiRootResourceResolver.swift
@@ -4,9 +4,24 @@ import Foundation
 struct WPEMultiRootResourceResolver: Sendable {
     private let primary: SceneResourceResolver
     private let dependencyMounts: [String: SceneResourceResolver]
+    /// Optional read-only fallback rooted at `<engineRoot>/assets/`. Tried
+    /// only after the primary mount misses a non-dependency path — so it
+    /// resolves shared WPE framework assets (`materials/util/...`,
+    /// `models/util/...`, `effects/...`) without ever shadowing a project's
+    /// own files.
+    private let engineAssetsResolver: SceneResourceResolver?
 
-    init(primaryRootURL: URL, dependencyMounts: [WPEAssetMount]) {
+    init(
+        primaryRootURL: URL,
+        dependencyMounts: [WPEAssetMount],
+        engineAssetsRootURL: URL? = nil
+    ) {
         self.primary = SceneResourceResolver(cacheRootURL: primaryRootURL)
+        self.engineAssetsResolver = engineAssetsRootURL.map {
+            SceneResourceResolver(
+                cacheRootURL: $0.appendingPathComponent("assets", isDirectory: true)
+            )
+        }
         var mounts: [String: SceneResourceResolver] = [:]
         for mount in dependencyMounts {
             mounts[mount.workshopID] = SceneResourceResolver(cacheRootURL: mount.rootURL)
@@ -21,7 +36,9 @@ struct WPEMultiRootResourceResolver: Sendable {
             }
             return try resolver.resolveImage(relativePath: dependency.childPath)
         }
-        return try primary.resolveImage(relativePath: relativePath)
+        return try resolveWithEngineAssetsFallback(relativePath: relativePath) { resolver, path in
+            try resolver.resolveImage(relativePath: path)
+        }
     }
 
     func resolveExistingFileURL(relativePath: String) throws -> URL {
@@ -31,7 +48,9 @@ struct WPEMultiRootResourceResolver: Sendable {
             }
             return try resolver.resolveExistingFileURL(relativePath: dependency.childPath)
         }
-        return try primary.resolveExistingFileURL(relativePath: relativePath)
+        return try resolveWithEngineAssetsFallback(relativePath: relativePath) { resolver, path in
+            try resolver.resolveExistingFileURL(relativePath: path)
+        }
     }
 
     func resolveTexturePayload(relativePath: String) throws -> WPETexTexturePayload {
@@ -41,7 +60,28 @@ struct WPEMultiRootResourceResolver: Sendable {
             }
             return try resolver.resolveTexturePayload(relativePath: dependency.childPath)
         }
-        return try primary.resolveTexturePayload(relativePath: relativePath)
+        return try resolveWithEngineAssetsFallback(relativePath: relativePath) { resolver, path in
+            try resolver.resolveTexturePayload(relativePath: path)
+        }
+    }
+
+    /// Tries the primary resolver first; falls through to the engine assets
+    /// resolver ONLY on `.fileMissing`. Other `ResolveError` cases
+    /// (`.pathEscape`, `.materialUnresolved`, `.texture`, …) propagate
+    /// without retry — the engine root cannot fix a malformed path or a
+    /// project's broken JSON chain.
+    private func resolveWithEngineAssetsFallback<T>(
+        relativePath: String,
+        _ resolve: (SceneResourceResolver, String) throws -> T
+    ) throws -> T {
+        do {
+            return try resolve(primary, relativePath)
+        } catch SceneResourceResolver.ResolveError.fileMissing {
+            guard let engineAssetsResolver else {
+                throw SceneResourceResolver.ResolveError.fileMissing
+            }
+            return try resolve(engineAssetsResolver, relativePath)
+        }
     }
 
     private func dependencyReference(_ relativePath: String) -> (workshopID: String, childPath: String)? {

--- a/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
@@ -3,10 +3,11 @@ import Foundation
 struct WPERenderGraphBuilder: Sendable {
     private let resolver: WPEMultiRootResourceResolver
 
-    init(cacheRootURL: URL, dependencyMounts: [WPEAssetMount] = []) {
+    init(cacheRootURL: URL, dependencyMounts: [WPEAssetMount] = [], engineAssetsRootURL: URL? = nil) {
         self.resolver = WPEMultiRootResourceResolver(
             primaryRootURL: cacheRootURL,
-            dependencyMounts: dependencyMounts
+            dependencyMounts: dependencyMounts,
+            engineAssetsRootURL: engineAssetsRootURL
         )
     }
 

--- a/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
@@ -3,8 +3,11 @@ import Foundation
 struct WPERenderPipelineBuilder: Sendable {
     private let shaderLoader: WPEShaderSourceLoader
 
-    init(cacheRootURL: URL) {
-        self.shaderLoader = WPEShaderSourceLoader(cacheRootURL: cacheRootURL)
+    init(cacheRootURL: URL, engineAssetsRootURL: URL? = nil) {
+        self.shaderLoader = WPEShaderSourceLoader(
+            cacheRootURL: cacheRootURL,
+            engineAssetsRootURL: engineAssetsRootURL
+        )
     }
 
     func build(graph: WPERenderGraph) throws -> WPEPreparedRenderPipeline {
@@ -54,10 +57,18 @@ private struct WPEShaderUniformAnnotation {
 }
 
 private struct WPEShaderSourceLoader: Sendable {
-    private let cacheRootURL: URL
+    private let resolver: WPEMultiRootResourceResolver
 
-    init(cacheRootURL: URL) {
-        self.cacheRootURL = cacheRootURL.standardizedFileURL.resolvingSymlinksInPath()
+    init(cacheRootURL: URL, engineAssetsRootURL: URL? = nil) {
+        // Reuse the same fall-through chain as scene-asset lookup so shader
+        // `#include` resolution lands on the engine root for common helpers
+        // (`common_composite.h`, `common_blur.h`, …) that WPE ships under
+        // `assets/shaders/`.
+        self.resolver = WPEMultiRootResourceResolver(
+            primaryRootURL: cacheRootURL,
+            dependencyMounts: [],
+            engineAssetsRootURL: engineAssetsRootURL
+        )
     }
 
     func load(shaderName: String, pass: WPERenderPass) throws -> WPEShaderLoadResult {
@@ -674,19 +685,16 @@ private struct WPEShaderSourceLoader: Sendable {
     }
 
     private func resolveExistingFileURL(relativePath: String) throws -> URL {
-        let url = try resolveURL(relativePath: relativePath)
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
-              !isDirectory.boolValue else {
+        // Map the resolver's `ResolveError` into the pipeline-builder's
+        // `WPERenderPipelineError.includeMissing` so existing call sites
+        // (and tests asserting `throws: WPERenderPipelineError.self`) keep
+        // their error contract while still picking up the engine-root
+        // fall-through.
+        do {
+            return try resolver.resolveExistingFileURL(relativePath: relativePath)
+        } catch SceneResourceResolver.ResolveError.fileMissing,
+                SceneResourceResolver.ResolveError.pathEscape {
             throw WPERenderPipelineError.includeMissing(path: relativePath, requestedBy: "")
         }
-        return url
-    }
-
-    private func resolveURL(relativePath: String) throws -> URL {
-        guard let resolved = WPEPathSafety.strictResourceURL(root: cacheRootURL, relativePath: relativePath) else {
-            throw WPERenderPipelineError.includeMissing(path: relativePath, requestedBy: "")
-        }
-        return resolved
     }
 }

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -300,12 +300,19 @@ final class WallpaperEngineImportService {
         }
 
         let tier = WPESceneCapabilityClassifier().capabilityTier(for: document, cacheURL: cacheURL)
+        let preflight = WPEScenePreflight.classify(
+            document: document,
+            project: project,
+            scenePackageEntries: scenePackageEntryNames(in: cacheURL, fileManager: fileManager)
+        )
         let descriptor = SceneDescriptor(
             workshopID: project.workshopID,
             cacheRelativePath: cacheRelativePath(for: project),
             entryFile: project.entryFile,
             capabilityTier: tier,
-            dependencyWorkshopIDs: project.dependencyWorkshopIDs
+            dependencyWorkshopIDs: project.dependencyWorkshopIDs,
+            preflightTier: preflight.tier,
+            preflightFeatureFlags: sortedPreflightFeatureFlags(preflight.featureFlags)
         )
         let origin = makeOrigin(
             project: project,
@@ -489,10 +496,33 @@ struct WPECachedContentResolver {
             )
         case .scene:
             var tier: SceneCapabilityTier = .unsupported
+            var preflightTier: WPEScenePreflightTier?
+            var preflightFeatureFlags: [WPESceneFeatureFlag] = []
             do {
                 let data = try Data(contentsOf: entryURL)
                 let document = try WPESceneDocumentParser.parse(data: data)
                 tier = WPESceneCapabilityClassifier().capabilityTier(for: document, cacheURL: cacheURL)
+                // Reconstruct a minimal `WallpaperEngineProject` from the
+                // persisted origin so preflight can read the same flags it
+                // does at first-import time. The `propertyCount` is
+                // irrelevant to preflight; we pass 0.
+                let synthesizedProject = WallpaperEngineProject(
+                    workshopID: origin.workshopID,
+                    title: origin.title,
+                    entryFile: entryFile,
+                    type: origin.originalType,
+                    previewFileName: origin.previewFileName,
+                    propertyCount: 0,
+                    dependencyWorkshopIDs: origin.dependencyWorkshopIDs,
+                    requiresWindowsPlugin: origin.requiresWindowsPlugin
+                )
+                let preflight = WPEScenePreflight.classify(
+                    document: document,
+                    project: synthesizedProject,
+                    scenePackageEntries: scenePackageEntryNames(in: cacheURL, fileManager: fileManager)
+                )
+                preflightTier = preflight.tier
+                preflightFeatureFlags = sortedPreflightFeatureFlags(preflight.featureFlags)
             } catch {
             }
             return .scene(SceneDescriptor(
@@ -500,7 +530,9 @@ struct WPECachedContentResolver {
                 cacheRelativePath: cacheRelativePath,
                 entryFile: entryFile,
                 capabilityTier: tier,
-                dependencyWorkshopIDs: origin.dependencyWorkshopIDs
+                dependencyWorkshopIDs: origin.dependencyWorkshopIDs,
+                preflightTier: preflightTier,
+                preflightFeatureFlags: preflightFeatureFlags
             ))
         case .application, .unknown:
             return nil
@@ -510,4 +542,41 @@ struct WPECachedContentResolver {
     private func resourceURL(root: URL, relativePath: String) -> URL? {
         WPEPathSafety.resourceURL(root: root, relativePath: relativePath)
     }
+}
+
+/// Enumerates regular-file entries under a scene cache root so
+/// `WPEScenePreflight` can probe for custom shader payloads (`.vert`,
+/// `.frag`) without having to walk the directory itself. Capped at
+/// `limit` files to keep large auxiliary asset folders from dominating the
+/// import critical path.
+private func scenePackageEntryNames(
+    in rootURL: URL,
+    fileManager: FileManager,
+    limit: Int = 10_000
+) -> [String] {
+    guard limit > 0,
+          let enumerator = fileManager.enumerator(
+              at: rootURL,
+              includingPropertiesForKeys: [.isRegularFileKey],
+              options: [.skipsHiddenFiles, .skipsPackageDescendants]
+          ) else {
+        return []
+    }
+
+    var entries: [String] = []
+    entries.reserveCapacity(min(limit, 256))
+    for case let url as URL in enumerator {
+        guard entries.count < limit else { break }
+        guard (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true else {
+            continue
+        }
+        entries.append(url.lastPathComponent)
+    }
+    return entries
+}
+
+/// `WPEScenePreflight` emits an unordered `Set` so descriptor persistence
+/// matches the historical ordering convention (alphabetical by raw value).
+private func sortedPreflightFeatureFlags(_ flags: Set<WPESceneFeatureFlag>) -> [WPESceneFeatureFlag] {
+    flags.sorted { $0.rawValue < $1.rawValue }
 }

--- a/LiveWallpaper/NotificationNames.swift
+++ b/LiveWallpaper/NotificationNames.swift
@@ -48,6 +48,11 @@ extension Notification.Name {
     /// without needing a manual reopen.
     static let workshopLibraryRootBookmarkDidChange = Notification.Name("WorkshopLibraryRootBookmarkDidChange")
 
+    /// Wallpaper Engine install-root bookmark was set or cleared. Runtime
+    /// scenes use it to mount WPE's bundled framework assets, and the Scene
+    /// section's onboarding banner watches it to dismiss itself once granted.
+    static let wpeEngineAssetsBookmarkDidChange = Notification.Name("WPEEngineAssetsBookmarkDidChange")
+
     /// `GlobalSettings.showInDock` changed. The app delegate listens so the
     /// activation policy switch happens immediately without a relaunch.
     static let dockVisibilityDidChange = Notification.Name("DockVisibilityDidChange")

--- a/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
+++ b/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
@@ -76,6 +76,7 @@ final class AmbientWallpaperSessionBuilder {
         frame: CGRect,
         dependencyMounts: [WPEAssetMount] = [],
         rendererBackend: WPESceneRendererBackend = .metalExperimental,
+        engineAssetsRootURL: URL? = nil,
         applicationSupportRootURL: URL? = nil,
         fileManager: FileManager = .default
     ) -> SceneWallpaperSession? {
@@ -132,6 +133,7 @@ final class AmbientWallpaperSessionBuilder {
                 descriptor: descriptor,
                 cacheRootURL: cacheURL,
                 dependencyMounts: dependencyMounts,
+                engineAssetsRootURL: engineAssetsRootURL,
                 frame: rendererFrame
             )
         case .metalExperimental:
@@ -144,6 +146,7 @@ final class AmbientWallpaperSessionBuilder {
                     descriptor: descriptor,
                     cacheRootURL: cacheURL,
                     dependencyMounts: dependencyMounts,
+                    engineAssetsRootURL: engineAssetsRootURL,
                     frame: rendererFrame,
                     device: device
                 )

--- a/LiveWallpaper/Runtime/SceneRenderingController.swift
+++ b/LiveWallpaper/Runtime/SceneRenderingController.swift
@@ -21,6 +21,15 @@ final class SceneRenderingController: WPESceneRenderer {
 
     private let descriptor: SceneDescriptor
     private let cacheRootURL: URL
+    private let dependencyMounts: [WPEAssetMount]
+    /// Resolved Wallpaper Engine install root (the directory that contains
+    /// `assets/`). Captured at init so the graph builder Task can hand it
+    /// off to `WPERenderGraphBuilder` without re-fetching from the
+    /// engine-assets singleton.
+    private let engineAssetsRootURL: URL?
+    /// `(unsafe)` because `deinit` is non-isolated. All other writes happen
+    /// on `@MainActor` (`cleanup()`); single-thread mutation is preserved.
+    nonisolated(unsafe) private var activeEngineAssetsRootURL: URL?
     private let resolver: SceneResourceResolver
     private let imageResolver: WPEMultiRootResourceResolver
     private let initialFrame: CGRect
@@ -50,16 +59,28 @@ final class SceneRenderingController: WPESceneRenderer {
         descriptor: SceneDescriptor,
         cacheRootURL: URL,
         dependencyMounts: [WPEAssetMount] = [],
+        engineAssetsRootURL: URL? = nil,
         frame: CGRect
     ) {
         self.descriptor = descriptor
         self.cacheRootURL = cacheRootURL
+        self.dependencyMounts = dependencyMounts
+        self.engineAssetsRootURL = engineAssetsRootURL
+        let didStartEngineAssetsAccess = engineAssetsRootURL?.startAccessingSecurityScopedResource() ?? false
+        self.activeEngineAssetsRootURL = didStartEngineAssetsAccess ? engineAssetsRootURL : nil
         self.resolver = SceneResourceResolver(cacheRootURL: cacheRootURL)
         self.imageResolver = WPEMultiRootResourceResolver(
             primaryRootURL: cacheRootURL,
-            dependencyMounts: dependencyMounts
+            dependencyMounts: dependencyMounts,
+            engineAssetsRootURL: engineAssetsRootURL
         )
         self.initialFrame = frame
+        if engineAssetsRootURL != nil && !didStartEngineAssetsAccess {
+            Logger.warning(
+                "Wallpaper Engine assets security scope could not be started — engine fallback disabled for this session",
+                category: .fileAccess
+            )
+        }
         let view = SKView(frame: frame)
         view.allowsTransparency = true
         view.ignoresSiblingOrder = true
@@ -132,8 +153,14 @@ final class SceneRenderingController: WPESceneRenderer {
         )
 
         do {
+            let mounts = dependencyMounts
+            let engineRoot = engineAssetsRootURL
             let graph = try await Task.detached(priority: .userInitiated) { [cacheRootURL] in
-                try WPERenderGraphBuilder(cacheRootURL: cacheRootURL).build(document: document)
+                try WPERenderGraphBuilder(
+                    cacheRootURL: cacheRootURL,
+                    dependencyMounts: mounts,
+                    engineAssetsRootURL: engineRoot
+                ).build(document: document)
             }.value
             renderGraph = graph
             let passCount = graph.layers.reduce(0) { $0 + $1.passes.count }
@@ -143,7 +170,10 @@ final class SceneRenderingController: WPESceneRenderer {
             )
             do {
                 let pipeline = try await Task.detached(priority: .userInitiated) { [cacheRootURL] in
-                    try WPERenderPipelineBuilder(cacheRootURL: cacheRootURL).build(graph: graph)
+                    try WPERenderPipelineBuilder(
+                        cacheRootURL: cacheRootURL,
+                        engineAssetsRootURL: engineRoot
+                    ).build(graph: graph)
                 }.value
                 renderPipeline = pipeline
                 let preparedPassCount = pipeline.layers.reduce(0) { $0 + $1.passes.count }
@@ -264,6 +294,17 @@ final class SceneRenderingController: WPESceneRenderer {
         loadDiagnostics = nil
         renderGraph = nil
         renderPipeline = nil
+        stopEngineAssetsAccessIfNeeded()
+    }
+
+    deinit {
+        stopEngineAssetsAccessIfNeeded()
+    }
+
+    nonisolated private func stopEngineAssetsAccessIfNeeded() {
+        guard let url = activeEngineAssetsRootURL else { return }
+        url.stopAccessingSecurityScopedResource()
+        activeEngineAssetsRootURL = nil
     }
 
     /// Tears the current SKScene down and re-runs `load()`. Used by the

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -16,6 +16,14 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
     private let descriptor: SceneDescriptor
     private let cacheRootURL: URL
     private let dependencyMounts: [WPEAssetMount]
+    /// Resolved Wallpaper Engine install root (the directory that contains
+    /// `assets/`). Captured at init for graph + pipeline builder use; the
+    /// security scope is owned here for the lifetime of the renderer.
+    private let engineAssetsRootURL: URL?
+    /// `(unsafe)` because `deinit` is non-isolated and needs to clear the
+    /// reference + drop the scope. All other writes happen on `@MainActor`
+    /// (`cleanup()`), so observed mutation is single-threaded.
+    nonisolated(unsafe) private var activeEngineAssetsRootURL: URL?
     private let entryResolver: SceneResourceResolver
     private let resourceResolver: WPEMultiRootResourceResolver
     private let mtkView: MTKView
@@ -73,6 +81,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         descriptor: SceneDescriptor,
         cacheRootURL: URL,
         dependencyMounts: [WPEAssetMount],
+        engineAssetsRootURL: URL? = nil,
         frame: CGRect,
         device: MTLDevice,
         frameClock: WPEMetalFrameClock = WPEMetalFrameClock(),
@@ -82,18 +91,37 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         self.descriptor = descriptor
         self.cacheRootURL = cacheRootURL
         self.dependencyMounts = dependencyMounts
+        self.engineAssetsRootURL = engineAssetsRootURL
+        // Build the throwing dependencies BEFORE opening the security
+        // scope. If executor init fails, Swift will not run `deinit` for a
+        // partially-initialized instance — opening the scope first would
+        // leak that reference count until process exit. Audited by codex.
+        let executor = try WPEMetalRenderExecutor(device: device)
+        // Open the security scope once for the renderer's lifetime; balanced
+        // by `cleanup()` / `deinit`. Tracking the URL that actually started
+        // a scope means we won't try to stop one that never opened.
+        let didStartEngineAssetsAccess = engineAssetsRootURL?.startAccessingSecurityScopedResource() ?? false
+        self.activeEngineAssetsRootURL = didStartEngineAssetsAccess ? engineAssetsRootURL : nil
         self.entryResolver = SceneResourceResolver(cacheRootURL: cacheRootURL)
         self.resourceResolver = WPEMultiRootResourceResolver(
             primaryRootURL: cacheRootURL,
-            dependencyMounts: dependencyMounts
+            dependencyMounts: dependencyMounts,
+            engineAssetsRootURL: engineAssetsRootURL
         )
-        self.executor = try WPEMetalRenderExecutor(device: device)
+        self.executor = executor
         self.textureLoader = WPEMetalTextureLoader(device: device)
         self.mtkView = MTKView(frame: frame, device: device)
         self.frameClock = frameClock
         self.pointerSampler = pointerSampler
         self.snapshotter = snapshotter
         super.init()
+
+        if engineAssetsRootURL != nil && !didStartEngineAssetsAccess {
+            Logger.warning(
+                "Wallpaper Engine assets security scope could not be started — engine fallback disabled for this session",
+                category: .fileAccess
+            )
+        }
 
         mtkView.delegate = self
         mtkView.colorPixelFormat = WPEMetalRenderExecutor.outputPixelFormat
@@ -132,13 +160,21 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         onProgress?("Building render graph")
         let cacheRoot = cacheRootURL
         let mounts = dependencyMounts
+        let engineRoot = engineAssetsRootURL
         let graph = try await Task.detached(priority: .userInitiated) {
-            try WPERenderGraphBuilder(cacheRootURL: cacheRoot, dependencyMounts: mounts).build(document: document)
+            try WPERenderGraphBuilder(
+                cacheRootURL: cacheRoot,
+                dependencyMounts: mounts,
+                engineAssetsRootURL: engineRoot
+            ).build(document: document)
         }.value
 
         onProgress?("Preparing render pipeline")
         let pipeline = try await Task.detached(priority: .userInitiated) {
-            try WPERenderPipelineBuilder(cacheRootURL: cacheRoot).build(graph: graph)
+            try WPERenderPipelineBuilder(
+                cacheRootURL: cacheRoot,
+                engineAssetsRootURL: engineRoot
+            ).build(graph: graph)
         }.value
 
         renderGraph = graph
@@ -473,6 +509,17 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         lastRuntimeUniforms = nil
         cachedSnapshot = nil
         executor.releaseTransientResources()
+        stopEngineAssetsAccessIfNeeded()
+    }
+
+    deinit {
+        stopEngineAssetsAccessIfNeeded()
+    }
+
+    nonisolated private func stopEngineAssetsAccessIfNeeded() {
+        guard let url = activeEngineAssetsRootURL else { return }
+        url.stopAccessingSecurityScopedResource()
+        activeEngineAssetsRootURL = nil
     }
 
     nonisolated func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -1131,11 +1131,16 @@ final class ScreenManager {
                 dependencyWorkshopIDs: descriptor.dependencyWorkshopIDs,
                 origin: configuration.wpeOrigin
             )
+            // Resolve the engine assets root at the call site so the runtime
+            // never reaches back into the UI singleton; the renderer owns
+            // the security scope for its lifetime.
+            let engineRoot = WPEEngineAssetsLibrary.shared.resolveAuthorizedRoot()
             guard let sceneSession = ambientSessionBuilder.makeSceneSession(
                 descriptor: descriptor,
                 frame: screen.frame,
                 dependencyMounts: dependencyMounts,
-                rendererBackend: .metalExperimental
+                rendererBackend: .metalExperimental,
+                engineAssetsRootURL: engineRoot
             ) else {
                 Logger.warning("Scene wallpaper for screen \(screen.id) (workshop \(descriptor.workshopID)) could not be built — cache missing or descriptor invalid", category: .screenManager)
                 return

--- a/LiveWallpaper/SettingsManager.swift
+++ b/LiveWallpaper/SettingsManager.swift
@@ -28,6 +28,7 @@ final class SettingsManager {
         static let bookmarks = "WallpaperBookmarks.v1"
         static let trustedHosts = "TrustedHTMLHosts.v1"
         static let workshopLibraryRootBookmark = "WPELibrary.RootBookmark.v1"
+        static let wpeEngineAssetsRootBookmark = "WPEEngineAssets.RootBookmark.v1"
         static let appLanguage = AppLanguagePreference.storageKey
         /// Bumped each time we successfully migrate a blob out of UserDefaults
         /// into the file store. Lets us run the migration at most once even
@@ -168,6 +169,26 @@ final class SettingsManager {
         NotificationCenter.default.post(name: .workshopLibraryRootBookmarkDidChange, object: nil)
     }
 
+    // MARK: - Wallpaper Engine Assets Root Bookmark
+
+    /// Persists the security-scoped bookmark to the Wallpaper Engine install
+    /// root. Scene renderers mount `<root>/assets` as a read-only fallback so
+    /// projects that reference shared engine framework files (e.g.
+    /// `materials/util/composelayer.json`) can resolve them.
+    func saveWPEEngineAssetsBookmark(_ bookmark: Data) {
+        UserDefaults.standard.set(bookmark, forKey: Keys.wpeEngineAssetsRootBookmark)
+        NotificationCenter.default.post(name: .wpeEngineAssetsBookmarkDidChange, object: nil)
+    }
+
+    func loadWPEEngineAssetsBookmark() -> Data? {
+        UserDefaults.standard.data(forKey: Keys.wpeEngineAssetsRootBookmark)
+    }
+
+    func clearWPEEngineAssetsBookmark() {
+        UserDefaults.standard.removeObject(forKey: Keys.wpeEngineAssetsRootBookmark)
+        NotificationCenter.default.post(name: .wpeEngineAssetsBookmarkDidChange, object: nil)
+    }
+
     private func applyStartOnLoginSetting(_ startOnLogin: Bool) {
         do {
             let service = SMAppService.mainApp
@@ -214,6 +235,7 @@ final class SettingsManager {
         UserDefaults.standard.removeObject(forKey: Keys.bookmarks)
         UserDefaults.standard.removeObject(forKey: Keys.trustedHosts)
         UserDefaults.standard.removeObject(forKey: Keys.workshopLibraryRootBookmark)
+        UserDefaults.standard.removeObject(forKey: Keys.wpeEngineAssetsRootBookmark)
         UserDefaults.standard.removeObject(forKey: Keys.appLanguage)
         // `configMigrationVersion` is intentionally preserved — it tracks
         // "which migration steps have already been applied to this install",

--- a/LiveWallpaper/Views/ScreenDetail/WPEFallbackCard.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEFallbackCard.swift
@@ -5,12 +5,12 @@ import AppKit
 /// to the inspector so the user gets a specific reason instead of a generic
 /// "unsupported" message.
 enum FallbackReason: Equatable, Sendable {
-    // Phase 2.0
+    // Scene diagnostics
     case unsupportedType
     case sceneParseFailed(String)
     case sceneShaderUnsupported
     case sceneResourceMissing
-    // Phase 2.0.1
+    // Dependency / platform gating
     /// Project declares Steam Workshop dependencies we couldn't satisfy
     /// from the local cache. Lists IDs the user must subscribe to in
     /// Steam before retrying the import.
@@ -18,8 +18,8 @@ enum FallbackReason: Equatable, Sendable {
     /// Project ships a Windows `.dll` plugin under `bin/`. Permanent on
     /// macOS — subscribing more workshop items will not help.
     case requiresWindowsPlugin
-    // Phase 2.1 — `.tex` decoder failures with precise codes so the user
-    // sees "Format 8 (RGBA1010102) not yet supported" instead of a vague
+    // Texture decoder failures with precise codes so the user sees
+    // "Format 8 (RGBA1010102) not yet supported" instead of a vague
     // "scene unsupported".
     case texContainerUnsupported(magic: String)
     case texUnsupportedFormat(code: Int)
@@ -243,11 +243,11 @@ struct WPEFallbackCard: View {
                 return String(localized: "We couldn't recognize this Wallpaper Engine project type.", defaultValue: "We couldn't recognize this Wallpaper Engine project type.", comment: "Wallpaper Engine fallback warning body.")
             }
         case .sceneParseFailed(let detail):
-            return String(localized: "Phase 2.0 ships an image-only renderer. The author's scene.json couldn't be parsed: \(detail)", comment: "Wallpaper Engine fallback warning body. The placeholder is parser detail.")
+            return String(localized: "The author's scene.json couldn't be parsed: \(detail)", comment: "Wallpaper Engine fallback warning body. The placeholder is parser detail.")
         case .sceneShaderUnsupported:
-            return String(localized: "This scene relies on custom shaders that the image-only Phase 2.0 renderer can't compile yet.", defaultValue: "This scene relies on custom shaders that the image-only Phase 2.0 renderer can't compile yet.", comment: "Wallpaper Engine fallback warning body.")
+            return String(localized: "This scene uses a custom shader the renderer couldn't translate to Metal. Try re-downloading the project in Steam.", defaultValue: "This scene uses a custom shader the renderer couldn't translate to Metal. Try re-downloading the project in Steam.", comment: "Wallpaper Engine fallback warning body.")
         case .sceneResourceMissing:
-            return String(localized: "Some image layers couldn't be located inside the cache. The wallpaper may have been published partially or your cache is corrupted.", defaultValue: "Some image layers couldn't be located inside the cache. The wallpaper may have been published partially or your cache is corrupted.", comment: "Wallpaper Engine fallback warning body.")
+            return String(localized: "Some assets the scene needs aren't where the renderer expected them. If the scene references shared Wallpaper Engine framework files (materials/util, models/util), open the Workshop Library and grant your Wallpaper Engine install folder via the Engine Assets menu — most other cases mean re-downloading the project in Steam will fix it.", defaultValue: "Some assets the scene needs aren't where the renderer expected them. If the scene references shared Wallpaper Engine framework files (materials/util, models/util), open the Workshop Library and grant your Wallpaper Engine install folder via the Engine Assets menu — most other cases mean re-downloading the project in Steam will fix it.", comment: "Wallpaper Engine fallback warning body.")
         case .missingDependency:
             return String(localized: "This wallpaper relies on other Workshop projects we don't have on disk yet. Subscribe to them in Steam, then re-import this folder.", defaultValue: "This wallpaper relies on other Workshop projects we don't have on disk yet. Subscribe to them in Steam, then re-import this folder.", comment: "Wallpaper Engine fallback warning body.")
         case .requiresWindowsPlugin:

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneDetailView.swift
@@ -2,10 +2,11 @@ import AppKit
 import SpriteKit
 import SwiftUI
 
-/// Phase 2.0 scene detail card. Drives the loading/playing/paused/error state
-/// machine on top of the SKView the wallpaper session already mounted into
-/// the desktop window. The inspector reuses the same `SceneRenderingController`
-/// instance so the preview seen here is byte-identical to the live wallpaper.
+/// Scene detail card for Wallpaper Engine projects. Drives the loading /
+/// playing / paused / error state machine on top of the renderer view the
+/// wallpaper session already mounted into the desktop window. The inspector
+/// reuses the same renderer instance so the preview seen here is
+/// byte-identical to the live wallpaper.
 @MainActor
 struct WPESceneDetailView: View {
     let origin: WPEOrigin
@@ -166,7 +167,7 @@ struct WPESceneDetailView: View {
         case .sceneParseFailed(let detail):
             return Text(verbatim: detail)
         case .sceneShaderUnsupported:
-            return Text("Phase 2.0 ships an image-only renderer.")
+            return Text("A custom shader couldn't be translated. Try re-downloading the project.")
         case .sceneResourceMissing:
             return Text("Image layers couldn't be located inside the cache.")
         case .missingDependency(let ids):

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
@@ -12,32 +12,54 @@ struct WPESceneSection: View {
     @State private var selectedHistoryEntry: WPEHistoryEntry?
     @State private var showWorkshopGallery: Bool = false
     @State private var pendingDestructive: PendingDestructive?
+    /// User has opted out of seeing the engine-assets banner for this
+    /// run. Resets to `false` on next launch so granting access later
+    /// (or removing the grant) re-evaluates banner visibility.
+    @State private var bannerDismissedForSession: Bool = false
+    @State private var isEngineAssetsAuthorized: Bool = WPEEngineAssetsLibrary.shared.isAuthorized
 
     var body: some View {
-        Group {
-            if hasActiveSceneWallpaper {
-                activeSceneCard
-            } else if recentImports.isEmpty {
-                emptyState
-            } else if let selected = selectedHistoryEntry {
-                unsupportedDetail(for: selected)
-            } else {
-                historyList
+        VStack(spacing: 0) {
+            if shouldShowEngineAssetsBanner {
+                engineAssetsBanner
+                    .padding([.horizontal, .top], 24)
+                    .padding(.bottom, 8)
+                    // Slide-in from the top so the layout shift is read as
+                    // "new affordance arriving" rather than a jarring jump.
+                    // Reduce Motion swaps the spring for a cross-fade
+                    // automatically per SwiftUI accessibility semantics.
+                    .transition(.move(edge: .top).combined(with: .opacity))
             }
+            Group {
+                if hasActiveSceneWallpaper {
+                    activeSceneCard
+                } else if recentImports.isEmpty {
+                    emptyState
+                } else if let selected = selectedHistoryEntry {
+                    unsupportedDetail(for: selected)
+                } else {
+                    historyList
+                }
+            }
+            // Animate only the empty↔grid transition (both pure-SwiftUI
+            // subtrees). Cross-branch animation into `unsupportedDetail` is
+            // deliberately skipped because that branch hosts
+            // `WPEPreviewView` (NSViewRepresentable) and animating across
+            // NSView boundaries triggers an AppKit Auto-Layout constraint
+            // cycle (`needs Update Constraints in Window pass …`).
+            .animation(.default, value: recentImports.isEmpty)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        // Animate only the empty↔grid transition (both pure-SwiftUI subtrees).
-        // Cross-branch animation into `unsupportedDetail` is deliberately
-        // skipped because that branch hosts `WPEPreviewView` (NSViewRepresentable)
-        // and animating across NSView boundaries triggers an AppKit Auto-Layout
-        // constraint cycle (`needs Update Constraints in Window pass …`).
-        .animation(.default, value: recentImports.isEmpty)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.spring(response: 0.35, dampingFraction: 0.85), value: shouldShowEngineAssetsBanner)
         .onAppear {
             // `reloadHistory()` writes `recentImports` / `selectedHistoryEntry`
             // @State — defer to next main-actor tick to keep the first paint
             // out of the "Modifying state during view update" cascade. Same
             // pattern as the .onReceive handlers below.
-            Task { @MainActor in reloadHistory() }
+            Task { @MainActor in
+                reloadHistory()
+                isEngineAssetsAuthorized = WPEEngineAssetsLibrary.shared.isAuthorized
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .wpeImportDidComplete)) { notification in
             Task { @MainActor in
@@ -47,6 +69,11 @@ struct WPESceneSection: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .wpeHistoryDidChange)) { _ in
             Task { @MainActor in reloadHistory() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .wpeEngineAssetsBookmarkDidChange)) { _ in
+            Task { @MainActor in
+                isEngineAssetsAuthorized = WPEEngineAssetsLibrary.shared.isAuthorized
+            }
         }
         .sheet(isPresented: $showWorkshopGallery) {
             WorkshopGalleryView(screen: screen)
@@ -60,6 +87,60 @@ struct WPESceneSection: View {
                 set: { if $0 == nil { screenManager.clearWPEImportError(for: screen) } }
             )
         )
+    }
+
+    // MARK: - Engine assets banner
+
+    /// Banner appears when (a) we don't already have access AND
+    /// (b) the user has at least tried to import a scene AND
+    /// (c) the user hasn't dismissed it this session. Hiding on the empty
+    /// state keeps the very first launch focused on the primary CTA.
+    private var shouldShowEngineAssetsBanner: Bool {
+        !isEngineAssetsAuthorized
+            && !bannerDismissedForSession
+            && !recentImports.isEmpty
+    }
+
+    private var engineAssetsBanner: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                Image(systemName: "puzzlepiece.extension")
+                    .font(.title2)
+                    .foregroundStyle(.yellow)
+                    .accessibilityHidden(true)
+                Text("Grant Wallpaper Engine install folder")
+                    .font(.headline)
+            }
+            Text("Many scenes reference shared engine framework files (materials/util/composelayer.json, models/util/*.json, effects/*). Grant your Wallpaper Engine install folder so we can resolve them like WPE does.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                Button {
+                    Task { @MainActor in
+                        _ = await WPEEngineAssetsLibrary.shared.requestAccess()
+                    }
+                } label: {
+                    Label("Grant Folder…", systemImage: "folder.badge.plus")
+                }
+                .buttonStyle(.glassProminent)
+                .controlSize(.regular)
+                .accessibilityHint(Text("Opens a folder chooser to grant access to your Wallpaper Engine install root"))
+
+                Button {
+                    bannerDismissedForSession = true
+                } label: {
+                    Label("Skip for now", systemImage: "xmark")
+                }
+                .buttonStyle(.glass)
+                .controlSize(.regular)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .glassEffect(.regular, in: .rect(cornerRadius: 16))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("Grant Wallpaper Engine install folder. Many scenes need access to shared engine framework files (materials, models, effects) to render correctly."))
     }
 
     // MARK: - States

--- a/LiveWallpaper/Views/ScreenDetail/WorkshopGalleryView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WorkshopGalleryView.swift
@@ -89,6 +89,12 @@ struct WorkshopGalleryView: View {
     @State private var pendingDestructive: PendingDestructive?
     @State private var sortOrder: WorkshopProjectSortOrder = .recommended
     @State private var bookmarkStore = BookmarkStore.shared
+    /// Mirrors `WPEEngineAssetsLibrary.shared.isAuthorized` so the toolbar
+    /// chip reflects current state without consumers having to subscribe
+    /// to the @Observable directly. Refreshed via the
+    /// `wpeEngineAssetsBookmarkDidChange` notification.
+    @State private var isEngineAssetsAuthorized: Bool = WPEEngineAssetsLibrary.shared.isAuthorized
+    @State private var engineAssetsDisplayName: String? = WPEEngineAssetsLibrary.shared.engineRootDisplayName
 
     private let scanner = WallpaperEngineLibraryScanner()
 
@@ -132,8 +138,17 @@ struct WorkshopGalleryView: View {
         .onReceive(NotificationCenter.default.publisher(for: .screensRefreshed)) { _ in
             Task { @MainActor in selectInitialTargetIfNeeded() }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .wpeEngineAssetsBookmarkDidChange)) { _ in
+            Task { @MainActor in refreshEngineAssetsState() }
+        }
         .errorAlert("Library Error", message: $errorMessage)
         .confirmDestructive($pendingDestructive)
+    }
+
+    private func refreshEngineAssetsState() {
+        let library = WPEEngineAssetsLibrary.shared
+        isEngineAssetsAuthorized = library.isAuthorized
+        engineAssetsDisplayName = library.engineRootDisplayName
     }
 
     // MARK: - Header
@@ -195,6 +210,8 @@ struct WorkshopGalleryView: View {
                             .buttonStyle(WorkshopToolbarButtonStyle(tint: .secondary))
                             .accessibilityHint(Text("Change or forget the selected Steam Workshop folder"))
                             .disabled(isBusy)
+
+                            engineAssetsMenu
                         }
 
                         if !allowsTargetSelection {
@@ -400,6 +417,62 @@ struct WorkshopGalleryView: View {
         }
         .padding(24)
         .frame(maxWidth: .infinity, alignment: .top)
+    }
+
+    // MARK: - Engine Assets
+
+    /// Toolbar peer of "Library Folder". Lets the user grant / forget the
+    /// Wallpaper Engine install root — the same bookmark the runtime
+    /// resolver falls through to for shared framework files
+    /// (`materials/util/composelayer.json`, `models/util/*.json`, …).
+    @ViewBuilder
+    private var engineAssetsMenu: some View {
+        Menu {
+            if isEngineAssetsAuthorized {
+                if let displayName = engineAssetsDisplayName {
+                    Text("Granted: \(displayName)")
+                }
+                Button {
+                    presentEngineAssetsGrant()
+                } label: {
+                    Label("Change Engine Folder...", systemImage: "folder.badge.gearshape")
+                }
+                Button(role: .destructive) {
+                    confirmDisconnectEngineAssets()
+                } label: {
+                    Label("Forget Engine Folder", systemImage: "xmark.circle")
+                }
+            } else {
+                Button {
+                    presentEngineAssetsGrant()
+                } label: {
+                    Label("Grant Engine Folder…", systemImage: "folder.badge.plus")
+                }
+            }
+        } label: {
+            Label("Engine Assets", systemImage: isEngineAssetsAuthorized ? "puzzlepiece.extension.fill" : "puzzlepiece.extension")
+        }
+        .menuStyle(.button)
+        .buttonStyle(WorkshopToolbarButtonStyle(tint: isEngineAssetsAuthorized ? .secondary : .yellow))
+        .accessibilityHint(Text("Grant or forget the Wallpaper Engine install folder so scenes can resolve shared framework files"))
+        .disabled(isBusy)
+    }
+
+    private func presentEngineAssetsGrant() {
+        Task { @MainActor in
+            _ = await WPEEngineAssetsLibrary.shared.requestAccess()
+        }
+    }
+
+    private func confirmDisconnectEngineAssets() {
+        let path = engineAssetsDisplayName ?? String(
+            localized: "your Wallpaper Engine install folder",
+            defaultValue: "your Wallpaper Engine install folder",
+            comment: "Fallback label used in the engine assets disconnect confirmation when no display name is available."
+        )
+        pendingDestructive = PendingDestructive(.forgetEngineAssets(path: path)) {
+            WPEEngineAssetsLibrary.shared.clearAccess()
+        }
     }
 
     // MARK: - Actions

--- a/LiveWallpaper/Views/Styles/DestructiveActionPolicy.swift
+++ b/LiveWallpaper/Views/Styles/DestructiveActionPolicy.swift
@@ -20,6 +20,7 @@ enum DestructiveAction: Identifiable, Equatable {
     case disableSchedule(slotCount: Int)
     case clearUnusedWallpapers(itemCount: Int, byteSize: String)
     case forgetWorkshopLibrary(path: String)
+    case forgetEngineAssets(path: String)
     case removeHistoryEntry(name: String)
     case clearAllShortcuts
     case resetShortcut(commandName: String)
@@ -40,6 +41,7 @@ enum DestructiveAction: Identifiable, Equatable {
         case .disableSchedule(let c): return "disableSchedule-\(c)"
         case .clearUnusedWallpapers(let i, let b): return "clearUnusedWallpapers-\(i)-\(b)"
         case .forgetWorkshopLibrary(let p): return "forgetWorkshopLibrary-\(p)"
+        case .forgetEngineAssets(let p): return "forgetEngineAssets-\(p)"
         case .removeHistoryEntry(let n): return "removeHistoryEntry-\(n)"
         case .clearAllShortcuts: return "clearAllShortcuts"
         case .resetShortcut(let n): return "resetShortcut-\(n)"
@@ -63,6 +65,7 @@ enum DestructiveAction: Identifiable, Equatable {
         case .disableSchedule:           return "Disable schedule?"
         case .clearUnusedWallpapers:     return "Clear unused wallpapers?"
         case .forgetWorkshopLibrary:     return "Forget Workshop library?"
+        case .forgetEngineAssets:        return "Forget Wallpaper Engine install folder?"
         case .removeHistoryEntry:        return "Remove from history?"
         case .clearAllShortcuts:         return "Reset all keyboard shortcuts?"
         case .resetShortcut:             return "Reset this shortcut?"
@@ -97,6 +100,8 @@ enum DestructiveAction: Identifiable, Equatable {
             return "Removes \(itemCount) items · \(byteSize) not displayed for more than 30 days. Currently-applied and pinned wallpapers are untouched."
         case .forgetWorkshopLibrary(let path):
             return "The library at '\(path)' will be unlinked. Local scene caches are kept; you can re-link the folder later."
+        case .forgetEngineAssets(let path):
+            return "The Wallpaper Engine install folder at '\(path)' will be unlinked. Scenes that depend on shared engine framework files will fail to render until you grant access again."
         case .removeHistoryEntry(let name):
             return "'\(name)' will be removed from your recent items. The underlying file or scene is not deleted."
         case .clearAllShortcuts:
@@ -128,6 +133,7 @@ enum DestructiveAction: Identifiable, Equatable {
         case .disableSchedule:           return "Disable Schedule"
         case .clearUnusedWallpapers(let itemCount, _): return "Clear \(itemCount) Items"
         case .forgetWorkshopLibrary:     return "Forget Library"
+        case .forgetEngineAssets:        return "Forget Engine Folder"
         case .removeHistoryEntry:        return "Remove"
         case .clearAllShortcuts:         return "Reset All"
         case .resetShortcut:             return "Reset"

--- a/LiveWallpaperTests/WPEMultiRootResourceResolverTests.swift
+++ b/LiveWallpaperTests/WPEMultiRootResourceResolverTests.swift
@@ -23,11 +23,85 @@ struct WPEMultiRootResourceResolverTests {
         #expect(url.lastPathComponent == "dep.png")
     }
 
+    @Test("Engine assets fallback resolves only after primary miss")
+    func engineAssetsFallbackResolvesOnlyAfterPrimaryMiss() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+
+        let primaryMaterials = fixture.primaryRoot.appendingPathComponent("materials/util", isDirectory: true)
+        let engineMaterials = fixture.engineRoot.appendingPathComponent("assets/materials/util", isDirectory: true)
+        try FileManager.default.createDirectory(at: primaryMaterials, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: engineMaterials, withIntermediateDirectories: true)
+        try Data("primary".utf8).write(to: primaryMaterials.appendingPathComponent("composelayer.json"))
+        try Data("engine".utf8).write(to: engineMaterials.appendingPathComponent("fallback.json"))
+
+        let resolver = WPEMultiRootResourceResolver(
+            primaryRootURL: fixture.primaryRoot,
+            dependencyMounts: [],
+            engineAssetsRootURL: fixture.engineRoot
+        )
+
+        let primaryURL = try resolver.resolveExistingFileURL(relativePath: "materials/util/composelayer.json")
+        let fallbackURL = try resolver.resolveExistingFileURL(relativePath: "materials/util/fallback.json")
+
+        #expect(String(data: try Data(contentsOf: primaryURL), encoding: .utf8) == "primary")
+        #expect(String(data: try Data(contentsOf: fallbackURL), encoding: .utf8) == "engine")
+    }
+
+    @Test("Engine assets fallback does not shadow project's own files")
+    func engineAssetsFallbackDoesNotShadowProjectFiles() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+
+        let primaryMaterials = fixture.primaryRoot.appendingPathComponent("materials", isDirectory: true)
+        let engineMaterials = fixture.engineRoot.appendingPathComponent("assets/materials", isDirectory: true)
+        try FileManager.default.createDirectory(at: primaryMaterials, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: engineMaterials, withIntermediateDirectories: true)
+        // Project ships its own copy AND the engine ships a different one
+        // at the same relative path. The project copy must always win.
+        try Data("project-version".utf8).write(to: primaryMaterials.appendingPathComponent("composelayer.json"))
+        try Data("engine-version".utf8).write(to: engineMaterials.appendingPathComponent("composelayer.json"))
+
+        let resolver = WPEMultiRootResourceResolver(
+            primaryRootURL: fixture.primaryRoot,
+            dependencyMounts: [],
+            engineAssetsRootURL: fixture.engineRoot
+        )
+
+        let url = try resolver.resolveExistingFileURL(relativePath: "materials/composelayer.json")
+        #expect(String(data: try Data(contentsOf: url), encoding: .utf8) == "project-version")
+    }
+
+    @Test("Engine assets fallback only triggers on .fileMissing")
+    func engineAssetsFallbackOnlyTriggersOnFileMissing() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+
+        let resolver = WPEMultiRootResourceResolver(
+            primaryRootURL: fixture.primaryRoot,
+            dependencyMounts: [],
+            engineAssetsRootURL: fixture.engineRoot
+        )
+
+        // pathEscape from primary must NOT retry against engine root —
+        // pathEscape means the user-supplied path was malformed, not that
+        // we picked the wrong root. Use the dependency-style escape path:
+        // "../" prefix triggers `dependencyReference` short-circuit but
+        // since no mounts are declared it throws pathEscape directly.
+        #expect(throws: SceneResourceResolver.ResolveError.pathEscape) {
+            _ = try resolver.resolveExistingFileURL(relativePath: "../456/materials/x.png")
+        }
+    }
+
     @Test("Undeclared dependency reference is rejected")
     func undeclaredDependencyReferenceRejected() throws {
         let fixture = try makeFixture()
         defer { fixture.cleanup() }
-        let resolver = WPEMultiRootResourceResolver(primaryRootURL: fixture.primaryRoot, dependencyMounts: [])
+        let resolver = WPEMultiRootResourceResolver(
+            primaryRootURL: fixture.primaryRoot,
+            dependencyMounts: [],
+            engineAssetsRootURL: fixture.engineRoot
+        )
 
         #expect(throws: SceneResourceResolver.ResolveError.pathEscape) {
             _ = try resolver.resolveExistingFileURL(relativePath: "../123/materials/dep.png")
@@ -52,6 +126,7 @@ struct WPEMultiRootResourceResolverTests {
         let root: URL
         let primaryRoot: URL
         let dependencyRoot: URL
+        let engineRoot: URL
 
         func cleanup() {
             try? FileManager.default.removeItem(at: root)
@@ -63,8 +138,10 @@ struct WPEMultiRootResourceResolverTests {
             .appendingPathComponent("WPEMultiRootResourceResolverTests-\(UUID().uuidString)", isDirectory: true)
         let primary = root.appendingPathComponent("primary", isDirectory: true)
         let dependency = root.appendingPathComponent("dependency", isDirectory: true)
+        let engine = root.appendingPathComponent("engine", isDirectory: true)
         try FileManager.default.createDirectory(at: primary, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: dependency, withIntermediateDirectories: true)
-        return Fixture(root: root, primaryRoot: primary, dependencyRoot: dependency)
+        try FileManager.default.createDirectory(at: engine, withIntermediateDirectories: true)
+        return Fixture(root: root, primaryRoot: primary, dependencyRoot: dependency, engineRoot: engine)
     }
 }

--- a/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
+++ b/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
@@ -642,6 +642,50 @@ struct WallpaperEngineImportServiceTests {
         #expect(origin.resourceLocation == .cache)
     }
 
+    @Test("Scene import persists preflight tier and feature flags")
+    func sceneImportPersistsPreflightMetadata() async throws {
+        let sceneJSON = """
+        {
+            "camera": { "center": "0 0 0" },
+            "general": {
+                "orthogonalprojection": { "width": 1920, "height": 1080, "auto": true }
+            },
+            "objects": [{
+                "id": "layer1",
+                "name": "Layer 1",
+                "type": "image",
+                "image": "materials/layer.png"
+            }]
+        }
+        """
+        let png = try makeFixturePNG(width: 1, height: 1)
+        let fixture = try makeFixture(
+            type: .scene,
+            entryFile: "scene.json",
+            pkgEntries: [
+                PackageEntrySpec("scene.json", Array(sceneJSON.utf8)),
+                PackageEntrySpec("materials/layer.png", Array(png)),
+                PackageEntrySpec("shaders/custom.frag", Array("void main() {}".utf8))
+            ]
+        )
+        defer { fixture.cleanup() }
+
+        let result = try await fixture.service.importProject(folder: fixture.folderURL)
+
+        guard case .ready(let content, _) = result else {
+            Issue.record("Expected .ready, got \(result)")
+            return
+        }
+        guard case .scene(let descriptor) = content else {
+            Issue.record("Expected .scene content, got \(content)")
+            return
+        }
+
+        #expect(descriptor.capabilityTier == .imageOnly)
+        #expect(descriptor.preflightTier == .degradedPlayable)
+        #expect(descriptor.preflightFeatureFlags == [.customShaderSource])
+    }
+
     @Test("Cached content resolver rebuilds scene descriptor by reclassifying scene.json")
     func cachedContentResolverRebuildsSceneDescriptor() throws {
         let fileManager = FileManager.default
@@ -663,6 +707,11 @@ struct WallpaperEngineImportServiceTests {
         }
         """
         try Data(sceneJSON.utf8).write(to: cacheURL.appendingPathComponent("scene.json"))
+        // Drop a custom shader file in the cache so preflight detects the
+        // `.customShaderSource` flag during reclassification.
+        let shaderDir = cacheURL.appendingPathComponent("shaders", isDirectory: true)
+        try fileManager.createDirectory(at: shaderDir, withIntermediateDirectories: true)
+        try Data("void main() {}".utf8).write(to: shaderDir.appendingPathComponent("cached.frag"))
 
         let origin = WPEOrigin(
             workshopID: "resolve-scene",
@@ -688,6 +737,11 @@ struct WallpaperEngineImportServiceTests {
         #expect(descriptor.entryFile == "scene.json")
         #expect(descriptor.capabilityTier == .unsupported)
         #expect(descriptor.dependencyWorkshopIDs == [])
+        // Preflight reclassification picks up the custom shader source on
+        // the cached side too — the descriptor should carry the same flag
+        // set the first-import path would have produced.
+        #expect(descriptor.preflightTier == .degradedPlayable)
+        #expect(descriptor.preflightFeatureFlags == [.customShaderSource])
     }
 
     @Test("Cached content resolver rebuilds packaged video without source folder access")


### PR DESCRIPTION
## Summary

Fixes the "WPE graph asset missing: models/util/composelayer.json" cascade for scene wallpapers, plus wires the already-shipped `WPEScenePreflight` classifier into the import flow and clears stale Phase 2.0 copy.

**Root cause:** scenes reference shared Wallpaper Engine framework files (`materials/util/*.json`, `models/util/*.json`, `effects/*`, shader `#include` helpers) that live in WPE's own install root, not inside the user-imported project folder. Our resolver only mounted the project + declared Workshop dependencies, so every framework reference threw `WPERenderGraphError.fileMissing` even though the projects play fine in WPE itself.

**Coverage trajectory** (estimated against the 33-scene `431960` corpus, on top of what PR #48 already enabled):
- Before this PR: scenes referencing `materials/util/composelayer.json` / `models/util/*.json` / shader helpers → red error after spinner.
- After: granted-once WPE install folder + transparent fall-through; expected to recover ~10+ additional scenes that hit the framework-asset path.

## What landed

### P0 — Engine-assets fallback (the big one)

- New `WPEEngineAssetsLibrary` (mirrors `AppleAerialsLibrary`): one-time security-scoped bookmark to the WPE install root. Validates the chosen folder contains `assets/`; auto-walks `Contents/Resources/` when the user picks `Wallpaper Engine.app`. Suggests common Steam + /Applications paths.
- Preserves the bookmark across transient resolution failures (5b0e006 defensive pattern); only an explicit "Forget" clears it.
- `WPEMultiRootResourceResolver` grows an optional engine-assets resolver tried ONLY on `.fileMissing`. `.pathEscape`, `.materialUnresolved`, `.texture` propagate without retry — the engine root can't fix a malformed path or a project's broken JSON chain.
- Same fall-through wires into `WPERenderPipelineBuilder`'s shader-source loader so `#include` resolution lands on the engine root for shared helpers (`common_composite.h`, etc.). Existing callers' error contract is preserved: `WPERenderPipelineError.includeMissing` still flies.
- `WPEMetalSceneRenderer` + `SceneRenderingController` open the scope at init, hand the URL through graph + pipeline builders, and stop the scope in `cleanup()` / `deinit`. Throwing init is now scope-safe (executor init runs **before** `startAccessingSecurityScopedResource()` — codex audit catch).

### P1 — Scene preflight wiring

- Both `importProject` (first-import) and `WPECachedContentResolver.content(for:)` (re-mount) now call `WPEScenePreflight.classify(...)` and persist `preflightTier` + `preflightFeatureFlags` on the `SceneDescriptor`.
- The 5-tier model (`.nativePlayable` / `.degradedPlayable` / `.shaderTranslationRequired` / `.runtimeSystemsRequired` / `.unsupported`) finally exits the test-only state.
- A small `scenePackageEntryNames(...)` walks the cache root (capped at 10k entries) so preflight can detect `.vert` / `.frag` payloads.
- Old `WPESceneCapabilityClassifier` intentionally kept — consolidation is a separate iteration.

### P2 — UI

- `WPESceneSection` engine-assets banner: yellow severity tint, Liquid Glass material, spring slide-from-top transition (Reduce-Motion-safe per SwiftUI accessibility semantics). "Skip for now" hides for the session; auto-rebinds via `wpeEngineAssetsBookmarkDidChange`.
- `WorkshopGalleryView` toolbar gets an "Engine Assets" peer menu next to "Library Folder", state-aware icon, destructive `.forgetEngineAssets` routed through `pendingDestructive`.
- Stale "Phase 2.0 ships an image-only renderer" copy replaced everywhere (`WPEFallbackCard` parse / shader / resource-missing bodies + `WPESceneDetailView`). The `sceneResourceMissing` body now self-recovers by pointing users at the new menu.

## Multi-agent process

- **codex** (architect role, session `019e2c7d`) generated the P0 backend + P1 wiring prototype, then audited the landed code — caught a High-severity scope-leak edge in the Metal renderer's throwing init path. Fixed: executor init moved before scope start.
- **gemini** (frontend role, session `2ba7300f`) generated the banner + toolbar UI prototype, then reviewed the final UI — flagged 3 minor polish items (animation, a11y label, copy disambiguation). All accepted.

## Build + tests

- `xcodebuild build` ✅ BUILD SUCCEEDED (3 pre-existing warnings, 0 new errors)
- 622 unit tests: 621 pass / 1 fail. The only failure is `LocalizationCoverageTests` flagging missing zh-Hans translations for English strings added in earlier sessions — unrelated to this PR.

New test coverage:
- `WPEMultiRootResourceResolverTests`: engine fallback resolves only after `.fileMissing`, never shadows project files, never retries on `.pathEscape`. Existing dependency-mount tests carry the new param.
- `WallpaperEngineImportServiceTests`: scene import persists `preflightTier = .degradedPlayable` + `[.customShaderSource]` when shipping `.frag`. Cached-content reclassification roundtrip asserts preflight metadata.

## Test plan

- [ ] Smoke: import a Workshop scene that previously failed with `WPE graph asset missing: materials/util/composelayer.json`; grant WPE install folder via the new banner; verify the scene renders.
- [ ] Multi-display: scope reference-count stability — apply the same scene to 2+ displays simultaneously, then clear them one at a time. Verify no scope-leak warnings in console.
- [ ] Forget flow: forget the engine folder via the Workshop Library toolbar menu; verify the destructive confirmation appears, scenes fall back to red error on next reload, and granting again recovers them.
- [ ] Stale bookmark: Migration Assistant moves home folder → bookmark should refresh in place (info log "bookmark is stale; refreshing in place"), not get cleared.
- [ ] Banner UX: with no recent imports, the banner stays hidden on first launch. After one import, the banner appears with spring animation. "Skip for now" dismisses until next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)