### PR TITLE
wpe: prefer SPIRV-Cross compiler when toolchain is available (v2, rebased)

### DIFF
--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -50,7 +50,21 @@ final class WPEMetalRenderExecutor {
         // Phase 2D-H: default to the Swift transpiler, falling back to the
         // stub if a caller wants to opt out (tests). Production now goes
         // through the real translator path.
-        self.shaderCompiler = shaderCompiler ?? WPESwiftShaderCompiler(device: device)
+        //
+        // Phase 2b seam: when the vendored glslang+SPIRV-Cross XCFramework
+        // is linked (see `WPESPIRVShaderCompiler.isToolchainAvailable()`),
+        // prefer it and use the Swift transpiler as a fall-through. Builds
+        // without the framework keep the existing behaviour because the
+        // toolchain check returns false statically — no runtime cost.
+        self.shaderCompiler = shaderCompiler ?? Self.preferredCompiler(device: device)
+    }
+
+    private static func preferredCompiler(device: MTLDevice) -> any WPEShaderCompiling {
+        let swiftTranspiler = WPESwiftShaderCompiler(device: device)
+        if WPESPIRVShaderCompiler.isToolchainAvailable() {
+            return WPESPIRVShaderCompiler(device: device, fallback: swiftTranspiler)
+        }
+        return swiftTranspiler
     }
 
     /// Phase 2E: lets `WPEMetalSceneRenderer` hand the executor's MTLDevice


### PR DESCRIPTION
## Summary

Rebased version of [PR #74](https://github.com/Paradox07127/LiveWallpaper/pull/74) onto the now-complete
[PR #73](https://github.com/Paradox07127/LiveWallpaper/pull/73) (which includes the vendored XCFramework,
pbxproj link, bridge config, wrapper fallback chaining, and integration smoke tests).

Phase 2b seam swap. The renderer init now checks
\`WPESPIRVShaderCompiler.isToolchainAvailable()\` and picks the
SPIRV-Cross-backed compiler when the WPEShaderToolchain XCFramework is
linked. With PR #73 merged, this seam now actively prefers SPIRV-Cross
at runtime.

Tested end-to-end via WPESPIRVIntegrationSmokeTests (in PR #73):
- Toolchain reports available ✓
- Helper-scope \`texture(g_Texture0, uv)\` shader compiles cleanly via the
  new path ✓ (the very pattern that ~8 corpus scenes hit and the Swift
  transpiler cannot handle)

Old PR #74 should be closed in favour of this one. The history has been
linearised onto the latest #73 state so reviewing as a single chain is
clean.

## Dependency

Base = claude/wpe-spirv-cross-phase-2a-scaffolding (PR #73). Merge #73
first, then this rebases cleanly onto main.

## Test plan

- [x] \`xcodebuild build\` clean.
- [x] Full LiveWallpaperTests suite passes (651 tests, 107 suites).
- [x] Integration smoke tests prove SPIRV-Cross handles helper-scope textures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)