### PR TITLE
wpe: prefer SPIRV-Cross compiler when toolchain is available

### DIFF
--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -50,7 +50,21 @@ final class WPEMetalRenderExecutor {
         // Phase 2D-H: default to the Swift transpiler, falling back to the
         // stub if a caller wants to opt out (tests). Production now goes
         // through the real translator path.
-        self.shaderCompiler = shaderCompiler ?? WPESwiftShaderCompiler(device: device)
+        //
+        // Phase 2b seam: when the vendored glslang+SPIRV-Cross XCFramework
+        // is linked (see `WPESPIRVShaderCompiler.isToolchainAvailable()`),
+        // prefer it and use the Swift transpiler as a fall-through. Builds
+        // without the framework keep the existing behaviour because the
+        // toolchain check returns false statically — no runtime cost.
+        self.shaderCompiler = shaderCompiler ?? Self.preferredCompiler(device: device)
+    }
+
+    private static func preferredCompiler(device: MTLDevice) -> any WPEShaderCompiling {
+        let swiftTranspiler = WPESwiftShaderCompiler(device: device)
+        if WPESPIRVShaderCompiler.isToolchainAvailable() {
+            return WPESPIRVShaderCompiler(device: device, fallback: swiftTranspiler)
+        }
+        return swiftTranspiler
     }
 
     /// Phase 2E: lets `WPEMetalSceneRenderer` hand the executor's MTLDevice


### PR DESCRIPTION
## Summary

**This is the actual seam swap that activates SPIRV-Cross at runtime.**

[PR #76](https://github.com/Paradox07127/LiveWallpaper/pull/76) was auto-marked
MERGED by GitHub when its base branch (#73) got deleted — but the seam-swap
commit itself never landed on main. The XCFramework is linked, the wrapper is
in tree, but \`WPEMetalRenderExecutor.init\` still constructs the Swift
transpiler unconditionally.

That's why the latest corpus run still shows 20/57: SPIRV-Cross is loaded
into the process but not actually called.

## The change

One file, ~15 lines. Adds \`preferredCompiler(device:)\` that picks
\`WPESPIRVShaderCompiler\` when \`isToolchainAvailable()\` returns true,
falls through to \`WPESwiftShaderCompiler\` otherwise. Since the wrapper
itself falls through to the Swift transpiler on any toolchain failure,
this is purely additive — no shader that compiles today will regress.

## Expected corpus delta

Helper-scope texture failures should drop. The standalone CLI verification
in PR #73 proved SPIRV-Cross handles the pattern; the integration smoke
tests in main confirm \`isToolchainAvailable()\` returns true and an
end-to-end shader compile succeeds.

## Test plan

- [x] \`xcodebuild build\` clean
- [x] Full test suite passes
- [ ] Re-run corpus harness from dev menu after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)