### PR TITLE
refactor(schedule): drop dead scheduledBookmark helper

### DIFF
--- a/LiveWallpaper/Policies/SchedulePolicy.swift
+++ b/LiveWallpaper/Policies/SchedulePolicy.swift
@@ -39,17 +39,6 @@ enum SchedulePolicy {
         return .none
     }
 
-    /// Legacy helper kept for backward compatibility.
-    static func scheduledBookmark(
-        in configuration: ScreenConfiguration,
-        hour: Int
-    ) -> (slot: ScheduleSlot, bookmarkData: Data)? {
-        guard case .applySlot(let slot, let bookmarkData) = decision(for: configuration, hour: hour) else {
-            return nil
-        }
-        return (slot, bookmarkData)
-    }
-
     // MARK: - Conflict Detection
 
     /// IDs of slots overlapping the given slot (excluding itself).

--- a/LiveWallpaperTests/WallpaperArchitectureTests.swift
+++ b/LiveWallpaperTests/WallpaperArchitectureTests.swift
@@ -1203,19 +1203,17 @@ struct SchedulePolicyTests {
     func schedulePolicyReturnsBookmark() {
         let current = Data([0x01])
         let scheduled = Data([0x02])
+        let slot = ScheduleSlot(startHour: 6, endHour: 12, videoBookmarkData: scheduled, label: "Morning")
         var configuration = ScreenConfiguration(
             screenID: 41,
             videoBookmarkData: current,
-            scheduleSlots: [
-                ScheduleSlot(startHour: 6, endHour: 12, videoBookmarkData: scheduled, label: "Morning")
-            ]
+            scheduleSlots: [slot]
         )
         configuration.wallpaperMode = .schedule
 
-        let result = SchedulePolicy.scheduledBookmark(in: configuration, hour: 8)
+        let result = SchedulePolicy.decision(for: configuration, hour: 8)
 
-        #expect(result?.slot.label == "Morning")
-        #expect(result?.bookmarkData == scheduled)
+        #expect(result == .applySlot(slot: slot, bookmarkData: scheduled))
     }
 
     @Test("Schedule policy skips already active bookmark")
@@ -1230,9 +1228,9 @@ struct SchedulePolicyTests {
         )
         configuration.wallpaperMode = .schedule
 
-        let result = SchedulePolicy.scheduledBookmark(in: configuration, hour: 8)
+        let result = SchedulePolicy.decision(for: configuration, hour: 8)
 
-        #expect(result == nil)
+        #expect(result == .none)
     }
 
     @Test("Schedule policy applies a primary slot when current wallpaper is not video")


### PR DESCRIPTION
## Summary

- `SchedulePolicy.scheduledBookmark(in:hour:)` was a "Legacy helper kept for backward compatibility" with no production callers — only two tests still exercised it.
- Delete the helper from [`LiveWallpaper/Policies/SchedulePolicy.swift`](LiveWallpaper/Policies/SchedulePolicy.swift) and migrate `schedulePolicyReturnsBookmark` / `schedulePolicySkipsAlreadyActiveBookmark` to assert directly against `SchedulePolicy.decision(for:hour:)`, matching against `.applySlot(slot:bookmarkData:)` / `.none`.
- The first test now pulls the `ScheduleSlot` into a local so the `.applySlot` equality check can compare against the same `UUID`-bearing value (same pattern as the existing `schedulePolicyAppliesPrimarySlotOverHTML` test).

## Why

`decision(for:hour:)` already covers the same behavior with a richer enum; the wrapper just adapted the new result back to the old tuple shape for tests that predated the API change. Keeping it around obscures the actual contract.

## Test plan

- [x] `xcodebuild -scheme LiveWallpaper test -only-testing:LiveWallpaperTests` — 684/684 pass, including the two migrated cases.
- [x] `xcodebuild -scheme LiveWallpaperLite build` — succeeds.
- [x] `grep -r SchedulePolicy.scheduledBookmark` — no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)