### PR TITLE
Phase 1+2: SecurityScopedBookmarkResolver + workshop-bookmark migration

### DIFF
--- a/LiveWallpaper/Infrastructure/SecurityScopedBookmarkResolver.swift
+++ b/LiveWallpaper/Infrastructure/SecurityScopedBookmarkResolver.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+/// Single point of resolution for every security-scoped bookmark in the app.
+///
+/// `bookmarkDataIsStale` MUST be observed every time a bookmark is resolved
+/// — Apple gives a one-shot grace use, then the next resolve permanently
+/// fails. Historically that flag was dropped at 13 of 16 resolution sites,
+/// causing user-granted folder access (Workshop library, engine assets,
+/// aerials directory, video files, HTML folders) to silently invalidate
+/// after restart or after the underlying inode changed.
+///
+/// This type centralises resolution so each bookmark kind goes through one
+/// path, and a typed `Target` carries the closure that writes refreshed
+/// data back to its owning store. Adding a new bookmark kind = adding one
+/// `Target` extension; the resolver itself never has to learn about
+/// `UserDefaults` keys or persistence schemas.
+///
+/// Tests inject their own `SecurityScopedBookmarkResolver(resolveData:refreshData:)`
+/// to drive the stale path without touching real bookmarks.
+struct SecurityScopedBookmarkResolver: Sendable {
+    /// Identifies WHERE to persist a refreshed bookmark. The closure runs
+    /// when the resolver detects `isStale == true` and successfully
+    /// recreates the bookmark. Closure is `@Sendable` so the resolver can
+    /// be called from any isolation; typed targets that need MainActor
+    /// access dispatch internally.
+    struct Target: Sendable {
+        let label: String
+        let save: @Sendable (Data) -> Void
+    }
+
+    /// Successful resolution result. `didRefresh` distinguishes a healthy
+    /// cache hit from a stale + recreated bookmark — callers can log /
+    /// surface UI accordingly.
+    struct Resolved: Sendable {
+        let url: URL
+        let bookmarkData: Data
+        let didRefresh: Bool
+    }
+
+    enum Failure: Error, LocalizedError, Sendable {
+        /// No bookmark was stored — user hasn't granted access yet.
+        case missing
+        /// Bookmark resolution itself threw (file deleted, sandbox revoked,
+        /// bookmark data corrupted).
+        case resolutionFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missing:
+                return "No bookmark is stored for this resource."
+            case .resolutionFailed(let reason):
+                return "Failed to resolve bookmark: \(reason)"
+            }
+        }
+    }
+
+    /// Injection seam — production uses `.live`; tests construct their own.
+    let resolveData: @Sendable (Data) throws -> (URL, Bool)
+    let refreshData: @Sendable (URL) throws -> Data
+
+    /// Resolves the stored bookmark with security scope, detecting and
+    /// transparently refreshing stale bookmarks. Returned `Resolved.url`
+    /// is NOT scope-active — caller must use `withScopedAccess` (or call
+    /// `startAccessingSecurityScopedResource` directly) before any file
+    /// I/O on it.
+    ///
+    /// Behaviour:
+    /// - `nil` input → `.missing`
+    /// - resolve throws → `.resolutionFailed`
+    /// - `isStale == false` → `.success` with input data
+    /// - `isStale == true` + refresh succeeds → `.success` with new data, target.save invoked
+    /// - `isStale == true` + refresh fails → `.success` with input data (one-shot grace),
+    ///   logged so the next failure surfaces in the log file
+    func resolve(_ data: Data?, target: Target) -> Result<Resolved, Failure> {
+        guard let data else {
+            return .failure(.missing)
+        }
+
+        let url: URL
+        let isStale: Bool
+        do {
+            (url, isStale) = try resolveData(data)
+        } catch {
+            Logger.warning(
+                "[bookmark/\(target.label)] resolve failed: \(error.localizedDescription)",
+                category: .fileAccess
+            )
+            return .failure(.resolutionFailed(error.localizedDescription))
+        }
+
+        guard isStale else {
+            return .success(Resolved(url: url, bookmarkData: data, didRefresh: false))
+        }
+
+        // Stale — try to recreate. Apple recommends starting the scope so
+        // bookmarkData can read the URL's resource values; balanced stop on
+        // exit. Refresh failure isn't fatal: the URL is still good for THIS
+        // run via Apple's grace, so we return the existing data and let the
+        // next launch surface re-grant if it really cannot recover.
+        Self.withScopedAccess(url) { _ in
+            do {
+                let fresh = try refreshData(url)
+                target.save(fresh)
+                Logger.info(
+                    "[bookmark/\(target.label)] was stale; refreshed in place",
+                    category: .fileAccess
+                )
+            } catch {
+                Logger.warning(
+                    "[bookmark/\(target.label)] stale and refresh failed: \(error.localizedDescription) — current URL still usable but re-grant may be needed next launch",
+                    category: .fileAccess
+                )
+            }
+        }
+
+        // Re-derive resolved data: if refresh succeeded, target.save has the
+        // new value; we still return the input bookmarkData here because
+        // typed targets dispatch save asynchronously and we don't block on
+        // it. The next resolve will pick up the refreshed bookmark.
+        return .success(Resolved(url: url, bookmarkData: data, didRefresh: true))
+    }
+
+    /// Runs `work` with security scope started; the stop call is balanced
+    /// in `defer` even if `work` throws. Returns the closure's result; the
+    /// passed-in `Bool` tells the closure whether scope actually started
+    /// (some URLs inside the app container resolve fine without it).
+    @discardableResult
+    static func withScopedAccess<R>(
+        _ url: URL,
+        _ work: (Bool) throws -> R
+    ) rethrows -> R {
+        let didStart = url.startAccessingSecurityScopedResource()
+        defer { if didStart { url.stopAccessingSecurityScopedResource() } }
+        return try work(didStart)
+    }
+}
+
+extension SecurityScopedBookmarkResolver {
+    /// Production resolver — wraps Foundation's bookmark APIs directly.
+    static let live = SecurityScopedBookmarkResolver(
+        resolveData: { data in
+            var isStale = false
+            let url = try URL(
+                resolvingBookmarkData: data,
+                options: .withSecurityScope,
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+            return (url, isStale)
+        },
+        refreshData: { url in
+            try url.bookmarkData(
+                options: [.withSecurityScope, .securityScopeAllowOnlyReadAccess],
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            )
+        }
+    )
+
+    /// Shorthand for the live resolver; equivalent to `.live`.
+    static var shared: SecurityScopedBookmarkResolver { .live }
+}
+
+// MARK: - Typed targets
+
+/// One `Target` per persistence destination. Adding a new bookmark kind is
+/// the only code change required to plug it into the resolver — call sites
+/// then become `SecurityScopedBookmarkResolver.shared.resolve(data, target: .myKind)`.
+extension SecurityScopedBookmarkResolver.Target {
+    /// Workshop library root — the user-granted `~/Documents/Live Wallpapers/<appid>/`
+    /// folder scanned for WPE projects.
+    static var workshopLibraryRoot: Self {
+        Self(label: "workshopLibraryRoot") { data in
+            Task { @MainActor in
+                SettingsManager.shared.saveWorkshopLibraryRootBookmark(data)
+            }
+        }
+    }
+
+    /// Wallpaper Engine install root — the directory containing `assets/`
+    /// the user authorised so the renderer can fall back to engine builtins.
+    static var wpeEngineAssets: Self {
+        Self(label: "wpeEngineAssets") { data in
+            Task { @MainActor in
+                SettingsManager.shared.saveWPEEngineAssetsBookmark(data)
+            }
+        }
+    }
+
+    /// Apple Aerials wallpaper library directory.
+    static var aerialsDirectory: Self {
+        Self(label: "aerialsDirectory") { data in
+            Task { @MainActor in
+                SettingsManager.shared.saveAerialsDirectoryBookmark(data)
+            }
+        }
+    }
+
+    /// Read-only one-shot resolution where no persistence is wanted
+    /// (e.g. previewing a thumbnail, validating that a path still exists).
+    /// Future regressions where someone forgets to plumb a typed target
+    /// should be flagged in review.
+    static var transient: Self {
+        Self(label: "transient") { _ in }
+    }
+}

--- a/LiveWallpaper/Infrastructure/SecurityScopedBookmarkResolver.swift
+++ b/LiveWallpaper/Infrastructure/SecurityScopedBookmarkResolver.swift
@@ -23,9 +23,24 @@ struct SecurityScopedBookmarkResolver: Sendable {
     /// recreates the bookmark. Closure is `@Sendable` so the resolver can
     /// be called from any isolation; typed targets that need MainActor
     /// access dispatch internally.
+    ///
+    /// The closure receives BOTH the original (stale) bookmark Data and
+    /// the freshly recreated Data. Typed targets must compare-and-swap
+    /// against the currently stored value before writing — if the user
+    /// cleared or re-granted the bookmark between resolve and save, the
+    /// stored value will differ and the late save must be a no-op so it
+    /// can't resurrect a stale grant.
     struct Target: Sendable {
         let label: String
-        let save: @Sendable (Data) -> Void
+        let save: @Sendable (_ original: Data, _ refreshed: Data) -> Void
+
+        init(
+            label: String,
+            save: @escaping @Sendable (_ original: Data, _ refreshed: Data) -> Void = { _, _ in }
+        ) {
+            self.label = label
+            self.save = save
+        }
     }
 
     /// Successful resolution result. `didRefresh` distinguishes a healthy
@@ -97,10 +112,12 @@ struct SecurityScopedBookmarkResolver: Sendable {
         // exit. Refresh failure isn't fatal: the URL is still good for THIS
         // run via Apple's grace, so we return the existing data and let the
         // next launch surface re-grant if it really cannot recover.
+        var refreshedData: Data?
         Self.withScopedAccess(url) { _ in
             do {
                 let fresh = try refreshData(url)
-                target.save(fresh)
+                refreshedData = fresh
+                target.save(data, fresh)
                 Logger.info(
                     "[bookmark/\(target.label)] was stale; refreshed in place",
                     category: .fileAccess
@@ -113,11 +130,15 @@ struct SecurityScopedBookmarkResolver: Sendable {
             }
         }
 
-        // Re-derive resolved data: if refresh succeeded, target.save has the
-        // new value; we still return the input bookmarkData here because
-        // typed targets dispatch save asynchronously and we don't block on
-        // it. The next resolve will pick up the refreshed bookmark.
-        return .success(Resolved(url: url, bookmarkData: data, didRefresh: true))
+        // Return the refreshed bookmark so in-process callers that copy
+        // `bookmarkData` into their own state (e.g. `DiscoveredProject`)
+        // don't continue circulating the stale blob and burn another grace
+        // use. Falls back to the input on refresh failure.
+        return .success(Resolved(
+            url: url,
+            bookmarkData: refreshedData ?? data,
+            didRefresh: refreshedData != nil
+        ))
     }
 
     /// Runs `work` with security scope started; the stop call is balanced
@@ -170,9 +191,16 @@ extension SecurityScopedBookmarkResolver.Target {
     /// Workshop library root — the user-granted `~/Documents/Live Wallpapers/<appid>/`
     /// folder scanned for WPE projects.
     static var workshopLibraryRoot: Self {
-        Self(label: "workshopLibraryRoot") { data in
+        Self(label: "workshopLibraryRoot") { original, refreshed in
             Task { @MainActor in
-                SettingsManager.shared.saveWorkshopLibraryRootBookmark(data)
+                guard SettingsManager.shared.loadWorkshopLibraryRootBookmark() == original else {
+                    Logger.info(
+                        "[bookmark/workshopLibraryRoot] skipped stale refresh save — stored bookmark changed between resolve and save",
+                        category: .fileAccess
+                    )
+                    return
+                }
+                SettingsManager.shared.saveWorkshopLibraryRootBookmark(refreshed)
             }
         }
     }
@@ -180,18 +208,32 @@ extension SecurityScopedBookmarkResolver.Target {
     /// Wallpaper Engine install root — the directory containing `assets/`
     /// the user authorised so the renderer can fall back to engine builtins.
     static var wpeEngineAssets: Self {
-        Self(label: "wpeEngineAssets") { data in
+        Self(label: "wpeEngineAssets") { original, refreshed in
             Task { @MainActor in
-                SettingsManager.shared.saveWPEEngineAssetsBookmark(data)
+                guard SettingsManager.shared.loadWPEEngineAssetsBookmark() == original else {
+                    Logger.info(
+                        "[bookmark/wpeEngineAssets] skipped stale refresh save — stored bookmark changed between resolve and save",
+                        category: .fileAccess
+                    )
+                    return
+                }
+                SettingsManager.shared.saveWPEEngineAssetsBookmark(refreshed)
             }
         }
     }
 
     /// Apple Aerials wallpaper library directory.
     static var aerialsDirectory: Self {
-        Self(label: "aerialsDirectory") { data in
+        Self(label: "aerialsDirectory") { original, refreshed in
             Task { @MainActor in
-                SettingsManager.shared.saveAerialsDirectoryBookmark(data)
+                guard SettingsManager.shared.loadAerialsDirectoryBookmark() == original else {
+                    Logger.info(
+                        "[bookmark/aerialsDirectory] skipped stale refresh save — stored bookmark changed between resolve and save",
+                        category: .fileAccess
+                    )
+                    return
+                }
+                SettingsManager.shared.saveAerialsDirectoryBookmark(refreshed)
             }
         }
     }
@@ -201,6 +243,6 @@ extension SecurityScopedBookmarkResolver.Target {
     /// Future regressions where someone forgets to plumb a typed target
     /// should be flagged in review.
     static var transient: Self {
-        Self(label: "transient") { _ in }
+        Self(label: "transient")
     }
 }

--- a/LiveWallpaper/Infrastructure/WallpaperEngineLibraryScanner.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineLibraryScanner.swift
@@ -70,17 +70,15 @@ final class WallpaperEngineLibraryScanner: @unchecked Sendable {
         alreadyImportedWorkshopIDs: Set<String>,
         fileManager: FileManager
     ) throws -> [DiscoveredProject] {
-        var isStale = false
         let rootURL: URL
-        do {
-            rootURL = try URL(
-                resolvingBookmarkData: rootBookmarkData,
-                options: .withSecurityScope,
-                relativeTo: nil,
-                bookmarkDataIsStale: &isStale
-            )
-        } catch {
-            throw ScanError.rootInaccessible(error.localizedDescription)
+        switch SecurityScopedBookmarkResolver.shared.resolve(
+            rootBookmarkData,
+            target: .workshopLibraryRoot
+        ) {
+        case .success(let resolved):
+            rootURL = resolved.url
+        case .failure(let failure):
+            throw ScanError.rootInaccessible(failure.errorDescription ?? "Unknown bookmark failure")
         }
 
         let didStartScope = rootURL.startAccessingSecurityScopedResource()

--- a/LiveWallpaper/Infrastructure/WallpaperEngineLibraryScanner.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineLibraryScanner.swift
@@ -71,12 +71,18 @@ final class WallpaperEngineLibraryScanner: @unchecked Sendable {
         fileManager: FileManager
     ) throws -> [DiscoveredProject] {
         let rootURL: URL
+        let effectiveRootBookmarkData: Data
         switch SecurityScopedBookmarkResolver.shared.resolve(
             rootBookmarkData,
             target: .workshopLibraryRoot
         ) {
         case .success(let resolved):
             rootURL = resolved.url
+            // Carry the refreshed bookmark (if the resolver auto-refreshed a
+            // stale one) into every DiscoveredProject so the gallery's
+            // follow-up apply/prepare doesn't re-resolve the original stale
+            // blob and burn another grace use.
+            effectiveRootBookmarkData = resolved.bookmarkData
         case .failure(let failure):
             throw ScanError.rootInaccessible(failure.errorDescription ?? "Unknown bookmark failure")
         }
@@ -118,7 +124,7 @@ final class WallpaperEngineLibraryScanner: @unchecked Sendable {
                 folderURL: child,
                 previewURL: previewURL,
                 importedAlready: alreadyImportedWorkshopIDs.contains(project.workshopID),
-                libraryRootBookmarkData: rootBookmarkData,
+                libraryRootBookmarkData: effectiveRootBookmarkData,
                 dependencyWorkshopIDs: project.dependencyWorkshopIDs,
                 requiresWindowsPlugin: project.requiresWindowsPlugin,
                 hasScenePackage: fileManager.fileExists(

--- a/LiveWallpaper/ResourceUtilities.swift
+++ b/LiveWallpaper/ResourceUtilities.swift
@@ -113,6 +113,18 @@ class ResourceUtilities {
         return localBookmark
     }
 
+    /// Legacy bookmark resolver. Returns staleness as data without persisting
+    /// a refresh, so 11+ historical call sites silently dropped the flag and
+    /// caused user-granted folder access to invalidate after a single Apple
+    /// grace use. New code MUST route through `SecurityScopedBookmarkResolver`
+    /// with a typed `Target` so the refreshed Data is written back to its
+    /// owning store. Existing callers are being migrated incrementally; the
+    /// deprecation warning identifies the remaining work.
+    @available(
+        *,
+        deprecated,
+        message: "Use SecurityScopedBookmarkResolver.shared.resolve(_:target:) instead — it observes bookmarkDataIsStale and refreshes the saved Data via a typed Target."
+    )
     nonisolated static func resolveBookmark(_ data: Data) throws -> BookmarkResolution {
         var scopedStale = false
         do {

--- a/LiveWallpaper/Runtime/WPECorpusPlaybackHarness.swift
+++ b/LiveWallpaper/Runtime/WPECorpusPlaybackHarness.swift
@@ -144,10 +144,14 @@ final class WPECorpusPlaybackHarness {
         // loop — every per-scene `ensureExtracted` re-reads the source pkg
         // off the user's library.
         let libraryRoot: URL
-        do {
-            libraryRoot = try Self.resolveLibraryRoot(bookmarkData: rootBookmarkData)
-        } catch {
-            let message = Self.describe(error)
+        switch SecurityScopedBookmarkResolver.shared.resolve(
+            rootBookmarkData,
+            target: .workshopLibraryRoot
+        ) {
+        case .success(let resolved):
+            libraryRoot = resolved.url
+        case .failure(let failure):
+            let message = failure.errorDescription ?? "Workshop bookmark resolution failed"
             Logger.error("WPE corpus playback could not resolve library root: \(message)", category: .screenManager)
             progress(.failedToStart(message))
             return
@@ -477,16 +481,6 @@ final class WPECorpusPlaybackHarness {
             elapsedSeconds: Date().timeIntervalSince(startedAt),
             failureMessage: failureMessage,
             resolution: .empty
-        )
-    }
-
-    private static func resolveLibraryRoot(bookmarkData: Data) throws -> URL {
-        var isStale = false
-        return try URL(
-            resolvingBookmarkData: bookmarkData,
-            options: .withSecurityScope,
-            relativeTo: nil,
-            bookmarkDataIsStale: &isStale
         )
     }
 

--- a/LiveWallpaper/Views/ScreenDetail/WorkshopGalleryView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WorkshopGalleryView.swift
@@ -663,13 +663,14 @@ struct WorkshopGalleryView: View {
         _ project: WallpaperEngineLibraryScanner.DiscoveredProject,
         screen: Screen
     ) async -> ScreenManager.WPEProjectApplyOutcome {
-        var isStale = false
-        guard let rootURL = try? URL(
-            resolvingBookmarkData: project.libraryRootBookmarkData,
-            options: .withSecurityScope,
-            relativeTo: nil,
-            bookmarkDataIsStale: &isStale
-        ) else {
+        let rootURL: URL
+        switch SecurityScopedBookmarkResolver.shared.resolve(
+            project.libraryRootBookmarkData,
+            target: .workshopLibraryRoot
+        ) {
+        case .success(let resolved):
+            rootURL = resolved.url
+        case .failure:
             return .rejected(reason: "Workshop folder access expired. Re-grant library access.")
         }
 
@@ -690,13 +691,14 @@ struct WorkshopGalleryView: View {
     private func prepareWithLibraryAccess(
         _ project: WallpaperEngineLibraryScanner.DiscoveredProject
     ) async -> ScreenManager.WPEProjectPreparationOutcome {
-        var isStale = false
-        guard let rootURL = try? URL(
-            resolvingBookmarkData: project.libraryRootBookmarkData,
-            options: .withSecurityScope,
-            relativeTo: nil,
-            bookmarkDataIsStale: &isStale
-        ) else {
+        let rootURL: URL
+        switch SecurityScopedBookmarkResolver.shared.resolve(
+            project.libraryRootBookmarkData,
+            target: .workshopLibraryRoot
+        ) {
+        case .success(let resolved):
+            rootURL = resolved.url
+        case .failure:
             return .rejected(reason: "Workshop folder access expired. Re-grant library access.")
         }
 
@@ -819,16 +821,14 @@ struct WorkshopGalleryView: View {
     }
 
     private func resolveWorkshopRootURL() -> URL? {
-        guard let bookmark = SettingsManager.shared.loadWorkshopLibraryRootBookmark() else {
+        let bookmark = SettingsManager.shared.loadWorkshopLibraryRootBookmark()
+        guard case .success(let resolved) = SecurityScopedBookmarkResolver.shared.resolve(
+            bookmark,
+            target: .workshopLibraryRoot
+        ) else {
             return nil
         }
-        var isStale = false
-        return try? URL(
-            resolvingBookmarkData: bookmark,
-            options: .withSecurityScope,
-            relativeTo: nil,
-            bookmarkDataIsStale: &isStale
-        )
+        return resolved.url
     }
 
     private func importErrorMessage(_ error: AppError) -> String {

--- a/LiveWallpaperTests/SecurityScopedBookmarkResolverTests.swift
+++ b/LiveWallpaperTests/SecurityScopedBookmarkResolverTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+struct SecurityScopedBookmarkResolverTests {
+
+    private static let fixtureURL = URL(fileURLWithPath: "/tmp/livewallpaper-test-bookmark-fixture")
+    private static let originalData = Data("original".utf8)
+    private static let refreshedData = Data("refreshed".utf8)
+
+    @Test("Returns .missing when no data is stored")
+    func missingData() {
+        let resolver = SecurityScopedBookmarkResolver(
+            resolveData: { _ in (Self.fixtureURL, false) },
+            refreshData: { _ in Self.refreshedData }
+        )
+        let target = SecurityScopedBookmarkResolver.Target(label: "test") { _ in }
+
+        let result = resolver.resolve(nil, target: target)
+        guard case .failure(.missing) = result else {
+            Issue.record("Expected .missing for nil data, got \(result)")
+            return
+        }
+    }
+
+    @Test("Fresh bookmark resolves without refresh and never invokes save")
+    func freshBookmark() {
+        let capture = SaveCapture()
+        let resolver = SecurityScopedBookmarkResolver(
+            resolveData: { _ in (Self.fixtureURL, false) },
+            refreshData: { _ in Self.refreshedData }
+        )
+        let target = SecurityScopedBookmarkResolver.Target(label: "test", save: capture.save)
+
+        let result = resolver.resolve(Self.originalData, target: target)
+
+        guard case .success(let resolved) = result else {
+            Issue.record("Expected .success, got \(result)")
+            return
+        }
+        #expect(resolved.url == Self.fixtureURL)
+        #expect(resolved.bookmarkData == Self.originalData)
+        #expect(resolved.didRefresh == false)
+        #expect(capture.snapshot.isEmpty, "save must not be invoked when bookmark is fresh")
+    }
+
+    @Test("Stale bookmark refreshes and invokes the target's save closure")
+    func staleBookmarkRefreshes() {
+        let capture = SaveCapture()
+        let resolver = SecurityScopedBookmarkResolver(
+            resolveData: { _ in (Self.fixtureURL, true) },
+            refreshData: { _ in Self.refreshedData }
+        )
+        let target = SecurityScopedBookmarkResolver.Target(label: "test", save: capture.save)
+
+        let result = resolver.resolve(Self.originalData, target: target)
+
+        guard case .success(let resolved) = result else {
+            Issue.record("Expected .success on stale resolve, got \(result)")
+            return
+        }
+        #expect(resolved.didRefresh == true)
+        #expect(capture.snapshot == [Self.refreshedData])
+    }
+
+    @Test("Stale + refresh failure preserves grace-use semantics")
+    func staleRefreshFailure() {
+        let capture = SaveCapture()
+        let resolver = SecurityScopedBookmarkResolver(
+            resolveData: { _ in (Self.fixtureURL, true) },
+            refreshData: { _ in throw FakeError.refreshFailed }
+        )
+        let target = SecurityScopedBookmarkResolver.Target(label: "test", save: capture.save)
+
+        let result = resolver.resolve(Self.originalData, target: target)
+
+        guard case .success(let resolved) = result else {
+            Issue.record("Expected .success even when refresh fails, got \(result)")
+            return
+        }
+        #expect(resolved.url == Self.fixtureURL)
+        #expect(resolved.bookmarkData == Self.originalData, "must return current data for grace use")
+        #expect(capture.snapshot.isEmpty, "failed refresh must not invoke save")
+    }
+
+    @Test("Resolution throw propagates as .resolutionFailed")
+    func resolutionThrowsPropagates() {
+        let capture = SaveCapture()
+        let resolver = SecurityScopedBookmarkResolver(
+            resolveData: { _ in throw FakeError.resolutionFailed },
+            refreshData: { _ in Self.refreshedData }
+        )
+        let target = SecurityScopedBookmarkResolver.Target(label: "test", save: capture.save)
+
+        let result = resolver.resolve(Self.originalData, target: target)
+
+        guard case .failure(.resolutionFailed) = result else {
+            Issue.record("Expected .resolutionFailed, got \(result)")
+            return
+        }
+        #expect(capture.snapshot.isEmpty)
+    }
+
+    @Test("withScopedAccess runs the closure")
+    func withScopedAccessRunsWork() {
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        var ranWith: Bool?
+        SecurityScopedBookmarkResolver.withScopedAccess(tempURL) { didStart in
+            ranWith = didStart
+        }
+        #expect(ranWith != nil, "work closure must run regardless of scope outcome")
+    }
+
+    @Test("withScopedAccess rethrows but still runs work to completion")
+    func withScopedAccessRethrows() {
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        var didReach = false
+        do {
+            try SecurityScopedBookmarkResolver.withScopedAccess(tempURL) { _ in
+                didReach = true
+                throw FakeError.refreshFailed
+            }
+            Issue.record("Expected rethrow, work returned normally")
+        } catch FakeError.refreshFailed {
+            #expect(didReach)
+        } catch {
+            Issue.record("Wrong error rethrown: \(error)")
+        }
+    }
+}
+
+private enum FakeError: Error {
+    case resolutionFailed
+    case refreshFailed
+}
+
+/// Thread-safe accumulator for test save-side-effect assertions.
+private final class SaveCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var saved: [Data] = []
+
+    var snapshot: [Data] {
+        lock.lock(); defer { lock.unlock() }
+        return saved
+    }
+
+    var save: @Sendable (Data) -> Void {
+        { [weak self] data in
+            guard let self else { return }
+            self.lock.lock()
+            self.saved.append(data)
+            self.lock.unlock()
+        }
+    }
+}

--- a/LiveWallpaperTests/SecurityScopedBookmarkResolverTests.swift
+++ b/LiveWallpaperTests/SecurityScopedBookmarkResolverTests.swift
@@ -14,7 +14,7 @@ struct SecurityScopedBookmarkResolverTests {
             resolveData: { _ in (Self.fixtureURL, false) },
             refreshData: { _ in Self.refreshedData }
         )
-        let target = SecurityScopedBookmarkResolver.Target(label: "test") { _ in }
+        let target = SecurityScopedBookmarkResolver.Target(label: "test")
 
         let result = resolver.resolve(nil, target: target)
         guard case .failure(.missing) = result else {
@@ -60,6 +60,7 @@ struct SecurityScopedBookmarkResolverTests {
             return
         }
         #expect(resolved.didRefresh == true)
+        #expect(resolved.bookmarkData == Self.refreshedData, "must return refreshed data to in-process callers")
         #expect(capture.snapshot == [Self.refreshedData])
     }
 
@@ -80,6 +81,7 @@ struct SecurityScopedBookmarkResolverTests {
         }
         #expect(resolved.url == Self.fixtureURL)
         #expect(resolved.bookmarkData == Self.originalData, "must return current data for grace use")
+        #expect(resolved.didRefresh == false, "refresh that threw must not flip didRefresh")
         #expect(capture.snapshot.isEmpty, "failed refresh must not invoke save")
     }
 
@@ -144,11 +146,11 @@ private final class SaveCapture: @unchecked Sendable {
         return saved
     }
 
-    var save: @Sendable (Data) -> Void {
-        { [weak self] data in
+    var save: @Sendable (_ original: Data, _ refreshed: Data) -> Void {
+        { [weak self] _, refreshed in
             guard let self else { return }
             self.lock.lock()
-            self.saved.append(data)
+            self.saved.append(refreshed)
             self.lock.unlock()
         }
     }

--- a/scripts/release_candidate_check.sh
+++ b/scripts/release_candidate_check.sh
@@ -55,4 +55,28 @@ scripts/audit.sh static
 echo "== Diff whitespace check =="
 git diff --check
 
+echo "== Bookmark resolver audit =="
+# Every security-scoped bookmark resolve should go through
+# SecurityScopedBookmarkResolver (which observes bookmarkDataIsStale and
+# persists the refresh). Bare URL(resolvingBookmarkData:) calls drop
+# the stale flag and were the root cause of "user must re-grant after
+# every restart" — see .claude/plan/settings-persistence-audit.md.
+#
+# Currently soft-warning while Phase 3 migrates the remaining 9 call
+# sites. Once those are gone, drop the `|| true` and `>&2 ... continue`
+# branch so this fails the build (tracked in Phase 6 of the plan).
+BOOKMARK_OFFENDERS=$(
+  rg -l 'resolvingBookmarkData' LiveWallpaper \
+    --type swift \
+    --glob '!LiveWallpaper/Infrastructure/SecurityScopedBookmarkResolver.swift' \
+    --glob '!LiveWallpaper/ResourceUtilities.swift' \
+  || true
+)
+if [[ -n "$BOOKMARK_OFFENDERS" ]]; then
+  COUNT=$(echo "$BOOKMARK_OFFENDERS" | wc -l | tr -d ' ')
+  echo "WARNING: $COUNT files still resolve bookmarks outside SecurityScopedBookmarkResolver:" >&2
+  echo "$BOOKMARK_OFFENDERS" | sed 's/^/  - /' >&2
+  echo "Migrate to SecurityScopedBookmarkResolver.shared.resolve(_:target:) — see .claude/plan/settings-persistence-audit.md." >&2
+fi
+
 echo "Release candidate checks passed."


### PR DESCRIPTION
## Summary

Phase 1 + Phase 2 of [.claude/plan/settings-persistence-audit.md](.claude/plan/settings-persistence-audit.md). Fixes the user-reported symptom: *"grant 后不能永久保存，重开 app 要重新授权；workshop 会自己挂掉"*.

### Root cause (confirmed via grep)

macOS security-scoped bookmarks must observe `bookmarkDataIsStale` on every resolve and re-create + persist the bookmark when stale=true. Apple grants exactly one stale-grace resolve; the next one permanently fails. **13 of 16 resolution sites in this codebase dropped the flag**, so user-granted folder access (Workshop library, engine assets, aerials, video / HTML files) silently invalidated after restart or after Steam re-downloaded a workshop scene.

### What this PR does

**Phase 1**: New `SecurityScopedBookmarkResolver`
- Centralises every security-scoped bookmark resolve.
- Carries a typed `Target` whose `save` closure writes refreshed Data back to its owning store (UserDefaults key, AtomicFileStore JSON, etc.) — resolver itself never has to know about persistence schemas.
- On stale + refresh-success: returns the **refreshed** bookmark to in-process callers (so copies don't burn another grace) AND saves via target.
- On stale + refresh-failure: returns the existing Data with grace-use semantics + logs warning.
- Injectable `resolveData` / `refreshData` closures so tests drive the stale path without real bookmarks.
- Typed targets: `.workshopLibraryRoot`, `.wpeEngineAssets`, `.aerialsDirectory`, `.transient` (read-only).
- 7 unit tests covering: missing data, fresh, stale-success, stale-refresh-failure, resolution-throws, `withScopedAccess` work + rethrow.

**Phase 2**: Routed all 5 workshop-root bookmark sites through the resolver
- `WallpaperEngineLibraryScanner.performScan` (+ propagates refreshed Data into `DiscoveredProject.libraryRootBookmarkData`)
- `WorkshopGalleryView.applyForScreenWithLibraryAccess`
- `WorkshopGalleryView.prepareWithLibraryAccess`
- `WorkshopGalleryView.resolveWorkshopRootURL`
- `WPECorpusPlaybackHarness.run` (dropped dead `resolveLibraryRoot` helper)

**Phase 2.5**: Deprecated `ResourceUtilities.resolveBookmark` with `@available(*, deprecated, message:)`
- 10 deprecation warnings now surface every remaining legacy call site, providing migration pressure for Phase 3.
- Existing callers keep compiling (with warning) — no functional regression today.

**Phase 2.6**: Added bookmark-resolver audit to `release_candidate_check.sh`
- Soft-warning mode while 9 legacy call sites remain — Phase 6 of the plan tightens it to a hard build failure.
- New code adding `URL(resolvingBookmarkData:)` outside the resolver is immediately visible.

**Phase 2.7**: Addressed High-severity issues from codex audit
- Issue 1: Resolver now returns refreshed Data in `Resolved.bookmarkData` so in-process copiers (the scanner) propagate the fresh blob — fixes the "scan consumes grace, next click still fails" case.
- Issue 2: Typed `save` closures upgraded to `(original, refreshed)` pair and compare-and-swap against the currently-stored bookmark before writing. If the user cleared or re-granted the bookmark between resolve and the async MainActor save, the late save is now a no-op so it can't resurrect a stale grant.

## What this PR does NOT do (deferred to follow-up PRs)

| Plan phase | Why deferred |
|---|---|
| Phase 3 — migrate aerials / WPE / generic sites (8 more) | Larger surface area; some need typed targets that mutate Codable models (e.g. WPEHistoryEntry). Better as its own focused PR. |
| Phase 4 — DisplayIdentity composite key for per-display settings | Different bug class (CGDirectDisplayID instability), large model migration. Separate PR. |
| Phase 5 — failure-surfacing UX (banner / re-grant CTA) | Visible UX changes belong with their own design review. |
| Phase 6 — tighten lint to hard failure | Blocked on Phase 3 finishing the migration. |
| Phase 7 — Managed Locations privacy panel | Stretch / nice-to-have. |

## Test plan
- [x] `xcodebuild ... -only-testing:LiveWallpaperTests` — **644 tests / 105 suites pass** (+7 resolver tests; full ~5s)
- [x] codex audit pass — 2 High issues found + addressed in commit 65aa70a
- [ ] Manual: grant Workshop folder → close+reopen app 5 times → bookmark survives without re-grant prompt
- [ ] Manual: Steam re-downloads a workshop scene mid-session → app keeps scanning without re-grant
- [ ] Manual: open Settings → Workshop Library → confirm scan still works as before

## Files changed
| File | Op | Notes |
|---|---|---|
| `LiveWallpaper/Infrastructure/SecurityScopedBookmarkResolver.swift` | NEW (+219) | Centralised resolver |
| `LiveWallpaperTests/SecurityScopedBookmarkResolverTests.swift` | NEW (+155) | 7 unit tests |
| `LiveWallpaper/Infrastructure/WallpaperEngineLibraryScanner.swift` | modified | Workshop root via resolver + propagate refreshed Data |
| `LiveWallpaper/Views/ScreenDetail/WorkshopGalleryView.swift` | modified | 3 sites |
| `LiveWallpaper/Runtime/WPECorpusPlaybackHarness.swift` | modified | Workshop root via resolver |
| `LiveWallpaper/ResourceUtilities.swift` | modified | @available(*, deprecated) on `resolveBookmark` |
| `scripts/release_candidate_check.sh` | modified | Bookmark resolver audit (soft-warn) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)