### PR TITLE
fix(wpe): move linearSampler to file scope so helpers can use it

### DIFF
--- a/LiveWallpaper/Runtime/WPEShaderTranspiler.swift
+++ b/LiveWallpaper/Runtime/WPEShaderTranspiler.swift
@@ -517,6 +517,19 @@ struct WPEShaderTranspiler {
             out.append("")
         }
 
+        // Shared sampler at file scope so helper functions (declared above
+        // `main()`) can use it without each helper needing the sampler as
+        // an explicit parameter. WPE shaders routinely sample inside their
+        // helpers — `getNoise(float t) { return g_Texture1.sample(linearSampler, …); }`
+        // — and the previous local declaration left every such helper with
+        // `unknown identifier 'linearSampler'`. MSL allows `constexpr sampler`
+        // at file scope, so this is the cheapest fix that unblocks the
+        // sampler half of the helper-scope problem. Helper-scope `g_TextureN`
+        // still fails until SPIRV-Cross lands (file-scope textures are not
+        // legal in MSL).
+        out.append("constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);")
+        out.append("")
+
         // Helpers (transpiled).
         if !helpers.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             out.append(helpers)
@@ -536,7 +549,6 @@ struct WPEShaderTranspiler {
         }
         signature.append(") {")
         out.append(signature.joined(separator: "\n"))
-        out.append("    constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);")
 
         // For each sampler in the original source, alias the declared
         // name (e.g. `g_Texture0`) to the corresponding `texN` parameter

--- a/LiveWallpaperTests/WPEShaderTranspilerTests.swift
+++ b/LiveWallpaperTests/WPEShaderTranspilerTests.swift
@@ -340,4 +340,47 @@ struct WPEShaderTranspilerTests {
         opts.languageVersion = .version3_0
         _ = try device.makeLibrary(source: result.mslSource, options: opts)
     }
+
+    @Test("linearSampler is declared at file scope so helpers can use it")
+    func linearSamplerAtFileScope() throws {
+        // Workshop shaders (e.g. `effects/lens_flare_sun`) sample inside
+        // helper functions: `float getNoise(float t) { return g_Texture1.sample(linearSampler, …); }`.
+        // With the sampler declared only inside main() the helper saw
+        // `unknown identifier 'linearSampler'`. Moving the declaration to
+        // file scope makes it visible everywhere.
+        //
+        // NOTE: Helper-scope `g_TextureN` is still broken (Metal forbids
+        // file-scope textures; needs SPIRV-Cross or param-passing rewrite).
+        // This test only verifies the sampler half of the helper-scope fix.
+        let source = """
+        #version 410 core
+        in vec2 v_TexCoord;
+        // Helper using only the sampler (texture passed as arg externally).
+        float computeAngle(float2 uv) {
+            return uv.x + uv.y;
+        }
+        void main() {
+            gl_FragColor = vec4(computeAngle(v_TexCoord), 0.0, 0.0, 1.0);
+        }
+        """
+        let result = try WPEShaderTranspiler.translateFragment(
+            shaderName: "filescope_sampler",
+            preprocessedSource: source
+        )
+        // The declaration must appear BEFORE the helper definition so
+        // identifier resolution sees it from the helper scope.
+        let mslSource = result.mslSource
+        let samplerRange = try #require(mslSource.range(of: "constexpr sampler linearSampler"))
+        let helperRange = try #require(mslSource.range(of: "float computeAngle("))
+        #expect(samplerRange.lowerBound < helperRange.lowerBound, "linearSampler must precede the helper")
+        // Belt: the declaration should not also appear inside main (no duplicate).
+        let mainStart = try #require(mslSource.range(of: "wpe_translated_fragment"))
+        let mainBodyRest = mslSource[mainStart.upperBound...]
+        #expect(!mainBodyRest.contains("constexpr sampler linearSampler"), "no duplicate declaration inside main()")
+
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let opts = MTLCompileOptions()
+        opts.languageVersion = .version3_0
+        _ = try device.makeLibrary(source: mslSource, options: opts)
+    }
 }


### PR DESCRIPTION
## Summary

Workshop shaders place sampler-using helpers above \`main()\`:

\`\`\`glsl
float getNoise(float t) {
    return g_Texture1.sample(linearSampler, ...).r;
}
\`\`\`

With \`constexpr sampler linearSampler\` declared only inside \`main()\` (the
prior layout), every such helper hit \`unknown identifier 'linearSampler'\`
at parse time. MSL allows \`constexpr sampler\` at file scope, so move the
declaration above the helpers — it's now visible everywhere, no
duplicates.

## Known limitation

This is the **sampler half** of the helper-scope problem.

Helper-scope \`g_TextureN\` is still broken: Metal forbids file-scope
texture references, so the only real fixes are:
1. Pass each used texture as an extra function parameter, OR
2. Move helpers inside \`main()\` so they capture local aliases.

Both are architectural work tracked under the SPIRV-Cross integration plan
([PR #68](https://github.com/Paradox07127/LiveWallpaper/pull/68)).

## Test plan

- [x] New unit test verifies the declaration precedes helper definitions
  and is not duplicated inside \`main()\`.
- [x] End-to-end compile via \`MTLDevice.makeLibrary\` confirms Metal
  accepts the new layout.
- [x] Full \`LiveWallpaperTests\` suite passes (649 tests / 106 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)