### PR TITLE
[codex] Guard rain glass render dimensions

### DIFF
--- a/LiveWallpaper/Runtime/RainGlassMetalRenderer.swift
+++ b/LiveWallpaper/Runtime/RainGlassMetalRenderer.swift
@@ -268,6 +268,8 @@ class RainGlassFilter: CIFilter, @unchecked Sendable {
     @objc dynamic var inputTime: NSNumber = 0.0
     @objc dynamic var inputResolution: CIVector = CIVector(x: 1920, y: 1080)
 
+    private static let maximumRenderDimension = 16_384
+
     private static let renderer: RainGlassMetalRenderer? = {
         guard let device = MTLCreateSystemDefaultDevice() else {
             Logger.error("RainGlassFilter: Metal is unavailable", category: .videoPlayer)
@@ -276,19 +278,42 @@ class RainGlassFilter: CIFilter, @unchecked Sendable {
         return RainGlassMetalRenderer(device: device)
     }()
 
+    static func renderDimensions(inputResolution: CIVector, inputExtent: CGRect) -> (width: Int, height: Int)? {
+        guard let width = renderDimension(preferred: inputResolution.x, fallback: inputExtent.width),
+              let height = renderDimension(preferred: inputResolution.y, fallback: inputExtent.height)
+        else {
+            return nil
+        }
+        return (width, height)
+    }
+
+    private static func renderDimension(preferred: CGFloat, fallback: CGFloat) -> Int? {
+        sanitizedDimension(preferred) ?? sanitizedDimension(fallback)
+    }
+
+    private static func sanitizedDimension(_ value: CGFloat) -> Int? {
+        guard value.isFinite else { return nil }
+        let rounded = value.rounded()
+        guard rounded >= 1, rounded <= CGFloat(maximumRenderDimension) else { return nil }
+        return Int(rounded)
+    }
+
     override var outputImage: CIImage? {
         guard let inputImage else { return nil }
         guard let renderer = Self.renderer else { return inputImage }
 
-        let extent = inputImage.extent
-        let width = max(Int(inputResolution.x.rounded()), Int(extent.width.rounded()), 1)
-        let height = max(Int(inputResolution.y.rounded()), Int(extent.height.rounded()), 1)
+        guard let dimensions = Self.renderDimensions(
+            inputResolution: inputResolution,
+            inputExtent: inputImage.extent
+        ) else {
+            return inputImage
+        }
 
         return renderer.render(
             inputImage: inputImage,
             time: inputTime.floatValue,
-            width: width,
-            height: height
+            width: dimensions.width,
+            height: dimensions.height
         ) ?? inputImage
     }
 }

--- a/LiveWallpaper/Runtime/RainGlassMetalRenderer.swift
+++ b/LiveWallpaper/Runtime/RainGlassMetalRenderer.swift
@@ -126,7 +126,7 @@ final class RainGlassMetalRenderer: @unchecked Sendable {
         self.sourcePool = RainGlassTexturePool(
             device: device,
             inFlightTextureCount: Self.inFlightTextureCount,
-            usage: [.shaderRead, .renderTarget]
+            usage: [.shaderRead, .shaderWrite, .renderTarget]
         )
         self.waterMapPool = RainGlassTexturePool(
             device: device,

--- a/LiveWallpaperTests/RainGlassMetalRendererTests.swift
+++ b/LiveWallpaperTests/RainGlassMetalRendererTests.swift
@@ -49,6 +49,26 @@ struct RainGlassMetalRendererTests {
         #expect(output.extent == CGRect(x: 0, y: 0, width: 96, height: 64))
     }
 
+    @Test("Renderer output carries the source color signal")
+    func rendererOutputCarriesSourceColorSignal() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let renderer = try #require(RainGlassMetalRenderer(device: device))
+        let input = CIImage(color: CIColor(red: 0.9, green: 0.15, blue: 0.1, alpha: 1))
+            .cropped(to: CGRect(x: 0, y: 0, width: 64, height: 64))
+
+        let output = try #require(renderer.render(inputImage: input, time: 0.25, width: 64, height: 64))
+        let bytes = renderBytes(output, width: 64, height: 64)
+
+        var redTotal = 0
+        var blueTotal = 0
+        for i in stride(from: 0, to: bytes.count, by: 4) {
+            redTotal += Int(bytes[i])
+            blueTotal += Int(bytes[i + 2])
+        }
+
+        #expect(redTotal > blueTotal * 2)
+    }
+
     @Test("Water map carries alpha, thickness, and non-neutral refraction")
     func waterMapCarriesDropSignals() throws {
         guard let device = MTLCreateSystemDefaultDevice() else { return }
@@ -85,6 +105,19 @@ struct RainGlassMetalRendererTests {
             bytesPerRow: texture.width * 4,
             from: MTLRegionMake2D(0, 0, texture.width, texture.height),
             mipmapLevel: 0
+        )
+        return bytes
+    }
+
+    private func renderBytes(_ image: CIImage, width: Int, height: Int) -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: width * height * 4)
+        CIContext().render(
+            image,
+            toBitmap: &bytes,
+            rowBytes: width * 4,
+            bounds: CGRect(x: 0, y: 0, width: width, height: height),
+            format: .RGBA8,
+            colorSpace: CGColorSpaceCreateDeviceRGB()
         )
         return bytes
     }

--- a/LiveWallpaperTests/RainGlassMetalRendererTests.swift
+++ b/LiveWallpaperTests/RainGlassMetalRendererTests.swift
@@ -11,6 +11,32 @@ struct RainGlassMetalRendererTests {
         #expect(RainGlassMetalRenderer.inFlightTextureCount == 3)
     }
 
+    @Test("Filter dimensions ignore infinite clamped input extent")
+    func filterDimensionsIgnoreInfiniteClampedExtent() throws {
+        let input = CIImage(color: CIColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+            .cropped(to: CGRect(x: 0, y: 0, width: 96, height: 64))
+            .clampedToExtent()
+
+        let dimensions = try #require(RainGlassFilter.renderDimensions(
+            inputResolution: CIVector(x: 96, y: 64),
+            inputExtent: input.extent
+        ))
+
+        #expect(dimensions.width == 96)
+        #expect(dimensions.height == 64)
+    }
+
+    @Test("Filter dimensions fall back to finite extent when resolution is invalid")
+    func filterDimensionsFallBackToFiniteExtent() throws {
+        let dimensions = try #require(RainGlassFilter.renderDimensions(
+            inputResolution: CIVector(x: .infinity, y: .nan),
+            inputExtent: CGRect(x: 0, y: 0, width: 320, height: 180)
+        ))
+
+        #expect(dimensions.width == 320)
+        #expect(dimensions.height == 180)
+    }
+
     @Test("Renderer returns an image cropped to the requested extent")
     func rendererReturnsRequestedExtent() throws {
         guard let device = MTLCreateSystemDefaultDevice() else { return }


### PR DESCRIPTION
## Summary
- Guard RainGlassFilter dimension conversion against infinite or invalid Core Image extents.
- Prefer the finite source resolution from AVVideoComposition and only fall back to finite image extent values.
- Allow Core Image to write into the rain renderer's source Metal texture by including MTLTextureUsageShaderWrite.
- Add regression coverage for clamped input images with infinite extent, invalid resolution fallback, and source color preservation through the renderer.

## Root Cause
The rain filter receives an image that has been clamped to extent. Core Image can represent that extent as infinite, and Swift traps when converting a non-finite or oversized Double/CGFloat to Int. The previous implementation converted both the preferred resolution and input extent before choosing a maximum dimension.

During verification, the renderer also logged that the source texture usage did not include MTLTextureUsageShaderWrite, which can prevent CIContext.render from writing the video frame into the Metal texture. The follow-up fix adds the required usage flag and a color-signal regression test.

## Validation
- git diff --check
- Swift one-off reproduction confirmed clamped infinite extent resolves to 96x64 without trapping
- swiftc -module-cache-path /private/tmp/swift-module-cache -typecheck -parse-as-library -target arm64-apple-macos26.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk LiveWallpaper/Logger.swift LiveWallpaper/Infrastructure/LogFileSink.swift LiveWallpaper/Runtime/RainGlassMetalRenderer.swift
- xcodebuild -project LiveWallpaper.xcodeproj -scheme LiveWallpaper -destination 'platform=macOS,arch=arm64' -derivedDataPath /private/tmp/LiveWallpaperDerivedData CODE_SIGNING_ALLOWED=NO -toolchain com.apple.dt.toolchain.Metal.32023.883 -skipPackagePluginValidation -skipMacroValidation -only-testing:LiveWallpaperTests/RainGlassMetalRendererTests test

## Notes
- Xcode reports MetalToolchain as installed. In this environment, the default xcrun metal wrapper still reports a missing MetalToolchain, but explicit xcodebuild -toolchain com.apple.dt.toolchain.Metal.32023.883 resolves to the installed cryptex Metal compiler and the targeted rain renderer suite passes.