### PR TITLE
fix(wpe): strip GLSL 'in' parameter qualifier in transpiler

### DIFF
--- a/LiveWallpaper/Runtime/WPEShaderTranspiler.swift
+++ b/LiveWallpaper/Runtime/WPEShaderTranspiler.swift
@@ -292,6 +292,16 @@ struct WPEShaderTranspiler {
         // ~4 corpus scenes (lightshafts, tint, ps2_startup_screen, …).
         s = rewriteReferenceParameters(s)
 
+        // GLSL's `in T name` parameter qualifier is the default pass-by-value
+        // form and has no MSL keyword equivalent — it must be stripped or
+        // Metal rejects the declaration with `unknown type name 'in'`. Hit
+        // every helper signature in effects/blendgradient + related blend
+        // shaders (≥9 corpus scenes ran into this on `ApplyBlending`,
+        // `ApplyBlendingAlpha`, `mixSoftLight`, etc.), and the cascading
+        // "undeclared identifier" errors for `A`, `B`, `result`, `opacity`
+        // were all downstream of the failed function declaration.
+        s = stripInParameterQualifier(s)
+
         // gl_FragCoord → custom binding. We won't support FragCoord-driven
         // shaders in the first pass — trip the compile error on use.
         // (The transpiler still emits the source; Metal's compiler will
@@ -322,6 +332,25 @@ struct WPEShaderTranspiler {
             in: source,
             range: range,
             withTemplate: "thread $2& $3"
+        )
+    }
+
+    /// Strip GLSL's `in T name` parameter qualifier (MSL has no equivalent —
+    /// `in` is the implicit default). Runs AFTER `rewriteReferenceParameters`
+    /// so `inout` matches `\b(inout|out)\b` and is consumed before this pass
+    /// can mistakenly slice off its `in` prefix. The lookahead `[,)]` keeps
+    /// the regex out of vertex-shader top-level `in vec3 a_Position;`
+    /// declarations and struct field lines that end in `;`.
+    private static func stripInParameterQualifier(_ source: String) -> String {
+        let pattern = #"\bin\s+([A-Za-z_][A-Za-z0-9_]*(?:\d+x\d+)?)\s+([A-Za-z_][A-Za-z0-9_]*)(?=\s*[,)])"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return source
+        }
+        let range = NSRange(source.startIndex..., in: source)
+        return regex.stringByReplacingMatches(
+            in: source,
+            range: range,
+            withTemplate: "$1 $2"
         )
     }
 

--- a/LiveWallpaperTests/WPEShaderTranspilerTests.swift
+++ b/LiveWallpaperTests/WPEShaderTranspilerTests.swift
@@ -222,4 +222,76 @@ struct WPEShaderTranspilerTests {
             )
         }
     }
+
+    @Test("Strips GLSL 'in' parameter qualifiers so MSL accepts helper signatures")
+    func stripsInParameterQualifier() throws {
+        // Mirrors the failing shape from `effects/blendgradient` (workshop
+        // 3479521040): every helper signature uses `in T name` and Metal
+        // rejects the declaration with `unknown type name 'in'`. Once the
+        // qualifier is stripped, the helper compiles and the downstream
+        // `result = B;`, `min(A, B)`, etc. body references resolve.
+        let source = """
+        #version 410 core
+        uniform sampler2D g_Texture0;
+        in vec2 v_TexCoord;
+        float3 ApplyBlending(const int blendMode, in float3 A, in float3 B, in float opacity) {
+            float3 result = B;
+            if (blendMode == 1) { result = A; }
+            return mix(A, result, opacity);
+        }
+        void main() {
+            vec4 c = texture(g_Texture0, v_TexCoord);
+            gl_FragColor = vec4(ApplyBlending(0, c.rgb, c.rgb, 1.0), 1.0);
+        }
+        """
+        let result = try WPEShaderTranspiler.translateFragment(
+            shaderName: "blend-in-quals",
+            preprocessedSource: source
+        )
+        // Stripping the qualifier means MSL sees `float3 A` etc., not
+        // `in float3 A`. The whole-string check is enough — we don't need
+        // to enumerate every helper.
+        #expect(!result.mslSource.contains("in float3 A"))
+        #expect(!result.mslSource.contains("in float3 B"))
+        #expect(!result.mslSource.contains("in float opacity"))
+        #expect(result.mslSource.contains("float3 A"))
+        // Existing `inout/out` rewrite is untouched — the new pass must not
+        // double-strip a parameter that the prior rule already rewrote.
+        #expect(!result.mslSource.contains("thread in"))
+
+        // Confirm Metal accepts the translated MSL end-to-end.
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let opts = MTLCompileOptions()
+        opts.languageVersion = .version3_0
+        _ = try device.makeLibrary(source: result.mslSource, options: opts)
+    }
+
+    @Test("In-qualifier strip leaves top-level vertex inputs untouched")
+    func inQualifierIgnoresTopLevelInputs() throws {
+        // Top-level `in vec2 v_TexCoord;` must survive — the transpiler
+        // lifts those into the stage_in struct downstream. Only parameter
+        // lists (lookahead `[,)]`) are targeted.
+        let source = """
+        #version 410 core
+        uniform sampler2D g_Texture0;
+        in vec2 v_TexCoord;
+        in vec3 v_Normal;
+        void main() {
+            gl_FragColor = texture(g_Texture0, v_TexCoord) * vec4(v_Normal, 1.0);
+        }
+        """
+        let result = try WPEShaderTranspiler.translateFragment(
+            shaderName: "in-top-level",
+            preprocessedSource: source
+        )
+        // The varyings should appear in the WPEStageIn struct, not as
+        // leftover `in vec2 v_TexCoord;` lines.
+        #expect(result.mslSource.contains("WPEStageIn"))
+        #expect(!result.mslSource.contains("in vec2 v_TexCoord;"))
+
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let opts = MTLCompileOptions()
+        opts.languageVersion = .version3_0
+        _ = try device.makeLibrary(source: result.mslSource, options: opts)
+    }
 }


### PR DESCRIPTION
## Summary

\`effects/blendgradient\` (workshop 3479521040) and ≥8 other corpus scenes
declare helper functions like:

\`\`\`glsl
float3 ApplyBlending(const int blendMode, in float3 A, in float3 B, in float opacity)
\`\`\`

MSL has no \`in\` keyword — it's the implicit default for parameters — so the
Metal compiler rejected the declaration with \`unknown type name 'in'\`. That
cascaded into 25+ \"undeclared identifier\" errors for \`A\`, \`B\`, \`result\`,
\`opacity\` because the function body never made it past the broken signature.

## Fix

Adds a one-pass \`stripInParameterQualifier\` after the existing
\`inout/out\` rewrite. Running the \`inout\` rule first means it consumes its
\`in\` prefix as part of the longer match, so the new pass can safely target
the bare \`in T name\` pattern without double-stripping. Lookahead \`[,)]\`
keeps the regex out of top-level \`in vec3 a_Position;\` declarations the
transpiler lifts into the stage_in struct downstream.

## Test plan

- [x] New unit tests in \`WPEShaderTranspilerTests\` cover the
  \`ApplyBlending\`-style signature with three \`in\` parameters, verify the
  qualifier is gone in MSL, and end-to-end compile via \`MTLDevice\`.
- [x] Second test confirms top-level \`in vec2 v_TexCoord;\` survives — those
  flow into the stage_in struct and must not be mistakenly stripped.
- [x] Full \`LiveWallpaperTests\` suite passes (649 tests / 106 suites).
- [ ] Phase A.3 corpus run after merge — expect 25 helper-signature errors
  to clear; downstream \"undeclared identifier\" cascade should resolve too,
  so total scene yield is ≥9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)