### PR TITLE
WPE Phase A.3: corpus playback test harness + DEBUG dev menu

### DIFF
--- a/LiveWallpaper/Runtime/WPECorpusPlaybackHarness.swift
+++ b/LiveWallpaper/Runtime/WPECorpusPlaybackHarness.swift
@@ -1,0 +1,635 @@
+import AppKit
+import Foundation
+import Metal
+
+#if DEBUG
+
+/// JSON-serialisable summary of one corpus playback run. Phase A.3 output —
+/// drives the DEBUG developer-tools view and is the artifact maintainers
+/// share when triaging which subset of the workshop corpus fails to load.
+struct WPECorpusPlaybackReport: Codable, Sendable {
+    let generatedAt: Date
+    let perSceneTimeoutSeconds: Double
+    let total: Int
+    let summary: Summary
+    let entries: [Entry]
+
+    struct Summary: Codable, Sendable {
+        let passCount: Int
+        let failCount: Int
+        let timeoutCount: Int
+        let skippedCount: Int
+    }
+
+    struct Entry: Codable, Sendable, Identifiable {
+        let workshopID: String
+        let title: String
+        let capabilityTier: SceneCapabilityTier?
+        let preflightTier: WPEScenePreflightTier?
+        let result: Outcome
+        let elapsedSeconds: Double
+        let failureMessage: String?
+        let resolution: ResolutionSummary
+
+        var id: String { workshopID }
+
+        enum Outcome: String, Codable, Sendable {
+            case pass
+            case fail
+            case timeout
+            case skipped
+        }
+
+        struct ResolutionSummary: Codable, Sendable {
+            let events: Int
+            let resolved: Int
+            let missing: Int
+            let firstMisses: [String]
+
+            static let empty = Self(events: 0, resolved: 0, missing: 0, firstMisses: [])
+        }
+    }
+}
+
+/// Headless driver that runs `WPEMetalSceneRenderer.load()` against every
+/// imported scene workshop project and aggregates the outcome. Phase A.3:
+/// turns "57 unknown scenes" into "P pass / F fail / T timeout" with per-
+/// scene resolution diagnostics so Phase B has a target list.
+///
+/// The harness owns the renderer lifetime per scene — it builds the same
+/// `VideoWallpaperWindow` + renderer combo `AmbientWallpaperSessionBuilder`
+/// uses, but the window is held at `alphaValue = 0` and ordered to the
+/// wallpaper level so nothing flashes on the user's desktop while the loop
+/// runs.
+@MainActor
+final class WPECorpusPlaybackHarness {
+    struct Configuration: Sendable {
+        var perSceneTimeoutSeconds: Double = 8
+        var rendererFrame: CGSize = CGSize(width: 1920, height: 1080)
+    }
+
+    enum Progress: Sendable {
+        case scanning
+        case running(index: Int, total: Int, workshopID: String, title: String)
+        case sceneComplete(WPECorpusPlaybackReport.Entry)
+        case finished(WPECorpusPlaybackReport)
+        case cancelled(WPECorpusPlaybackReport)
+        case failedToStart(String)
+    }
+
+    private struct HeadlessSession {
+        let renderer: WPESceneRenderer
+        let window: NSWindow
+    }
+
+    private struct TimeoutError: Error, LocalizedError, Sendable {
+        let seconds: Double
+
+        var errorDescription: String? {
+            "Timed out after \(String(format: "%.1f", seconds))s waiting for renderer.load()."
+        }
+    }
+
+    private enum HarnessError: Error, LocalizedError, Sendable {
+        case metalUnavailable
+
+        var errorDescription: String? {
+            switch self {
+            case .metalUnavailable:
+                return "Metal is unavailable on this Mac."
+            }
+        }
+    }
+
+    private let configuration: Configuration
+    private let cache: WallpaperEngineCache
+
+    init(
+        configuration: Configuration = .init(),
+        cache: WallpaperEngineCache = .init()
+    ) {
+        self.configuration = configuration
+        self.cache = cache
+    }
+
+    func run(
+        progress: @escaping @MainActor (Progress) -> Void,
+        isCancelled: @escaping @MainActor () -> Bool
+    ) async {
+        progress(.scanning)
+        Logger.info("WPE corpus playback: scanning Workshop library", category: .screenManager)
+
+        guard let rootBookmarkData = SettingsManager.shared.loadWorkshopLibraryRootBookmark() else {
+            let message = "Workshop library root bookmark is missing."
+            Logger.error("WPE corpus playback could not start: \(message)", category: .screenManager)
+            progress(.failedToStart(message))
+            return
+        }
+
+        let projects: [WallpaperEngineLibraryScanner.DiscoveredProject]
+        do {
+            // `alreadyImported` only flips a flag on each row; pass an empty
+            // set so the scan is a pure inventory of the library.
+            projects = try await WallpaperEngineLibraryScanner()
+                .scan(rootBookmarkData: rootBookmarkData, alreadyImportedWorkshopIDs: [])
+                .filter { $0.type == .scene && $0.hasScenePackage }
+        } catch {
+            let message = Self.describe(error)
+            Logger.error("WPE corpus playback scan failed: \(message)", category: .screenManager)
+            progress(.failedToStart(message))
+            return
+        }
+
+        // The library bookmark needs to stay scoped for the lifetime of the
+        // loop — every per-scene `ensureExtracted` re-reads the source pkg
+        // off the user's library.
+        let libraryRoot: URL
+        do {
+            libraryRoot = try Self.resolveLibraryRoot(bookmarkData: rootBookmarkData)
+        } catch {
+            let message = Self.describe(error)
+            Logger.error("WPE corpus playback could not resolve library root: \(message)", category: .screenManager)
+            progress(.failedToStart(message))
+            return
+        }
+        let didStartScope = libraryRoot.startAccessingSecurityScopedResource()
+        defer {
+            if didStartScope { libraryRoot.stopAccessingSecurityScopedResource() }
+        }
+
+        Logger.info("WPE corpus playback: running \(projects.count) scene projects", category: .screenManager)
+
+        var entries: [WPECorpusPlaybackReport.Entry] = []
+        entries.reserveCapacity(projects.count)
+        let engineAssetsRoot = WPEEngineAssetsLibrary.shared.resolveAuthorizedRoot()
+
+        for (offset, project) in projects.enumerated() {
+            if isCancelled() || Task.isCancelled {
+                let report = makeReport(total: projects.count, entries: entries)
+                Logger.warning("WPE corpus playback cancelled with \(entries.count)/\(projects.count) entries", category: .screenManager)
+                progress(.cancelled(report))
+                return
+            }
+
+            progress(.running(
+                index: offset + 1,
+                total: projects.count,
+                workshopID: project.workshopID,
+                title: project.title
+            ))
+
+            let entry = await runScene(project: project, engineAssetsRoot: engineAssetsRoot)
+            entries.append(entry)
+            progress(.sceneComplete(entry))
+
+            switch entry.result {
+            case .pass:
+                Logger.info("WPE corpus playback passed \(entry.workshopID)", category: .screenManager)
+            case .fail, .timeout, .skipped:
+                Logger.warning(
+                    "WPE corpus playback \(entry.result.rawValue) \(entry.workshopID): \(entry.failureMessage ?? "(no message)")",
+                    category: .screenManager
+                )
+            }
+
+            // Drain Metal + AppKit queues between scenes so the next renderer
+            // sees a clean slate.
+            await Task.yield()
+        }
+
+        let report = makeReport(total: projects.count, entries: entries)
+        Logger.info(
+            "WPE corpus playback finished: pass=\(report.summary.passCount) fail=\(report.summary.failCount) timeout=\(report.summary.timeoutCount) skipped=\(report.summary.skippedCount)",
+            category: .screenManager
+        )
+        progress(.finished(report))
+    }
+
+    private func runScene(
+        project discovered: WallpaperEngineLibraryScanner.DiscoveredProject,
+        engineAssetsRoot: URL?
+    ) async -> WPECorpusPlaybackReport.Entry {
+        let startedAt = Date()
+        var capabilityTier: SceneCapabilityTier?
+        var preflightTier: WPEScenePreflightTier?
+
+        do {
+            let project = try await Self.readProject(from: discovered.folderURL)
+            let sourcePkgURL = discovered.folderURL.appendingPathComponent("scene.pkg")
+            let cacheURL = try await cache.ensureExtracted(
+                workshopID: project.workshopID,
+                sourcePkgURL: sourcePkgURL
+            )
+            let entryURL = try SceneResourceResolver(cacheRootURL: cacheURL)
+                .resolveExistingFileURL(relativePath: project.entryFile)
+            let document = try await Self.readSceneDocument(from: entryURL)
+            let scenePackageEntries = await Self.scenePackageEntryNames(in: cacheURL)
+            let preflight = WPEScenePreflight.classify(
+                document: document,
+                project: project,
+                scenePackageEntries: scenePackageEntries
+            )
+            preflightTier = preflight.tier
+
+            // Pass `origin: nil` — corpus testing doesn't need cross-workshop
+            // Steam-subscription resolution, and synthesising an origin would
+            // require a fresh security-scoped bookmark on every iteration.
+            let dependencyMounts = WPEDependencyMountResolver().mounts(
+                dependencyWorkshopIDs: project.dependencyWorkshopIDs,
+                origin: nil
+            )
+            capabilityTier = await Self.capabilityTier(
+                document: document,
+                cacheURL: cacheURL,
+                dependencyMounts: dependencyMounts,
+                engineAssetsRoot: engineAssetsRoot
+            )
+
+            let descriptor = SceneDescriptor(
+                workshopID: project.workshopID,
+                cacheRelativePath: Self.cacheRelativePath(for: project.workshopID),
+                entryFile: project.entryFile,
+                capabilityTier: capabilityTier ?? .unsupported,
+                dependencyWorkshopIDs: project.dependencyWorkshopIDs,
+                preflightTier: preflight.tier,
+                preflightFeatureFlags: preflight.featureFlags.sorted { $0.rawValue < $1.rawValue }
+            )
+            let headless = try makeHeadlessSession(
+                descriptor: descriptor,
+                dependencyMounts: dependencyMounts,
+                engineAssetsRoot: engineAssetsRoot
+            )
+            defer { tearDown(headless) }
+
+            do {
+                try await loadWithTimeout(
+                    renderer: headless.renderer,
+                    seconds: configuration.perSceneTimeoutSeconds
+                )
+                return makeEntry(
+                    workshopID: project.workshopID,
+                    title: discovered.title.isEmpty ? project.title : discovered.title,
+                    capabilityTier: capabilityTier,
+                    preflightTier: preflightTier,
+                    result: .pass,
+                    startedAt: startedAt,
+                    failureMessage: nil,
+                    resolution: Self.resolutionSummary(from: headless.renderer.resolutionDiagnostics)
+                )
+            } catch let error as TimeoutError {
+                return makeEntry(
+                    workshopID: project.workshopID,
+                    title: discovered.title.isEmpty ? project.title : discovered.title,
+                    capabilityTier: capabilityTier,
+                    preflightTier: preflightTier,
+                    result: .timeout,
+                    startedAt: startedAt,
+                    failureMessage: error.errorDescription,
+                    resolution: Self.resolutionSummary(from: headless.renderer.resolutionDiagnostics)
+                )
+            } catch {
+                let diagnosticMessage = headless.renderer.loadDiagnostics?.errorDescription
+                return makeEntry(
+                    workshopID: project.workshopID,
+                    title: discovered.title.isEmpty ? project.title : discovered.title,
+                    capabilityTier: capabilityTier,
+                    preflightTier: preflightTier,
+                    result: .fail,
+                    startedAt: startedAt,
+                    failureMessage: diagnosticMessage ?? Self.describe(error),
+                    resolution: Self.resolutionSummary(from: headless.renderer.resolutionDiagnostics)
+                )
+            }
+        } catch HarnessError.metalUnavailable {
+            return makeFallbackEntry(
+                discovered: discovered,
+                capabilityTier: capabilityTier,
+                preflightTier: preflightTier,
+                result: .skipped,
+                startedAt: startedAt,
+                failureMessage: HarnessError.metalUnavailable.errorDescription
+            )
+        } catch {
+            return makeFallbackEntry(
+                discovered: discovered,
+                capabilityTier: capabilityTier,
+                preflightTier: preflightTier,
+                result: .fail,
+                startedAt: startedAt,
+                failureMessage: Self.describe(error)
+            )
+        }
+    }
+
+    private func makeHeadlessSession(
+        descriptor: SceneDescriptor,
+        dependencyMounts: [WPEAssetMount],
+        engineAssetsRoot: URL?
+    ) throws -> HeadlessSession {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            throw HarnessError.metalUnavailable
+        }
+
+        let frame = CGRect(origin: .zero, size: configuration.rendererFrame)
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: descriptor,
+            cacheRootURL: applicationSupportCacheURL(for: descriptor),
+            dependencyMounts: dependencyMounts,
+            engineAssetsRootURL: engineAssetsRoot,
+            frame: frame,
+            device: device
+        )
+        // Keep the window in the window server (so CAMetalLayer can produce
+        // drawables for the renderer's first-frame attempt) but invisible
+        // to the user — alphaValue 0 + wallpaper level + orderBack means
+        // the test sweep doesn't flash anything onto the desktop.
+        let window = VideoWallpaperWindow(frame: frame)
+        window.contentView = renderer.nsView
+        window.alphaValue = 0
+        window.orderBack(nil)
+        return HeadlessSession(renderer: renderer, window: window)
+    }
+
+    /// Re-derive the cache URL from the descriptor's `cacheRelativePath`,
+    /// matching the contract `AmbientWallpaperSessionBuilder` enforces. The
+    /// path was already produced by `ensureExtracted`, so any failure here
+    /// means the safety check would have rejected an in-process write too —
+    /// throw the same harness error so the entry is recorded as `.fail`.
+    private func applicationSupportCacheURL(for descriptor: SceneDescriptor) -> URL {
+        let support = (try? FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )) ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+        return support
+            .appendingPathComponent("LiveWallpaper", isDirectory: true)
+            .appendingPathComponent(descriptor.cacheRelativePath, isDirectory: true)
+    }
+
+    private func tearDown(_ headless: HeadlessSession) {
+        headless.renderer.cleanup()
+        headless.window.orderOut(nil)
+        headless.window.contentView = nil
+        headless.window.close()
+    }
+
+    /// Races `renderer.load()` against a wall-clock timeout. Returns when the
+    /// first one resolves; the other is cancelled. A `TaskGroup` would force
+    /// the load closure to be `@Sendable` even though both the closure and
+    /// the renderer are `@MainActor`-isolated, so we drive the race manually
+    /// via a continuation.
+    ///
+    /// On timeout (or any error), we explicitly drain `loadTask.value` before
+    /// returning so the caller's `defer { tearDown(...) }` sees a quiescent
+    /// renderer — otherwise an in-flight `performLoad` could still be
+    /// touching textures and pipeline state after `cleanup()` runs.
+    private func loadWithTimeout(renderer: WPESceneRenderer, seconds: Double) async throws {
+        let nanoseconds = Self.timeoutNanoseconds(for: seconds)
+        let state = TimeoutRaceState()
+        let loadTask = Task { @MainActor in
+            try await renderer.load()
+        }
+
+        do {
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    Task {
+                        do {
+                            try await loadTask.value
+                            if state.markComplete() {
+                                continuation.resume()
+                            }
+                        } catch {
+                            if state.markComplete() {
+                                continuation.resume(throwing: error)
+                            }
+                        }
+                    }
+                    Task {
+                        try? await Task.sleep(nanoseconds: nanoseconds)
+                        if state.markComplete() {
+                            loadTask.cancel()
+                            continuation.resume(throwing: TimeoutError(seconds: seconds))
+                        }
+                    }
+                }
+            } onCancel: {
+                loadTask.cancel()
+            }
+        } catch {
+            // Wait for the cancelled load to actually exit before propagating
+            // — keeps the renderer in a stable state for tearDown.
+            _ = await loadTask.result
+            throw error
+        }
+    }
+
+    private func makeReport(
+        total: Int,
+        entries: [WPECorpusPlaybackReport.Entry]
+    ) -> WPECorpusPlaybackReport {
+        WPECorpusPlaybackReport(
+            generatedAt: Date(),
+            perSceneTimeoutSeconds: configuration.perSceneTimeoutSeconds,
+            total: total,
+            summary: Self.summary(for: entries),
+            entries: entries
+        )
+    }
+
+    private func makeEntry(
+        workshopID: String,
+        title: String,
+        capabilityTier: SceneCapabilityTier?,
+        preflightTier: WPEScenePreflightTier?,
+        result: WPECorpusPlaybackReport.Entry.Outcome,
+        startedAt: Date,
+        failureMessage: String?,
+        resolution: WPECorpusPlaybackReport.Entry.ResolutionSummary
+    ) -> WPECorpusPlaybackReport.Entry {
+        WPECorpusPlaybackReport.Entry(
+            workshopID: workshopID,
+            title: title,
+            capabilityTier: capabilityTier,
+            preflightTier: preflightTier,
+            result: result,
+            elapsedSeconds: Date().timeIntervalSince(startedAt),
+            failureMessage: failureMessage,
+            resolution: resolution
+        )
+    }
+
+    private func makeFallbackEntry(
+        discovered: WallpaperEngineLibraryScanner.DiscoveredProject,
+        capabilityTier: SceneCapabilityTier?,
+        preflightTier: WPEScenePreflightTier?,
+        result: WPECorpusPlaybackReport.Entry.Outcome,
+        startedAt: Date,
+        failureMessage: String?
+    ) -> WPECorpusPlaybackReport.Entry {
+        WPECorpusPlaybackReport.Entry(
+            workshopID: discovered.workshopID,
+            title: discovered.title,
+            capabilityTier: capabilityTier,
+            preflightTier: preflightTier,
+            result: result,
+            elapsedSeconds: Date().timeIntervalSince(startedAt),
+            failureMessage: failureMessage,
+            resolution: .empty
+        )
+    }
+
+    private static func resolveLibraryRoot(bookmarkData: Data) throws -> URL {
+        var isStale = false
+        return try URL(
+            resolvingBookmarkData: bookmarkData,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        )
+    }
+
+    private static func readProject(from folderURL: URL) async throws -> WallpaperEngineProject {
+        try await Task.detached(priority: .userInitiated) {
+            try WallpaperEngineProject.read(from: folderURL)
+        }.value
+    }
+
+    private static func readSceneDocument(from entryURL: URL) async throws -> WPESceneDocument {
+        try await Task.detached(priority: .userInitiated) {
+            let data = try Data(contentsOf: entryURL)
+            return try WPESceneDocumentParser.parse(data: data)
+        }.value
+    }
+
+    private static func capabilityTier(
+        document: WPESceneDocument,
+        cacheURL: URL,
+        dependencyMounts: [WPEAssetMount],
+        engineAssetsRoot: URL?
+    ) async -> SceneCapabilityTier {
+        await Task.detached(priority: .userInitiated) {
+            WPESceneCapabilityClassifier().capabilityTier(
+                for: document,
+                cacheURL: cacheURL,
+                dependencyMounts: dependencyMounts,
+                engineAssetsRootURL: engineAssetsRoot
+            )
+        }.value
+    }
+
+    private static func scenePackageEntryNames(in rootURL: URL, limit: Int = 10_000) async -> [String] {
+        await Task.detached(priority: .utility) {
+            enumerateSceneEntries(in: rootURL, limit: limit)
+        }.value
+    }
+
+    /// Sync helper: Swift 6 marks `FileManager.DirectoryEnumerator`'s iterator
+    /// unavailable from async contexts. Running the enumeration in this
+    /// nonisolated nonasync function side-steps the diagnostic while the
+    /// caller stays on a detached cooperative task.
+    private nonisolated static func enumerateSceneEntries(
+        in rootURL: URL,
+        limit: Int
+    ) -> [String] {
+        guard limit > 0,
+              let enumerator = FileManager.default.enumerator(
+                at: rootURL,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles, .skipsPackageDescendants]
+              ) else {
+            return []
+        }
+
+        let rootPath = rootURL.standardizedFileURL.resolvingSymlinksInPath().path
+        var entries: [String] = []
+        entries.reserveCapacity(min(limit, 256))
+
+        for case let url as URL in enumerator {
+            guard entries.count < limit else { break }
+            guard (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true else {
+                continue
+            }
+            let path = url.standardizedFileURL.resolvingSymlinksInPath().path
+            if path.hasPrefix(rootPath + "/") {
+                entries.append(String(path.dropFirst(rootPath.count + 1)))
+            } else {
+                entries.append(url.lastPathComponent)
+            }
+        }
+        return entries
+    }
+
+    private static func resolutionSummary(
+        from snapshot: WPEResolutionDiagnosticsSnapshot
+    ) -> WPECorpusPlaybackReport.Entry.ResolutionSummary {
+        let misses = snapshot.events.filter { $0.finalOutcome == .fileMissing }
+        return WPECorpusPlaybackReport.Entry.ResolutionSummary(
+            events: snapshot.events.count,
+            resolved: snapshot.resolvedCount,
+            missing: misses.count,
+            firstMisses: misses.prefix(5).map(\.ref)
+        )
+    }
+
+    private static func summary(
+        for entries: [WPECorpusPlaybackReport.Entry]
+    ) -> WPECorpusPlaybackReport.Summary {
+        var passCount = 0
+        var failCount = 0
+        var timeoutCount = 0
+        var skippedCount = 0
+
+        for entry in entries {
+            switch entry.result {
+            case .pass: passCount += 1
+            case .fail: failCount += 1
+            case .timeout: timeoutCount += 1
+            case .skipped: skippedCount += 1
+            }
+        }
+
+        return WPECorpusPlaybackReport.Summary(
+            passCount: passCount,
+            failCount: failCount,
+            timeoutCount: timeoutCount,
+            skippedCount: skippedCount
+        )
+    }
+
+    private static func cacheRelativePath(for workshopID: String) -> String {
+        "wpe-cache/\(workshopID)"
+    }
+
+    private static func timeoutNanoseconds(for seconds: Double) -> UInt64 {
+        let clamped = min(max(seconds, 0.001), 86_400)
+        return UInt64(clamped * 1_000_000_000)
+    }
+
+    /// Single-shot latch for the timeout race in `loadWithTimeout` — whichever
+    /// branch (load completion or wall-clock timeout) calls `markComplete()`
+    /// first wins and resumes the continuation; the other call is a no-op.
+    private final class TimeoutRaceState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var done = false
+
+        func markComplete() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !done else { return false }
+            done = true
+            return true
+        }
+    }
+
+    private static func describe(_ error: Error) -> String {
+        if let localized = error as? LocalizedError,
+           let description = localized.errorDescription,
+           !description.isEmpty {
+            return description
+        }
+        return error.localizedDescription
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -199,12 +199,19 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
     }
 
     private func performLoad() async throws {
+        // Cancellation checkpoints at phase boundaries let unstructured
+        // callers (e.g. the DEBUG corpus-playback harness) actually abort
+        // a long load instead of waiting for it to run to completion. The
+        // production scene-session path is fire-and-forget so these are
+        // benign there.
         onProgress?("Reading scene")
+        try Task.checkCancellation()
         let entryURL = try entryResolver.resolveExistingFileURL(relativePath: descriptor.entryFile)
         let document = try await Task.detached(priority: .userInitiated) {
             let data = try Data(contentsOf: entryURL)
             return try WPESceneDocumentParser.parse(data: data)
         }.value
+        try Task.checkCancellation()
 
         onProgress?("Building render graph")
         let cacheRoot = cacheRootURL
@@ -217,6 +224,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
                 engineAssetsRootURL: engineRoot
             ).build(document: document)
         }.value
+        try Task.checkCancellation()
 
         onProgress?("Preparing render pipeline")
         let pipeline = try await Task.detached(priority: .userInitiated) {
@@ -225,6 +233,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
                 engineAssetsRootURL: engineRoot
             ).build(graph: graph)
         }.value
+        try Task.checkCancellation()
 
         renderGraph = graph
         renderPipeline = pipeline
@@ -236,15 +245,19 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
 
         onProgress?("Loading textures")
         try await loadTextures(for: pipeline)
+        try Task.checkCancellation()
 
         onProgress?("Loading particle systems")
         await loadParticleSystems(from: document)
+        try Task.checkCancellation()
 
         onProgress?("Loading text overlays")
         loadTextOverlays(from: document)
+        try Task.checkCancellation()
 
         onProgress?("Starting audio runtime")
         startSoundRuntime(from: document)
+        try Task.checkCancellation()
 
         onProgress?("Rendering scene")
         outputTexture = try renderCurrentFrame()
@@ -616,6 +629,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
         dynamicTextureSources = [:]
 
         for layer in pipeline.layers {
+            try Task.checkCancellation()
             if layer.passes.isEmpty {
                 try await loadTexture(
                     reference: .image(layer.graphLayer.imagePath),
@@ -625,6 +639,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, MTKViewDelegate {
             }
             for preparedPass in layer.passes {
                 for reference in requiredTextureReferences(for: preparedPass) {
+                    try Task.checkCancellation()
                     try await loadTexture(
                         reference: reference,
                         layerName: layer.graphLayer.objectName

--- a/LiveWallpaper/Views/ContentView.swift
+++ b/LiveWallpaper/Views/ContentView.swift
@@ -178,6 +178,9 @@ enum Navigation: Hashable {
     case appleAerials
     case bookmarks
     case workshop
+    #if DEBUG
+    case developerTools
+    #endif
 }
 
 // MARK: - Sidebar View
@@ -238,6 +241,13 @@ struct Sidebar: View {
                     Label("Workshop Library", systemImage: "cube.transparent")
                 }
                 .accessibilityHint(Text("Browse Wallpaper Engine workshop projects"))
+
+                #if DEBUG
+                NavigationLink(value: Navigation.developerTools) {
+                    Label("Developer Tools", systemImage: "wrench.and.screwdriver")
+                }
+                .accessibilityHint(Text("DEBUG-only: corpus playback test and diagnostics"))
+                #endif
             }
 
             Section(header: SidebarSectionHeader(title: "Dashboard", showsDivider: true) {
@@ -499,6 +509,12 @@ struct DetailContent: View {
             case .workshop:
                 WorkshopGalleryView(allowsTargetSelection: true)
                     .transition(.opacity)
+
+            #if DEBUG
+            case .developerTools:
+                DeveloperToolsView()
+                    .transition(.opacity)
+            #endif
 
             case .none:
                 EmptyStateView(

--- a/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
+++ b/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
@@ -1,0 +1,308 @@
+#if DEBUG
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+
+/// DEBUG-only Phase A.3 corpus playback test menu. Streams a
+/// `WPECorpusPlaybackHarness` run, surfaces per-scene outcomes in a table,
+/// and lets the maintainer export the resulting JSON report for triage.
+/// Compiled out of Release so end users never see (and the bundle never
+/// carries) this UI.
+struct DeveloperToolsView: View {
+    @State private var isRunning = false
+    @State private var progressLabel: String = ""
+    @State private var progressFraction: Double = 0
+    @State private var entries: [WPECorpusPlaybackReport.Entry] = []
+    @State private var lastReport: WPECorpusPlaybackReport?
+    @State private var startupError: String?
+    @State private var perSceneTimeout: Double = 8
+    @State private var cancelRequested = false
+    @State private var runTask: Task<Void, Never>?
+
+    var body: some View {
+        DetailPageScaffold(
+            showsHeader: true,
+            header: { header },
+            content: { content }
+        )
+        .onDisappear {
+            runTask?.cancel()
+            cancelRequested = true
+        }
+    }
+
+    private var header: some View {
+        DetailHeaderBar(
+            systemImage: "wrench.and.screwdriver",
+            title: { Text("Developer Tools") },
+            metadata: { metadata },
+            actions: { actions }
+        )
+    }
+
+    @ViewBuilder
+    private var metadata: some View {
+        if isRunning {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(verbatim: progressLabel)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        } else if let summary = lastReport?.summary {
+            Text(verbatim: summaryLabel(summary, total: lastReport?.total ?? entries.count))
+                .foregroundStyle(.secondary)
+        } else {
+            Text("Phase A.3 — Corpus playback test")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var actions: some View {
+        HStack(spacing: 8) {
+            if isRunning {
+                Button(role: .destructive) {
+                    cancelRequested = true
+                    runTask?.cancel()
+                } label: {
+                    Label("Stop", systemImage: "stop.fill")
+                }
+            } else {
+                Button {
+                    startRun()
+                } label: {
+                    Label("Run corpus playback test", systemImage: "play.fill")
+                }
+                .keyboardShortcut("r", modifiers: [.command])
+
+                Button {
+                    exportReport()
+                } label: {
+                    Label("Export JSON", systemImage: "square.and.arrow.up")
+                }
+                .disabled(lastReport == nil)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            configurationSection
+            if let startupError {
+                errorBanner(startupError)
+            }
+            if isRunning {
+                ProgressView(value: progressFraction)
+                    .progressViewStyle(.linear)
+            }
+            resultsTable
+        }
+        .padding(16)
+    }
+
+    private var configurationSection: some View {
+        GroupBox(label: Text("Configuration").font(.headline)) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Per-scene timeout")
+                    Slider(value: $perSceneTimeout, in: 3...30, step: 1)
+                        .frame(width: 220)
+                        .disabled(isRunning)
+                    Text(verbatim: "\(Int(perSceneTimeout))s")
+                        .monospacedDigit()
+                        .frame(width: 36, alignment: .trailing)
+                }
+                Text("Iterates every imported scene workshop project, runs `WPEMetalSceneRenderer.load()` headlessly with the configured timeout, and aggregates pass/fail/timeout outcomes plus resolution diagnostics. The test window is held at alpha 0 behind the desktop — nothing flashes on screen.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        Label(message, systemImage: "exclamationmark.triangle.fill")
+            .foregroundStyle(.orange)
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.orange.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var resultsTable: some View {
+        Table(entries) {
+            TableColumn("Workshop ID") { entry in
+                Text(verbatim: entry.workshopID).monospaced()
+            }
+            .width(min: 100, ideal: 120)
+
+            TableColumn("Title") { entry in
+                Text(verbatim: entry.title)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(Text(verbatim: entry.title))
+            }
+            .width(min: 120, ideal: 220)
+
+            TableColumn("Result") { entry in
+                Label(entry.result.rawValue.capitalized, systemImage: resultIcon(entry.result))
+                    .foregroundStyle(resultColor(entry.result))
+            }
+            .width(min: 80, ideal: 100)
+
+            TableColumn("Tier") { entry in
+                Text(verbatim: entry.preflightTier?.localizedLabel ?? "—")
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 90, ideal: 130)
+
+            TableColumn("Elapsed") { entry in
+                Text(verbatim: String(format: "%.2fs", entry.elapsedSeconds))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            .width(min: 60, ideal: 70)
+
+            TableColumn("Resolved / Missing") { entry in
+                Text(verbatim: "\(entry.resolution.resolved) / \(entry.resolution.missing)")
+                    .monospacedDigit()
+                    .foregroundStyle(entry.resolution.missing > 0 ? .orange : .secondary)
+            }
+            .width(min: 90, ideal: 110)
+
+            TableColumn("Failure") { entry in
+                Text(verbatim: entry.failureMessage ?? "")
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .foregroundStyle(.secondary)
+                    .help(Text(verbatim: failureHelp(for: entry)))
+            }
+        }
+        .frame(minHeight: 280)
+    }
+
+    // MARK: - Run lifecycle
+
+    private func startRun() {
+        guard !isRunning else { return }
+        isRunning = true
+        cancelRequested = false
+        startupError = nil
+        entries.removeAll()
+        lastReport = nil
+        progressFraction = 0
+        progressLabel = "Scanning library…"
+
+        let config = WPECorpusPlaybackHarness.Configuration(
+            perSceneTimeoutSeconds: perSceneTimeout
+        )
+        let harness = WPECorpusPlaybackHarness(configuration: config)
+
+        runTask = Task { @MainActor in
+            await harness.run(
+                progress: handleProgress,
+                isCancelled: { self.cancelRequested }
+            )
+            self.isRunning = false
+        }
+    }
+
+    @MainActor
+    private func handleProgress(_ progress: WPECorpusPlaybackHarness.Progress) {
+        switch progress {
+        case .scanning:
+            progressLabel = "Scanning library…"
+        case .running(let index, let total, let workshopID, let title):
+            progressLabel = "Running \(index)/\(total) — \(title.isEmpty ? workshopID : title)"
+            progressFraction = total > 0 ? Double(index) / Double(total) : 0
+        case .sceneComplete(let entry):
+            entries.append(entry)
+        case .finished(let report):
+            lastReport = report
+            progressLabel = "Finished — \(summaryLabel(report.summary, total: report.total))"
+            progressFraction = 1
+        case .cancelled(let partial):
+            lastReport = partial
+            progressLabel = "Cancelled — \(summaryLabel(partial.summary, total: partial.total)) (partial)"
+        case .failedToStart(let message):
+            startupError = message
+            progressLabel = ""
+            progressFraction = 0
+        }
+    }
+
+    // MARK: - Export
+
+    private func exportReport() {
+        guard let report = lastReport else { return }
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = defaultExportName(for: report)
+        panel.title = "Export Corpus Playback Report"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(report)
+            try data.write(to: url, options: .atomic)
+            Logger.info("WPE corpus playback report exported to \(url.path)", category: .screenManager)
+        } catch {
+            startupError = "Export failed: \(error.localizedDescription)"
+            Logger.error("WPE corpus playback report export failed: \(error.localizedDescription)", category: .screenManager)
+        }
+    }
+
+    private func defaultExportName(for report: WPECorpusPlaybackReport) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withFullDate, .withTime, .withColonSeparatorInTime]
+        let stamp = formatter.string(from: report.generatedAt)
+            .replacingOccurrences(of: ":", with: "-")
+        return "wpe-corpus-playback-\(stamp).json"
+    }
+
+    // MARK: - Formatting helpers
+
+    private func summaryLabel(_ summary: WPECorpusPlaybackReport.Summary, total: Int) -> String {
+        let completed = summary.passCount + summary.failCount + summary.timeoutCount + summary.skippedCount
+        return "\(completed)/\(total) — pass \(summary.passCount) · fail \(summary.failCount) · timeout \(summary.timeoutCount) · skipped \(summary.skippedCount)"
+    }
+
+    private func resultIcon(_ result: WPECorpusPlaybackReport.Entry.Outcome) -> String {
+        switch result {
+        case .pass: return "checkmark.circle.fill"
+        case .fail: return "xmark.octagon.fill"
+        case .timeout: return "clock.badge.exclamationmark"
+        case .skipped: return "minus.circle"
+        }
+    }
+
+    private func resultColor(_ result: WPECorpusPlaybackReport.Entry.Outcome) -> Color {
+        switch result {
+        case .pass: return .green
+        case .fail: return .red
+        case .timeout: return .orange
+        case .skipped: return .secondary
+        }
+    }
+
+    private func failureHelp(for entry: WPECorpusPlaybackReport.Entry) -> String {
+        var lines: [String] = []
+        if let message = entry.failureMessage, !message.isEmpty {
+            lines.append(message)
+        }
+        if !entry.resolution.firstMisses.isEmpty {
+            lines.append("First misses:")
+            for miss in entry.resolution.firstMisses {
+                lines.append("  • \(miss)")
+            }
+        }
+        return lines.isEmpty ? entry.title : lines.joined(separator: "\n")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Phase A.3 from the WPE bundle-and-native-recreate plan. Turns the question "which of the 57 imported workshop scenes actually load?" from an N-hour manual sweep into a single click + a JSON report Phase B can target.

All new surfaces are gated by `#if DEBUG` so Release ships unchanged.

### New harness
- [WPECorpusPlaybackHarness.swift](LiveWallpaper/Runtime/WPECorpusPlaybackHarness.swift) — `@MainActor` driver that, per scene: re-uses the production extract/preflight/dependency-mount path, builds a headless `WPEMetalSceneRenderer`, races `renderer.load()` against a wall-clock timeout, captures the resolution-diagnostics snapshot, tears down, yields, and moves on.
- `WPECorpusPlaybackReport` is `Codable + Sendable`: `total / pass / fail / timeout / skipped` summary plus per-scene entries (workshop ID, title, capability tier, preflight tier, elapsed seconds, failure message, resolved/missing counts, first 5 missing refs).

### Headless = invisible
The runtime renderer ships an MTKView and expects to be mounted in a window for CAMetalLayer to produce drawables. The harness wraps it in a `VideoWallpaperWindow` held at `alphaValue = 0` + `orderBack` at wallpaper level — drawable acquisition works, nothing visible on the user's desktop during the sweep.

### Timeout race
`TaskGroup` rejects @MainActor closures under Swift 6 sending-parameter checks. The harness uses a manual `CheckedContinuation` + paired `Task`s gated by a single-shot `TimeoutRaceState` (NSLock-backed `@unchecked Sendable`). On timeout or load error, `loadTask.value` is drained before propagation so the caller's `defer { tearDown(...) }` sees a quiescent renderer.

### Renderer cancellation checkpoints
`Task.cancel()` on an in-flight `renderer.load()` was previously a no-op because the load phases never observed cancellation. [WPEMetalSceneRenderer.performLoad](LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift) now calls `try Task.checkCancellation()` at every phase boundary and inside the per-layer / per-pass texture loop. Production scene-session load is fire-and-forget so this is benign there; the harness (and any future caller that explicitly cancels) gets actual cancellation.

### DEBUG dev menu
- New sidebar entry "Developer Tools" (Library section, `#if DEBUG`-gated).
- [DeveloperToolsView.swift](LiveWallpaper/Views/Settings/DeveloperToolsView.swift): Run / Stop / Export JSON buttons (⌘R on Run), per-scene timeout slider (3–30s), live progress bar + label, `Table` with workshop ID / title / result chip / preflight tier / elapsed / resolved-vs-missing / failure tooltip listing first misses.
- Stop button cancels both the `cancelRequested` flag and the wrapping Task so an in-flight `renderer.load()` aborts at the next checkpoint.
- `.onDisappear` cancels any running sweep so navigating away mid-run doesn't leak renderer + window.
- Export writes pretty-printed JSON via `NSSavePanel`; default filename timestamped.

## Test plan
- [x] `xcodebuild ... test -only-testing:LiveWallpaperTests` — **637 tests / 104 suites pass** (5.05s)
- [ ] Manual: build Debug, open Settings → Developer Tools, click Run → confirm progress streams + Table fills + Export JSON works
- [ ] Manual: hit Stop mid-sweep → confirm current scene aborts within ~1s (not stuck at the per-scene timeout)
- [ ] Manual: run with WPE folder granted vs not granted, compare pass/fail matrices
- [ ] Manual: confirm Release build still compiles cleanly without the DEBUG nav case (`xcodebuild -configuration Release build`)

## Why this is a separate PR (not folded into #54)
The Phase A.2 work (PR #54 — resolution diagnostics + scene-1 unblock fixes) was merged before A.3 could land — and the worktree it was written in was auto-cleaned along with the merged branch. This PR is the re-implementation; logic is identical to the prior worktree version with the same codex audit fixes (drain semantics + cancellation checkpoints) already applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)