### PR TITLE
fix(html): force WKWebView rebuild after revoking origin trust

### DIFF
--- a/LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift
@@ -167,7 +167,10 @@ struct HTMLSourceSection: View {
                     .font(.caption)
                     .lineLimit(2)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Button("Revoke") { trustStore.revoke(origin) }
+                Button("Revoke") {
+                    _ = trustStore.revoke(origin)
+                    screenManager.setHTMLWallpaper(source: source, config: config, forceReload: true, for: screen)
+                }
                     .buttonStyle(.bordered)
                     .controlSize(.mini)
                     .help(Text("Remove \(origin.displayName) from trusted origins"))

--- a/LiveWallpaperTests/ScreenManagerCoordinationTests.swift
+++ b/LiveWallpaperTests/ScreenManagerCoordinationTests.swift
@@ -609,6 +609,31 @@ struct ScreenManagerCoordinationTests {
         }
     }
 
+    @Test("Revoking the current trusted HTML origin forces the live page to rebuild")
+    func revokingCurrentTrustedHTMLOriginForcesRebuild() async throws {
+        let originURL = try #require(URL(string: "https://html-revoke-\(UUID().uuidString).example.com/live"))
+        let source = HTMLSource.url(originURL)
+        let origin = try #require(TrustedHTMLOrigin(url: originURL))
+        var config = HTMLConfig.default
+        config.allowJavaScript = true
+
+        #expect(TrustedHostStore.shared.trust(origin))
+        defer { _ = TrustedHostStore.shared.revoke(origin) }
+
+        try await Self.runWithHTMLConfiguration(source: source, config: config) { manager, screen in
+            let session = TestRuntimeSession(wallpaperType: .html)
+            screen.installRuntimeSession(session)
+
+            #expect(TrustedHostStore.shared.revoke(origin))
+            manager.setHTMLWallpaper(source: source, config: config, forceReload: true, for: screen)
+            await Self.drainMainQueue()
+
+            #expect(session.cleanupCount == 1)
+            #expect(!Self.isSameSession(screen.runtimeSession, session))
+            #expect(manager.getConfiguration(for: screen)?.wallpaperType == .html)
+        }
+    }
+
     @Test("Changing HTML JavaScript permission rebuilds the page")
     func updateHTMLConfigJavaScriptToggleRebuildsSession() async throws {
         try await Self.runWithHTMLConfiguration { manager, screen in


### PR DESCRIPTION
## Summary

- Revoke button in the HTML trust banner only updated `TrustedHostStore` — the running `WKWebView` kept executing JavaScript with the now-revoked origin until the next source/config change. Mirror the Grant path by calling `setHTMLWallpaper(…, forceReload: true, …)` so the session tears down and rebuilds against the fresh trust state.
- Adds regression test `revokingCurrentTrustedHTMLOriginForcesRebuild` next to the existing `trustingCurrentRemoteHTMLOriginForcesRebuild`, asserting that a revoke triggers `cleanupCount == 1` + new session identity (i.e. the WKWebView is destroyed and rebuilt).

## Why

Until the next source or config edit, an already-granted page kept its old privileges after the user clicked Revoke. The grant path at [HTMLSourceSection.swift:195-198](LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift) already does the right thing — revoke was the asymmetric hole.

## Scope

- `LiveWallpaper/Views/ScreenDetail/HTMLSourceSection.swift` — only the Revoke button action body (grant path untouched, trust UI unchanged).
- `LiveWallpaperTests/ScreenManagerCoordinationTests.swift` — one new `@Test` symmetric to the existing grant-rebuild test. Placed here (rather than `HTMLTrustTests.swift` / `HTMLSourceMultiplicityTests.swift`, which are pure-unit suites) because the rebuild assertion needs the full coordinator wiring already present in this file.

## Test plan

- [x] `xcodebuild test -only-testing:LiveWallpaperTests/ScreenManagerCoordinationTests` — 35 tests pass, including the new `revokingCurrentTrustedHTMLOriginForcesRebuild` and sibling grant rebuild test.
- [x] `xcodebuild test -only-testing:LiveWallpaperTests` — passes except for a pre-existing `LocalizationCoverageTests.stringCatalogsDoNotKeepStaleEntries` failure (stale entries like "Privacy Policy", "Report a bug", "Show welcome tour") unrelated to this diff.
- [x] `xcodebuild -scheme LiveWallpaperLite build` — green.
- [ ] Manual verify on real macOS: trust a remote HTML origin running JS, click Revoke, confirm WKWebView reloads and JS no longer executes without changing source/config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)