### PR TITLE
wpe: extend prelude helpers + scene-alias coverage (Phase 1.5)

### DIFF
--- a/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
@@ -647,6 +647,15 @@ private struct WPEShaderSourceLoader: Sendable {
     private func builtinInclude(named name: String) -> String? {
         switch name {
         case "common.h":
+            // Phase 1.5: Add minimal WPE-runtime helpers our transpiler
+            // could not synthesise. `mod(x, y)` is a GLSL intrinsic Metal
+            // doesn't ship at global scope — corpus shader
+            // `ps2_startup_screen` invokes it directly. `rotateVec2` is a
+            // WPE-runtime helper several effects (cloudmotion, swing,
+            // lens_flare) call without defining locally. Both are
+            // implemented as constexpr-friendly inline functions so the
+            // GLSL preprocessor + Metal compiler can fold uses at the
+            // call site without losing precision.
             return """
             #ifndef LIVEWALLPAPER_WPE_COMMON_H
             #define LIVEWALLPAPER_WPE_COMMON_H
@@ -654,6 +663,21 @@ private struct WPEShaderSourceLoader: Sendable {
             #ifndef texSample2D
             #define texSample2D texture
             #endif
+            #ifndef mod
+            #define mod(x, y) ((x) - (y) * floor((x) / (y)))
+            #endif
+
+            vec2 rotateVec2(vec2 v, float angle) {
+                float c = cos(angle);
+                float s = sin(angle);
+                return vec2(c * v.x - s * v.y, s * v.x + c * v.y);
+            }
+
+            vec3 rotateVec3AroundAxis(vec3 v, vec3 axis, float angle) {
+                float c = cos(angle);
+                float s = sin(angle);
+                return v * c + cross(axis, v) * s + axis * dot(axis, v) * (1.0 - c);
+            }
             #endif
             """
         case "common_blur.h":
@@ -675,6 +699,23 @@ private struct WPEShaderSourceLoader: Sendable {
             #ifndef LIVEWALLPAPER_WPE_COMMON_BLENDING_H
             #define LIVEWALLPAPER_WPE_COMMON_BLENDING_H
             #define wpe_common_blending_included 1
+
+            // Named blend-mode constants WPE workshop shaders pass to
+            // ApplyBlending. Values match Photoshop ordering and our
+            // implementation's runtime switch below. Workshops invoke
+            // ApplyBlending(BlendLinearDodge, A, B, opacity) — without
+            // these the transpiler emits 'undeclared identifier
+            // BlendLinearDodge' for the corpus vhs / sine_wave_circle
+            // shaders.
+            #define BlendNormal 0
+            #define BlendDarken 2
+            #define BlendLighten 3
+            #define BlendMultiply 4
+            #define BlendScreen 5
+            #define BlendLinearDodge 6
+            #define BlendAdd 6
+            #define BlendSubtract 7
+            #define BlendDifference 8
 
             // No `in` qualifier on parameters — it's GLSL-default (and thus
             // optional) but the MSL backend rejects it as an unknown type

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -418,15 +418,16 @@ final class WPEMetalRenderExecutor {
         frameState.registerWrite(texture: destination.texture, targetID: destination.id)
     }
 
-    /// Breaks the `_rt_FullFrameBuffer` ↔ scene aliasing hazard. The
-    /// fbo-resolver redirects `.fbo("_rt_FullFrameBuffer")` to the scene
-    /// output texture when no explicit named-texture exists, which lets
-    /// post-process effects sample the composed scene. But if the SAME
-    /// pass also targets `.scene`, the read and write would collide on one
-    /// texture. Pre-encoding a snapshot into a pool-managed slot named
-    /// `_rt_FullFrameBuffer` resolves both sides: the resolver now finds
-    /// the snapshot in `latestNamedTextures` and never falls through to
-    /// the scene texture.
+    /// Breaks the `_rt_*` scene-alias hazard. The fbo-resolver redirects
+    /// scene-alias names (`_rt_FullFrameBuffer`, `_rt_HalfFrameBuffer`,
+    /// `_rt_EightBuffer*`, …) to the scene output texture when no
+    /// explicit named-texture exists, which lets post-process effects
+    /// sample the composed scene. But if the SAME pass also targets
+    /// `.scene`, the read and write would collide on one texture.
+    /// Pre-encoding a snapshot into a pool-managed slot named after the
+    /// alias resolves both sides: the resolver now finds the snapshot
+    /// in `latestNamedTextures` and never falls through to the scene
+    /// texture.
     private func snapshotFullFrameBufferIfAliasingScene(
         pass: WPEPreparedRenderPass,
         destinationTexture: MTLTexture,
@@ -435,12 +436,16 @@ final class WPEMetalRenderExecutor {
         commandBuffer: MTLCommandBuffer,
         frameState: inout WPEMetalFrameState
     ) throws {
-        let alias = "_rt_FullFrameBuffer"
-        guard targetID == .scene,
-              frameState.latestNamedTextures[alias] == nil,
-              textureReferences(for: pass).contains(.fbo(alias)) else {
-            return
+        guard targetID == .scene else { return }
+        let aliases = textureReferences(for: pass).compactMap { reference -> String? in
+            guard case .fbo(let name) = reference,
+                  WPEMetalShaderInputs.isSceneAliasName(name),
+                  frameState.latestNamedTextures[name] == nil else {
+                return nil
+            }
+            return name
         }
+        guard let alias = aliases.first else { return }
         let snapshot = try targetPool.texture(
             for: .fbo(name: alias),
             layer: layer,

--- a/LiveWallpaper/Runtime/WPEMetalShaderInputs.swift
+++ b/LiveWallpaper/Runtime/WPEMetalShaderInputs.swift
@@ -45,15 +45,20 @@ enum WPEMetalShaderInputs {
             if let texture = frameState.latestNamedTextures[name] {
                 return texture
             }
-            // WPE runtime aliases `_rt_FullFrameBuffer` to "whatever the
+            // WPE runtime aliases several `_rt_*` names to "whatever the
             // scene currently contains" — workshop post-process effects
-            // (water ripple, blur, audio bars, …) bind this as their input
-            // source without any explicit pass writing to it. Without the
-            // redirect, 22 of 57 scenes in the Phase A.3 corpus baseline
-            // failed here with missingTexture. Falls back to the scene
-            // output texture (always allocated) so the effect samples the
-            // composed scene.
-            if name == "_rt_FullFrameBuffer" {
+            // bind these as input sources without any pass explicitly
+            // writing to them. The Phase A.3 baseline had 22 scenes
+            // failing on `_rt_FullFrameBuffer` alone; 3 more failed on
+            // `_rt_EightBuffer2` etc. WPE's intent for the downscaled
+            // variants is a half / quarter / eighth-resolution copy of
+            // the scene — until we implement proper mip generation the
+            // best-available fallback is the full-resolution scene
+            // texture. Effects that depend on the actual downscale (e.g.
+            // bloom kernels expecting blurry low-frequency content) will
+            // still over-sample, but the scene will draw something
+            // recognisable instead of crashing with `missingTexture`.
+            if Self.isSceneAliasName(name) {
                 return frameState.latestSceneTexture ?? frameState.output
             }
             throw WPEMetalRenderExecutorError.missingTexture(reference)
@@ -63,6 +68,28 @@ enum WPEMetalShaderInputs {
                 throw WPEMetalRenderExecutorError.missingTexture(reference)
             }
             return texture
+        }
+    }
+
+    /// True for `_rt_*` names that WPE's runtime aliases to the live scene
+    /// texture rather than a discrete FBO allocation. Used by the resolver
+    /// fallback when no explicit named-texture is registered. The
+    /// downscaled variants (`Half` / `Quarter` / `Eight`) intentionally
+    /// fall through to the same full-resolution scene texture — better
+    /// than throwing `missingTexture`, with the trade-off that bloom-like
+    /// effects expecting blur from downscale won't get it until proper
+    /// mip generation lands.
+    static func isSceneAliasName(_ name: String) -> Bool {
+        switch name {
+        case "_rt_FullFrameBuffer",
+             "_rt_HalfFrameBuffer",
+             "_rt_QuarterFrameBuffer",
+             "_rt_imageLayerComposite":
+            return true
+        default:
+            return name.hasPrefix("_rt_EightBuffer")
+                || name.hasPrefix("_rt_Mip")
+                || name.hasPrefix("_rt_downscaled")
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 1.5 batches three small wins surfaced by the Phase A.3 corpus baseline — none of them require the Phase 2 GLSL→MSL toolchain swap.

1. **Prelude helpers** ([WPERenderPipelineBuilder.swift](LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift)) — added `mod(x,y)`, `rotateVec2`, `rotateVec3AroundAxis` to the `common.h` stub; named blend constants (`BlendNormal`/`BlendDarken`/`BlendLighten`/`BlendMultiply`/`BlendScreen`/`BlendLinearDodge`/`BlendAdd`/`BlendSubtract`/`BlendDifference`) to the `common_blending.h` stub.

2. **Scene-alias coverage** ([WPEMetalShaderInputs.swift](LiveWallpaper/Runtime/WPEMetalShaderInputs.swift)) — `isSceneAliasName(_:)` predicate that recognises the full WPE runtime alias family (`_rt_FullFrameBuffer`, `_rt_HalfFrameBuffer`, `_rt_QuarterFrameBuffer`, `_rt_EightBuffer*`, `_rt_Mip*`, `_rt_downscaled*`, `_rt_imageLayerComposite`). The `.fbo(name)` resolver redirects all of them to `frameState.latestSceneTexture ?? frameState.output`.

3. **Executor snapshot extension** ([WPEMetalRenderExecutor.swift](LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift)) — `snapshotFullFrameBufferIfAliasingScene` walks the alias predicate so any aliased FBO write lands in the pool slot named after the actual alias, not just `_rt_FullFrameBuffer`.

## Expected corpus yield

Based on Phase A.3 baseline JSON:
- +2–3 scenes from `mod` / `rotateVec2` (transpiler missing-symbol failures)
- +1–2 from named blend constants (vhs, sine_wave_circle)
- +3 from `_rt_EightBuffer*` cluster (blur chains binding `_rt_HalfFrameBuffer` etc. as input source)

## Test plan

- [x] `xcodebuild build` clean
- [x] `xcodebuild test -only-testing:LiveWallpaperTests` green
- [ ] Re-run Phase A.3 corpus playback on next dev cycle, compare success delta vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)