### PR TITLE
WPE Workshop + Weather UI: #36-42 batch (responsive cards, retry badge, a11y) + sanitize hardening

### DIFF
--- a/LiveWallpaper/Diagnostics/BugReporter.swift
+++ b/LiveWallpaper/Diagnostics/BugReporter.swift
@@ -197,6 +197,26 @@ enum BugReporter {
             with: "file://<redacted>",
             options: .regularExpression
         )
+        // Defense-in-depth for Weather (and any future) errors that bring
+        // precise location coordinates or auth fragments through as plain
+        // localizedDescription text rather than a full URL. The query-string
+        // scrub above catches "https://api?latitude=…", but `error` strings
+        // can be re-thrown without the host, e.g. "URL Error -1009: lat=37.7…".
+        result = result.replacingOccurrences(
+            of: #"(?i)\b(lat(?:itude)?|lon(?:gitude)?)\s*[=:]\s*-?\d{1,3}(?:\.\d+)?"#,
+            with: "$1=<redacted>",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"(?i)\b(token|api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password)\s*[=:]\s*([^&\s'"]+)"#,
+            with: "$1=<redacted>",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"(?i)\b(Bearer|Token)\s+[A-Za-z0-9._~+/=-]+"#,
+            with: "$1 <redacted>",
+            options: .regularExpression
+        )
         return result
     }
 

--- a/LiveWallpaper/Resources/Localizable.xcstrings
+++ b/LiveWallpaper/Resources/Localizable.xcstrings
@@ -18201,6 +18201,35 @@
         }
       }
     },
+    "Preview unavailable. Tap to retry." : {
+      "comment" : "Tooltip on the WPE preview retry badge that surfaces when the preview image failed to load.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preview unavailable. Tap to retry."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビューを読み込めませんでした。タップして再試行。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预览不可用，点按重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽不可用，點按重試。"
+          }
+        }
+      }
+    },
     "Preview Unavailable" : {
       "comment" : "Scene pause reason.",
       "localizations" : {
@@ -28067,6 +28096,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "天氣"
+          }
+        }
+      }
+    },
+    "Weather fetch error (paths and tokens scrubbed)" : {
+      "comment" : "Tooltip on the weather badge's sanitized error caption. Hovering the truncated error line surfaces this hint that PII has been redacted before display.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weather fetch error (paths and tokens scrubbed)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天気の取得エラー（パスとトークンを除去済み）"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天气获取错误（路径和令牌已脱敏）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天氣取得錯誤（路徑與權杖已遮蔽）"
           }
         }
       }

--- a/LiveWallpaper/Views/ScreenDetail/WPEHistoryRow.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEHistoryRow.swift
@@ -2,8 +2,9 @@
 import SwiftUI
 import AppKit
 
-/// Single recent-import card in the Scene tab grid. 160×240pt,
-/// glass-effect background, hover lift, context menu for Finder/remove.
+/// Single recent-import card in the Scene tab grid. Adaptive width
+/// (160-240pt) × height (240-320pt) per `wpeProjectCardChrome`, glass-effect
+/// background, hover lift, context menu for Finder/remove.
 struct WPEHistoryRow: View {
     let entry: WPEHistoryEntry
     let isActive: Bool
@@ -11,6 +12,7 @@ struct WPEHistoryRow: View {
     let onRemove: () -> Void
 
     @State private var isHovering = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Button(action: onTap) {
@@ -19,7 +21,6 @@ struct WPEHistoryRow: View {
                     imageURL: previewURL,
                     securityScopedBookmarkData: entry.origin.sourceFolderBookmark
                 )
-                    .wpeCardPreviewClip()
                     .overlay(alignment: .topTrailing) {
                         if let badge = compatibilityBadge {
                             Text(badge.titleKey)
@@ -33,9 +34,11 @@ struct WPEHistoryRow: View {
                         }
                     }
 
+                Divider()
+
                 VStack(alignment: .leading, spacing: 8) {
                     Text(verbatim: entry.origin.title)
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.system(size: 13, weight: .semibold))
                         .lineLimit(2)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -67,9 +70,12 @@ struct WPEHistoryRow: View {
             }
         }
         .buttonStyle(.plain)
-        .wpeProjectCardChrome(isHovering: isHovering)
+        .wpeProjectCardChrome(isHovering: isHovering, reduceMotion: reduceMotion)
         .onHover { isHovering = $0 }
-        .accessibilityLabel(Text("Wallpaper Engine project: \(entry.origin.title)"))
+        .accessibilityLabel(Text(
+            "Wallpaper Engine project: \(entry.origin.title)",
+            comment: "A11y label for a WPE history row card. The placeholder is the WPE project title."
+        ))
         .accessibilityHint(isActive
             ? Text("Currently in use. Tap to reactivate.", comment: "A11y hint for a WPE history row that is the active wallpaper.")
             : Text("Tap to apply", comment: "A11y hint for a WPE history row that can be applied."))

--- a/LiveWallpaper/Views/ScreenDetail/WPEOriginBadge.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEOriginBadge.swift
@@ -13,7 +13,10 @@ struct WPEOriginBadge: View {
             HStack(spacing: 8) {
                 Image(systemName: "cube.transparent")
                     .foregroundStyle(.orange)
-                Text("Wallpaper Engine: \(origin.title)")
+                Text(
+                    "Wallpaper Engine: \(origin.title)",
+                    comment: "Origin badge label on top of the Video/HTML inspector. The placeholder is the WPE workshop project title."
+                )
                     .lineLimit(1)
                     .truncationMode(.middle)
                 Image(systemName: "chevron.right")
@@ -26,7 +29,10 @@ struct WPEOriginBadge: View {
             .adaptiveGlassSurface(.capsule, interactive: true)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(Text("Wallpaper from Wallpaper Engine: \(origin.title)"))
+        .accessibilityLabel(Text(
+            "Wallpaper from Wallpaper Engine: \(origin.title)",
+            comment: "A11y label for the WPE origin badge. The placeholder is the workshop project title."
+        ))
         .accessibilityHint(Text("Tap to manage in the Scene tab"))
     }
 }

--- a/LiveWallpaper/Views/ScreenDetail/WPEPreviewView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEPreviewView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import AppKit
 import ImageIO
 
-/// 16:9 preview tile for a Wallpaper Engine project.
+/// Square (1:1) preview tile for a Wallpaper Engine project.
 ///
 /// Renders into a CALayer with `contentsGravity = .resizeAspectFill` so
 /// previews of any source aspect (square — WPE editor's 512×512 default,
@@ -39,40 +39,61 @@ struct WPEPreviewView: View {
                     }
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-                if loadFailed {
-                    retryOverlay
-                }
             }
         }
         .aspectRatio(1, contentMode: .fit)
         .clipped()
+        .overlay(alignment: .bottomTrailing) {
+            if loadFailed {
+                retryBadge
+                    .padding(6)
+            }
+        }
         .onChange(of: imageURL) { _, _ in
             loadFailed = false
         }
     }
 
+    /// Non-blocking corner chip so the failed-load state is visible without
+    /// hiding whatever fragment of the preview did manage to render. Modeled
+    /// as a tap-gesture'd view (not a `Button`) because the parent grid cell
+    /// is itself a `Button` and AppKit-bridged buttons nested inside another
+    /// SwiftUI button race for hit-tests + confuse VoiceOver focus.
     @ViewBuilder
-    private var retryOverlay: some View {
-        VStack(spacing: 6) {
+    private var retryBadge: some View {
+        HStack(spacing: 4) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 18, weight: .medium))
                 .foregroundStyle(.orange)
-            Text("Preview unavailable")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Button {
-                loadFailed = false
-                loadAttempt &+= 1
-            } label: {
-                Label("Retry", systemImage: "arrow.clockwise")
-            }
-            .adaptiveGlassButton(.regular)
-            .controlSize(.small)
-            .accessibilityHint(Text("Re-attempt to load this preview"))
+            Image(systemName: "arrow.clockwise")
         }
-        .padding(12)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .font(.system(size: 10, weight: .semibold))
+        .padding(.horizontal, 7)
+        .padding(.vertical, 4)
+        .adaptiveGlassSurface(.capsule, interactive: true)
+        .contentShape(Capsule())
+        .onTapGesture {
+            retryLoad()
+        }
+        .help(Text(
+            "Preview unavailable. Tap to retry.",
+            comment: "Tooltip on the WPE preview retry badge that surfaces when the preview image failed to load."
+        ))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(
+            "Retry preview",
+            comment: "A11y label for the corner badge that retries a failed preview load."
+        ))
+        .accessibilityHint(Text(
+            "Re-attempt to load this preview",
+            comment: "A11y hint describing what the retry preview badge does."
+        ))
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { retryLoad() }
+    }
+
+    private func retryLoad() {
+        loadFailed = false
+        loadAttempt &+= 1
     }
 }
 

--- a/LiveWallpaper/Views/ScreenDetail/WPEProjectCardChrome.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEProjectCardChrome.swift
@@ -2,37 +2,39 @@
 import SwiftUI
 
 extension View {
-    func wpeCardPreviewClip(cornerRadius: CGFloat = 16) -> some View {
-        clipShape(
-            UnevenRoundedRectangle(
-                topLeadingRadius: cornerRadius,
-                bottomLeadingRadius: 0,
-                bottomTrailingRadius: 0,
-                topTrailingRadius: cornerRadius,
-                style: .continuous
-            )
-        )
-    }
-
-    func wpeProjectCardChrome(isHovering: Bool) -> some View {
-        modifier(WPEProjectCardChrome(isHovering: isHovering))
+    func wpeProjectCardChrome(isHovering: Bool, reduceMotion: Bool = false) -> some View {
+        modifier(WPEProjectCardChrome(isHovering: isHovering, reduceMotion: reduceMotion))
     }
 }
 
 private struct WPEProjectCardChrome: ViewModifier {
     let isHovering: Bool
+    let reduceMotion: Bool
+
+    private static let cornerRadius: CGFloat = 16
 
     func body(content: Content) -> some View {
         content
-            .frame(width: 160, height: 240)
-            .adaptiveGlassSurface(.roundedRectangle(16), interactive: true)
-            .scaleEffect(isHovering ? 1.02 : 1.0)
+            .frame(
+                minWidth: 160,
+                idealWidth: 188,
+                maxWidth: 240,
+                minHeight: 240,
+                idealHeight: 268,
+                maxHeight: 320
+            )
+            .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous))
+            .adaptiveGlassSurface(.roundedRectangle(Self.cornerRadius), interactive: true)
+            .scaleEffect(reduceMotion ? 1.0 : (isHovering ? 1.02 : 1.0))
             .shadow(
                 color: Color.black.opacity(isHovering ? 0.18 : 0.06),
                 radius: isHovering ? 8 : 4,
                 y: isHovering ? 4 : 2
             )
-            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: isHovering)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.8),
+                value: isHovering
+            )
     }
 }
 #endif

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct WPESceneSection: View {
     let screen: Screen
     @Environment(ScreenManager.self) private var screenManager
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var recentImports: [WPEHistoryEntry] = []
     @State private var selectedHistoryEntry: WPEHistoryEntry?
@@ -25,7 +26,7 @@ struct WPESceneSection: View {
                 historyList
             }
         }
-        .animation(.default, value: recentImports.isEmpty)
+        .animation(reduceMotion ? nil : .default, value: recentImports.isEmpty)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
             Task { @MainActor in reloadHistory() }
@@ -124,7 +125,7 @@ struct WPESceneSection: View {
                 }
 
                 LazyVGrid(
-                    columns: Array(repeating: GridItem(.fixed(160), spacing: 16), count: 4),
+                    columns: [GridItem(.adaptive(minimum: 160, maximum: 220), spacing: 16)],
                     alignment: .leading,
                     spacing: 16
                 ) {

--- a/LiveWallpaper/Views/ScreenDetail/WeatherStatusBadge.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WeatherStatusBadge.swift
@@ -42,10 +42,14 @@ struct WeatherStatusBadge: View {
                 }
 
                 if let error = weatherService.lastError {
-                    Text(verbatim: error)
+                    Text(verbatim: BugReporter.sanitize(error))
                         .font(.caption2)
                         .foregroundStyle(.red)
                         .lineLimit(1)
+                        .help(Text(
+                            "Weather fetch error (paths and tokens scrubbed)",
+                            comment: "Tooltip on the weather badge's sanitized error caption. Hovering surfaces this hint that PII has been redacted."
+                        ))
                 }
             }
             .accessibilityElement(children: .combine)
@@ -62,12 +66,21 @@ struct WeatherStatusBadge: View {
 
             if needsLocationSettingsLink {
                 Button(action: openLocationSettings) {
-                    Text("Open Settings")
+                    Text(
+                        "Open Settings",
+                        comment: "Weather badge button label that jumps to System Settings → Location Services."
+                    )
                         .font(.caption.weight(.semibold))
                 }
                 .buttonStyle(GlassCapsuleButtonStyle(fontSize: 10, horizontalPadding: 7, verticalPadding: 3))
-                .help(Text("Open System Settings → Privacy & Security → Location Services"))
-                .accessibilityLabel(Text("Open Location Services settings"))
+                .help(Text(
+                    "Open System Settings → Privacy & Security → Location Services",
+                    comment: "Tooltip for the Open Settings button on the weather badge."
+                ))
+                .accessibilityLabel(Text(
+                    "Open Location Services settings",
+                    comment: "A11y label for the weather badge Open Settings button."
+                ))
             }
 
             Button(action: refresh) {
@@ -75,8 +88,14 @@ struct WeatherStatusBadge: View {
                     .font(.caption.weight(.semibold))
             }
             .buttonStyle(.plain)
-            .help(Text("Refresh weather now"))
-            .accessibilityLabel(Text("Refresh weather"))
+            .help(Text(
+                "Refresh weather now",
+                comment: "Tooltip on the weather badge refresh icon."
+            ))
+            .accessibilityLabel(Text(
+                "Refresh weather",
+                comment: "A11y label for the weather badge refresh icon."
+            ))
         }
         .padding(.vertical, 4)
         .dynamicTypeSize(...DynamicTypeSize.accessibility3)
@@ -93,8 +112,9 @@ struct WeatherStatusBadge: View {
         case .available: return "cloud.sun.fill"
         case .fetching: return "arrow.triangle.2.circlepath"
         case .denied: return "location.slash"
+        case .notDetermined: return "location.circle"
         case .error: return "exclamationmark.triangle"
-        default: return "cloud.fill"
+        case .authorized: return "cloud.fill"
         }
     }
 
@@ -103,8 +123,9 @@ struct WeatherStatusBadge: View {
         case .available: return .cyan
         case .fetching: return .orange
         case .denied: return .red
+        case .notDetermined: return .orange
         case .error: return .red
-        default: return .secondary
+        case .authorized: return .secondary
         }
     }
 

--- a/LiveWallpaper/Views/ScreenDetail/WorkshopGalleryView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WorkshopGalleryView.swift
@@ -333,7 +333,7 @@ struct WorkshopGalleryView: View {
                         noFilteredResultsView
                     } else {
                         LazyVGrid(
-                            columns: [GridItem(.adaptive(minimum: 160, maximum: 160), spacing: 16)],
+                            columns: [GridItem(.adaptive(minimum: 160, maximum: 220), spacing: 16)],
                             alignment: .leading,
                             spacing: 16
                         ) {
@@ -940,6 +940,7 @@ private struct WorkshopGalleryCard: View {
     let onToggleBookmark: () -> Void
 
     @State private var isHovering = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         VStack(spacing: 0) {
@@ -947,11 +948,12 @@ private struct WorkshopGalleryCard: View {
                 imageURL: project.previewURL,
                 securityScopedBookmarkData: project.libraryRootBookmarkData
             )
-                .wpeCardPreviewClip()
                 .overlay(alignment: .topTrailing) {
                     typeBadge
                         .padding(8)
                 }
+
+            Divider()
 
             VStack(alignment: .leading, spacing: 8) {
                 Text(verbatim: project.title)
@@ -965,7 +967,7 @@ private struct WorkshopGalleryCard: View {
             .padding(12)
             .frame(maxHeight: .infinity, alignment: .top)
         }
-        .wpeProjectCardChrome(isHovering: isHovering)
+        .wpeProjectCardChrome(isHovering: isHovering, reduceMotion: reduceMotion)
         .onHover { isHovering = $0 }
     }
 


### PR DESCRIPTION
## Summary

Lands the **non-refactor** half of the UI-review report at `docs/ui-review/reviews/16-35-42-WPE-Weather.md` for the WPE Workshop + Weather surfaces (items **#36, #37, #38, #39, #40, #41, #42**). The two larger pieces — `#16` (`WorkshopGalleryView` 1159-line viewModel split) and `#35` (`WPESceneDetailView` 0.4s `Timer.publish` → `@Observable` subscription) — are intentionally deferred to dedicated follow-up PRs.

## What changed

### Cards & layout (#39 / #41)
- **WPEProjectCardChrome**: fixed 160×240pt → responsive 160-240pt × 240-320pt; single outer `.clipShape(RoundedRectangle(16))` + `.adaptiveGlassSurface(.roundedRectangle(16))`. `scaleEffect` + `animation` gated on `accessibilityReduceMotion`.
- **WPEHistoryRow** + **WorkshopGalleryCard**: drop top-only `UnevenRoundedRectangle` preview clip; metadata sits below a `Divider` inside the chrome's unified clip. Title weight harmonised at `.semibold` between the two card types.
- **WPESceneSection** + **WorkshopGalleryView** `LazyVGrid`: `.fixed(160)` / `.adaptive(160,160)` → `.adaptive(160,220)` so 4K/3K windows scale without stretching cards into banners.
- Dead-code: the `wpeCardPreviewClip` extension is fully removed (no remaining callers in repo).

### Retry badge (#38)
- **WPEPreviewView**: full-cover retry overlay → bottom-trailing corner badge.
- Uses `.onTapGesture` + `.accessibilityAction { retry }` rather than a nested `Button` — the previous nested-Button shape hit-tested against the parent `WPEHistoryRow` card Button and confused VoiceOver activation.
- Backing surface uses `.adaptiveGlassSurface(.capsule, interactive: true)` per the wrapper-only Liquid Glass rule (CLAUDE.md §9).

### Reduce-motion (#36)
- **WPESceneSection**: `.animation(.default, value: recentImports.isEmpty)` gated on `accessibilityReduceMotion`.
- Animation gating propagates into `wpeProjectCardChrome` via an explicit `reduceMotion: Bool` argument.

### Localization (#40 / #37)
- **WPEOriginBadge**: `Text(_, comment:)` on the visible label + a11y label — the existing `"Wallpaper Engine: %@"` / `"Wallpaper from Wallpaper Engine: %@"` catalog entries (already translated EN/JA/zh-Hans/zh-Hant) become discoverable to translators.
- **WPEFallbackCard** audit confirmed clean: all 10+ `FallbackReason` cases already route through `String(localized:)`.
- Several `Text` / `.help` / `.accessibilityLabel` instances on Weather + WPEHistoryRow + WPEPreviewView gain `comment:` translator hints.
- Two new keys added with EN/JA/zh-Hans/zh-Hant: `"Preview unavailable. Tap to retry."` and `"Weather fetch error (paths and tokens scrubbed)"`.

### Weather badge (#42)
- `WeatherStatusBadge`: raw `lastError` → `Text(verbatim: BugReporter.sanitize(error))` so error `localizedDescription` strings can't leak file paths or query strings.
- `.notDetermined` now gets `location.circle` + orange to disambiguate from `.denied` (`location.slash` + red) and `.error` (`exclamationmark.triangle` + red). Previously-default `.authorized` made explicit.

### BugReporter hardening (cross-cutting, separate commit)
The `BugReporter.sanitize(_:)` helper now also redacts:
- Bare coordinates: `lat(itude)?` / `lon(gitude)?` `=` *or* `:` `<value>` — so a re-thrown `URLError` with `"lat=37.7…"` no longer reveals location even when no full URL is attached.
- `token` / `api[_-]?key` / `access[_-]?token` / `refresh[_-]?token` / `secret` / `password` with `=` *or* `:` separator.
- `Bearer <token>` / `Token <token>` Authorization-header echoes.

This is defense-in-depth — same helper feeds both the bug-report sheet and (newly) the WeatherStatusBadge error caption, so credential / coordinate leakage on either path is now handled by a single regex set.

## Why this shape

- Two commits intentionally: the UI batch is a localised change; the `BugReporter.sanitize` regex is a cross-cutting Diagnostics change. Separating them keeps the latter easy to cherry-pick or revert without disturbing the visual work.
- The multi-model audit (codex + antigravity, two passes each) flagged the nested-Button anti-pattern on the retry chip and the missing VoiceOver activation path. Both are addressed; the chip is now keyboard- and VoiceOver-reachable without bubbling into the parent card.
- `#16` and `#35` are large enough to warrant their own PRs (viewModel extraction + Observation/Combine migration respectively). Skipping them keeps this PR reviewable.

## Test plan

- [x] `xcodebuild -scheme LiveWallpaper -configuration Debug build` — succeeds.
- [x] `xcodebuild -scheme LiveWallpaperLite -configuration Debug build` (separate DerivedData) — succeeds.
- [x] `LiveWallpaperTests/LocalizationCoverageTests` (4/4) — pass.
- [x] `LiveWallpaperTests/MacOSCompatibilityPolicyTests` (2/2: macOS-14 target + Liquid Glass APIs stay inside `AdaptiveGlass`) — pass.
- [ ] Manual: open the Scene tab on a 4K display, confirm Workshop / History cards scale up to ~220pt wide without stretching; tap the retry chip while a preview is intentionally broken; confirm VoiceOver announces "Retry preview, button" and the activation action fires without selecting the parent card.
- [ ] Manual: trigger a weather fetch failure with a malformed URL or coordinate stub in the log to confirm sanitize regex masks `lat=` / `token=` / `Bearer …` patterns.
- [ ] Manual: System Settings → Accessibility → Display → Reduce Motion ON — confirm hover lift no longer scales and history grid does not animate the empty → grid transition.

## Follow-ups (separate PRs)

- **#16**: split `WorkshopGalleryView` 1159 lines → `WorkshopGalleryDraftState` viewModel + `GalleryHeader` / `ProjectGrid` / `StateOverlays` subviews.
- **#35**: replace `Timer.publish(every: 0.4)` polling in `WPESceneDetailView` with an `@Observable SceneRenderState` subscription.
- **codex Info (deferred)**: visually verify on real macOS 14 / 15 VM that the unified outer card clip does not mask the focus ring when the `WPEHistoryRow` Button gains keyboard focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)