### PR TITLE
wpe: prefer SPIRV-Cross compiler when toolchain is available

### DIFF
--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -50,7 +50,21 @@ final class WPEMetalRenderExecutor {
         // Phase 2D-H: default to the Swift transpiler, falling back to the
         // stub if a caller wants to opt out (tests). Production now goes
         // through the real translator path.
-        self.shaderCompiler = shaderCompiler ?? WPESwiftShaderCompiler(device: device)
+        //
+        // Phase 2b seam: when the vendored glslang+SPIRV-Cross XCFramework
+        // is linked (see `WPESPIRVShaderCompiler.isToolchainAvailable()`),
+        // prefer it and use the Swift transpiler as a fall-through. Builds
+        // without the framework keep the existing behaviour because the
+        // toolchain check returns false statically — no runtime cost.
+        self.shaderCompiler = shaderCompiler ?? Self.preferredCompiler(device: device)
+    }
+
+    private static func preferredCompiler(device: MTLDevice) -> any WPEShaderCompiling {
+        let swiftTranspiler = WPESwiftShaderCompiler(device: device)
+        if WPESPIRVShaderCompiler.isToolchainAvailable() {
+            return WPESPIRVShaderCompiler(device: device, fallback: swiftTranspiler)
+        }
+        return swiftTranspiler
     }
 
     /// Phase 2E: lets `WPEMetalSceneRenderer` hand the executor's MTLDevice


### PR DESCRIPTION
## Summary

Phase 2b seam swap. The renderer init now checks
\`WPESPIRVShaderCompiler.isToolchainAvailable()\` and picks the
SPIRV-Cross-backed compiler when the \`WPEShaderToolchain\` XCFramework is
linked, falling through to the existing \`WPESwiftShaderCompiler\` when not.

## Behavioural impact

**Zero runtime change** on the current build. The toolchain is not vendored
yet (PR #73 stages it but the binary isn't produced), so
\`canImport(WPEShaderToolchain)\` returns false at compile time and the
seam picks the Swift transpiler — same as today.

Once PR #73's scaffolding lands AND a developer runs
\`scripts/build_spirv_cross_xcframework.sh\` to vendor the actual
XCFramework AND adds it to the Xcode project's Frameworks phase, this seam
automatically prefers the SPIRV-Cross path. No further code change at the
call site.

## Dependency

Base branch is **#73** (claude/wpe-spirv-cross-phase-2a-scaffolding), not
main, because the change references \`WPESPIRVShaderCompiler\` which lives
on that branch. Either merge #73 first or rebase this branch onto main
after #73 lands.

## Test plan

- [x] \`xcodebuild build\` clean.
- [x] Full \`LiveWallpaperTests\` suite passes (649 tests / 106 suites).
- [ ] Re-verify after PR #73 merges and the XCFramework is vendored:
  toolchain check should flip to true, executor should pick SPIRV-Cross.

🤖 Generated with [Claude Code](https://claude.com/claude-code)