### PR TITLE
feat(workshop): filter taxonomy, prev/next pager, inspector close, badges + bold hero

### DIFF
--- a/LiveWallpaper/Infrastructure/Workshop/WorkshopAnimatedGIF.swift
+++ b/LiveWallpaper/Infrastructure/Workshop/WorkshopAnimatedGIF.swift
@@ -35,11 +35,15 @@ struct WorkshopAnimatedGIF: @unchecked Sendable {
 
     private let source: CGImageSource
 
-    /// Reject inputs whose raw bytes exceed the loader's transfer cap.
-    static let maxBytes = 8 * 1024 * 1024
-    /// Reject animations with more frames than this.
+    /// Reject inputs whose raw bytes exceed the loader's transfer cap. Kept in
+    /// sync with `WorkshopPreviewImageLoader.maxBytes` — Workshop animated GIF
+    /// previews routinely run 8–24 MiB, so an 8 MiB cap silently blanked them.
+    static let maxBytes = 32 * 1024 * 1024
+    /// Animate at most this many frames; longer animations degrade to a static
+    /// poster (we never drop the preview entirely just because it's long).
     static let maxFrameCount = 120
-    /// Total decoded-pixel budget (RGBA bytes) across all frames.
+    /// Total decoded-pixel budget (RGBA bytes) across all frames before an
+    /// animation degrades to its static poster.
     static let maxDecodedPixelBytes = 96 * 1024 * 1024
     /// 30 FPS playback cap to bound CPU on long-running grids.
     static let minFrameDelay: TimeInterval = 0.033
@@ -64,16 +68,22 @@ extension WorkshopAnimatedGIF {
         let count = CGImageSourceGetCount(source)
         // Read dimensions from metadata (no full decode) and reject before
         // materializing the poster — guards against decompression bombs where
-        // a small compressed file expands to gigabytes of pixels.
+        // a small compressed file expands to gigabytes of pixels. The bomb
+        // guard is applied to the SINGLE poster frame so a high-res still is
+        // never rejected for its frame count.
         guard count > 0,
-              count <= maxFrameCount,
               let dimensions = imageDimensions(from: source, index: 0),
-              isWithinPixelBudget(width: dimensions.width, height: dimensions.height, frameCount: count),
+              isWithinPixelBudget(width: dimensions.width, height: dimensions.height, frameCount: 1),
               let poster = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
             return nil
         }
 
-        if count == 1 {
+        // Animate only within the frame-count + total decoded-pixel budgets;
+        // otherwise degrade to the static poster rather than showing nothing.
+        // (A long or large animated preview previously returned nil → blank.)
+        guard count > 1,
+              count <= maxFrameCount,
+              isWithinPixelBudget(width: dimensions.width, height: dimensions.height, frameCount: count) else {
             return .staticImage(poster)
         }
 

--- a/LiveWallpaper/Infrastructure/Workshop/WorkshopPreviewImageLoader.swift
+++ b/LiveWallpaper/Infrastructure/Workshop/WorkshopPreviewImageLoader.swift
@@ -12,7 +12,10 @@ final class WorkshopPreviewImageLoader {
 
     static let shared = WorkshopPreviewImageLoader()
 
-    nonisolated static let maxBytes = 8 * 1024 * 1024
+    // Kept in sync with `WorkshopAnimatedGIF.maxBytes`. Workshop animated GIF
+    // previews routinely exceed 8 MiB; an 8 MiB transfer cap aborted them
+    // mid-stream and the card fell back to a blank placeholder.
+    nonisolated static let maxBytes = 32 * 1024 * 1024
 
     private var cache: [URL: NSImage] = [:]
     private var assetCache: [URL: WorkshopPreviewAsset] = [:]

--- a/LiveWallpaper/Infrastructure/Workshop/WorkshopQueryService.swift
+++ b/LiveWallpaper/Infrastructure/Workshop/WorkshopQueryService.swift
@@ -69,7 +69,7 @@ struct WorkshopQueryRequest: Equatable, Hashable, Sendable {
         self.cursor = cursor.isEmpty ? "*" : cursor
         self.numPerPage = min(max(numPerPage, 1), 100)
         self.language = Self.canonicalLanguage(language)
-        self.days = effectiveSort.requiresDays ? 7 : days.flatMap { $0 > 0 ? $0 : nil }
+        self.days = effectiveSort.requiresDays ? Self.canonicalTrendingDays(days) : days.flatMap { $0 > 0 ? $0 : nil }
         self.requiredTags = Self.canonicalTags(requiredTags)
         self.excludedTags = Self.canonicalTags(excludedTags)
         self.returnPreviews = returnPreviews
@@ -85,11 +85,26 @@ struct WorkshopQueryRequest: Equatable, Hashable, Sendable {
         return trimmed.lowercased(with: Locale(identifier: "en_US_POSIX"))
     }
 
+    /// Steam matches `requiredtags`/`excludedtags` against the item's EXACT
+    /// display-name tags (e.g. `Scene`, `Anime`, `3840 x 2160`, `Dual 3840 x 1080`).
+    /// Lower-casing them — as this used to — made every tag filter silently
+    /// match nothing. So we only trim, de-duplicate, and sort (sorting just keeps
+    /// the cache key stable; tag order is irrelevant to Steam).
     private static func canonicalTags(_ tags: [String]) -> [String] {
-        tags
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(with: Locale(identifier: "en_US_POSIX")) }
-            .filter { !$0.isEmpty }
+        var seen = Set<String>()
+        return tags
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
             .sorted()
+    }
+
+    /// Trending (`query_type=3`) requires a `days` window. Clamp the caller's
+    /// requested period to the values Steam's Workshop browse exposes (week /
+    /// month / quarter / half-year / year), defaulting to a week.
+    private static func canonicalTrendingDays(_ days: Int?) -> Int {
+        let allowed: Set<Int> = [1, 7, 30, 90, 180, 365]
+        guard let days, allowed.contains(days) else { return 7 }
+        return days
     }
 }
 

--- a/LiveWallpaper/Views/ScreenDetail/WPEHistoryRow.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPEHistoryRow.swift
@@ -208,6 +208,10 @@ struct WPEHistoryRow: View {
 
     // MARK: - Inline apply control (Installed library)
 
+    /// Prominent blue Apply control. Only rendered when `allowsInlineApply` is
+    /// set (the Installed library) — the Scene tab leaves it off, so this is
+    /// unchanged there. The native `.borderedProminent` style replaces the old
+    /// glass capsule, whose hover effect fought the card's own hover lift.
     @ViewBuilder
     private var applyControl: some View {
         if screens.count > 1 {
@@ -220,16 +224,22 @@ struct WPEHistoryRow: View {
             } label: {
                 applyLabel
             }
-            .menuStyle(.borderlessButton)
+            .menuStyle(.button)
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
             .menuIndicator(.hidden)
+            .tint(.blue)
             .help(Text("Apply"))
         } else if let only = screens.first {
             Button { onApply(only) } label: { applyLabel }
-                .buttonStyle(GlassCapsuleButtonStyle(fontSize: 11, horizontalPadding: 9, verticalPadding: 5))
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .tint(.blue)
                 .help(Text("Apply"))
         } else {
             Button {} label: { applyLabel }
-                .buttonStyle(GlassCapsuleButtonStyle(tint: .secondary, fontSize: 11, horizontalPadding: 9, verticalPadding: 5))
+                .buttonStyle(.bordered)
+                .controlSize(.small)
                 .disabled(true)
                 .help(Text("Open a display first, then apply"))
         }

--- a/LiveWallpaper/Views/Workshop/WorkshopBrowseCard.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopBrowseCard.swift
@@ -74,7 +74,24 @@ struct WorkshopBrowseCard: View {
                     .padding(DesignTokens.Spacing.sm)
             }
         }
+        .overlay(alignment: .bottomTrailing) {
+            if let resolutionLabel {
+                resolutionPill(resolutionLabel)
+                    .padding(DesignTokens.Spacing.sm)
+            }
+        }
         .aspectRatio(1, contentMode: .fit)
+    }
+
+    private func resolutionPill(_ label: String) -> some View {
+        Text(verbatim: label)
+            .font(.system(size: 9, weight: .bold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            // Same dark scrim as the rating pill — legible over any thumbnail.
+            .background(.black.opacity(0.7), in: Capsule())
+            .accessibilityHidden(true)
     }
 
     private var inLibraryBadge: some View {
@@ -204,15 +221,67 @@ struct WorkshopBrowseCard: View {
         return nil
     }
 
+    /// Subscriber count moved to the detail inspector (issue #4) — the card's
+    /// trailing slot now carries only the download size, with the resolution
+    /// surfaced as a thumbnail badge instead.
     private var metaTrailing: String {
-        var parts: [String] = []
-        if let subs = item.subscriptionCount, subs > 0 {
-            parts.append(String(localized: "\(formatSubs(subs)) subs", comment: "Workshop card subscriber count. Placeholder is an abbreviated number such as 1.2K."))
+        formattedSize ?? ""
+    }
+
+    /// Short resolution label derived from the item's resolution tag (e.g.
+    /// "1080p", "4K", "Ultrawide" → "UW", "Portrait"). Nil when no resolution
+    /// tag is present.
+    private var resolutionLabel: String? {
+        Self.resolutionShortLabel(for: item.tags)
+    }
+
+    static func resolutionShortLabel(for tags: [String]) -> String? {
+        for tag in tags {
+            if let mapped = knownResolutionLabels[tag] { return mapped }
         }
-        if let size = formattedSize {
-            parts.append(size)
+        for tag in tags {
+            if let derived = deriveResolutionLabel(from: tag) { return derived }
         }
-        return parts.joined(separator: " · ")
+        return nil
+    }
+
+    private static let knownResolutionLabels: [String: String] = [
+        "Standard Definition": "SD",
+        "1280 x 720": "720p",
+        "1920 x 1080": "1080p",
+        "2560 x 1440": "1440p",
+        "3840 x 2160": "4K",
+        "2560 x 1080": "UW",
+        "3440 x 1440": "UW",
+        "Dual 3840 x 1080": "Dual",
+        "5120 x 1440": "Dual",
+        "7680 x 2160": "Dual",
+        "1080 x 1920": "Portrait",
+        "720 x 1280": "Portrait",
+        "1440 x 2560": "Portrait",
+        "2160 x 3840": "Portrait"
+    ]
+
+    /// Derive a label from any embedded "W x H" tag (covers prefixes like
+    /// "Dual 3840 x 1080"). Ratio buckets ultrawide/dual; height buckets the
+    /// landscape resolutions.
+    private static func deriveResolutionLabel(from tag: String) -> String? {
+        guard tag.range(of: #"\d+\s*[xX×]\s*\d+"#, options: .regularExpression) != nil else { return nil }
+        let nums = tag.split(whereSeparator: { !$0.isNumber }).compactMap { Int($0) }
+        guard nums.count >= 2 else { return nil }
+        let width = nums[nums.count - 2], height = nums[nums.count - 1]
+        guard width > 0, height > 0 else { return nil }
+        if height > width { return "Portrait" }
+        let ratio = Double(width) / Double(height)
+        if ratio >= 3.0 { return "Dual" }
+        if ratio >= 2.0 { return "UW" }
+        switch height {
+        case 2160...: return "4K"
+        case 1440..<2160: return "1440p"
+        case 1080..<1440: return "1080p"
+        case 720..<1080: return "720p"
+        default: return "SD"
+        }
     }
 
     private var formattedSize: String? {
@@ -246,6 +315,9 @@ struct WorkshopBrowseCard: View {
         }
         if let type = contentType {
             parts.append(type.displayName)
+        }
+        if let resolutionLabel {
+            parts.append(resolutionLabel)
         }
         if let subs = item.subscriptionCount, subs > 0 {
             parts.append(String(localized: "\(formatSubs(subs)) subscribers", comment: "Workshop card VoiceOver subscriber count."))

--- a/LiveWallpaper/Views/Workshop/WorkshopBrowseFilterRibbon.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopBrowseFilterRibbon.swift
@@ -93,9 +93,30 @@ struct WorkshopBrowseFilterRibbon: View {
         HStack(spacing: DesignTokens.Spacing.sm) {
             typeChips
             sortMenu
+            if viewModel.preferredSort == .trending {
+                trendingPeriodMenu
+            }
             filtersButton(includesPrimary: false)
         }
         .fixedSize(horizontal: true, vertical: false)
+    }
+
+    /// Trending (`query_type=3`) needs a time window — surface week / month /
+    /// year next to the sort control whenever Trending is the active sort.
+    private var trendingPeriodMenu: some View {
+        Picker("Period", selection: Binding(
+            get: { viewModel.trendingDays },
+            set: { viewModel.updateTrendingDays($0) }
+        )) {
+            ForEach(Self.trendingPeriods, id: \.days) { period in
+                Text(period.title).tag(period.days)
+            }
+        }
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .fixedSize()
+        .disabled(controlsDisabled)
+        .help(Text("Trending period"))
     }
 
     /// Narrow layout: a single Filters popover that holds everything (Type,
@@ -165,59 +186,122 @@ struct WorkshopBrowseFilterRibbon: View {
     }
 
     private func filtersPopover(includesPrimary: Bool) -> some View {
-        VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
-            if includesPrimary {
-                filterGroup("Type") {
-                    // Horizontal scroll guards against clipping when localized
-                    // type names widen past the fixed popover width.
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 6) {
-                            ForEach(WorkshopContentTypeFilter.allCases) { type in
-                                FilterChip(
-                                    title: Text(type.displayName),
-                                    isSelected: viewModel.typeFilter == type
-                                ) {
-                                    viewModel.updateType(type)
+        ScrollView {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
+                if includesPrimary {
+                    filterGroup("Type") {
+                        // Horizontal scroll guards against clipping when localized
+                        // type names widen past the fixed popover width.
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 6) {
+                                ForEach(WorkshopContentTypeFilter.allCases) { type in
+                                    FilterChip(
+                                        title: Text(type.displayName),
+                                        isSelected: viewModel.typeFilter == type
+                                    ) {
+                                        viewModel.updateType(type)
+                                    }
                                 }
                             }
                         }
                     }
+                    filterGroup("Sort") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Picker("Sort", selection: Binding(
+                                get: { viewModel.preferredSort },
+                                set: { viewModel.updateSort($0) }
+                            )) {
+                                ForEach(Self.visibleSorts, id: \.self) { sort in
+                                    Text(sort.displayName).tag(sort)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .labelsHidden()
+
+                            if viewModel.preferredSort == .trending {
+                                Picker("Period", selection: Binding(
+                                    get: { viewModel.trendingDays },
+                                    set: { viewModel.updateTrendingDays($0) }
+                                )) {
+                                    ForEach(Self.trendingPeriods, id: \.days) { period in
+                                        Text(period.title).tag(period.days)
+                                    }
+                                }
+                                .pickerStyle(.segmented)
+                                .labelsHidden()
+                            }
+                        }
+                    }
                 }
-                filterGroup("Sort") {
-                    Picker("Sort", selection: Binding(
-                        get: { viewModel.preferredSort },
-                        set: { viewModel.updateSort($0) }
+
+                filterGroup("Maturity") {
+                    Picker("Maturity", selection: Binding(
+                        get: { viewModel.ageRating },
+                        set: { viewModel.updateAgeRating($0) }
                     )) {
-                        ForEach(Self.visibleSorts, id: \.self) { sort in
-                            Text(sort.displayName).tag(sort)
+                        ForEach(WorkshopAgeRatingFilter.allCases) { rating in
+                            Text(rating.displayName).tag(rating)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .help(Text("Maximum maturity to show — hides ratings above the chosen level."))
+                }
+
+                filterGroup("Resolution") {
+                    Picker("Resolution", selection: Binding(
+                        get: { viewModel.resolution },
+                        set: { viewModel.updateResolution($0) }
+                    )) {
+                        ForEach(WorkshopResolutionFilter.allCases) { resolution in
+                            Text(resolution.displayName).tag(resolution)
                         }
                     }
                     .pickerStyle(.menu)
                     .labelsHidden()
                 }
-            }
 
-            filterGroup("Maturity") {
-                Picker("Maturity", selection: Binding(
-                    get: { viewModel.ageRating },
-                    set: { viewModel.updateAgeRating($0) }
-                )) {
-                    ForEach(WorkshopAgeRatingFilter.allCases) { rating in
-                        Text(rating.displayName).tag(rating)
-                    }
+                filterGroup("Genre") {
+                    genreCheckboxGrid
                 }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-            }
 
-            if activeFilterCount > 0 {
-                Button("Clear filters") { clearFilters() }
-                    .buttonStyle(.borderless)
-                    .controlSize(.small)
+                if activeFilterCount > 0 {
+                    Button("Clear filters") { clearFilters() }
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                }
+            }
+            .padding(DesignTokens.Spacing.md)
+        }
+        .frame(width: 300)
+        .frame(maxHeight: 430)
+    }
+
+    /// Two-column checkbox grid of the official genre tags. Selecting several
+    /// ANDs them (Steam-native). Toggles route through the view-model's
+    /// debounced reload, so ticking three genres issues a single query.
+    private var genreCheckboxGrid: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(), alignment: .leading),
+                GridItem(.flexible(), alignment: .leading)
+            ],
+            alignment: .leading,
+            spacing: 4
+        ) {
+            ForEach(WorkshopGenre.allTags, id: \.self) { tag in
+                Toggle(isOn: Binding(
+                    get: { viewModel.selectedGenres.contains(tag) },
+                    set: { _ in viewModel.toggleGenre(tag) }
+                )) {
+                    Text(tag)
+                        .font(.system(size: 11))
+                        .lineLimit(1)
+                }
+                .toggleStyle(.checkbox)
+                .controlSize(.small)
             }
         }
-        .padding(DesignTokens.Spacing.md)
-        .frame(width: 240)
     }
 
     private func filterGroup<Content: View>(
@@ -325,14 +409,26 @@ struct WorkshopBrowseFilterRibbon: View {
         var count = 0
         if viewModel.typeFilter != .all { count += 1 }
         if viewModel.ageRating != .everyone { count += 1 }
+        if viewModel.resolution != .any { count += 1 }
+        count += viewModel.selectedGenres.count
         return count
     }
 
     private func clearFilters() {
+        // Each call schedules the same debounced reload, so they coalesce into
+        // a single query rather than firing one per cleared filter.
         if viewModel.typeFilter != .all { viewModel.updateType(.all) }
         if viewModel.ageRating != .everyone { viewModel.updateAgeRating(.everyone) }
+        if viewModel.resolution != .any { viewModel.updateResolution(.any) }
+        if !viewModel.selectedGenres.isEmpty { viewModel.clearGenres() }
     }
 
     private static let visibleSorts: [WorkshopSortMode] = [.topRated, .newest, .trending, .mostSubscribed]
+
+    private static let trendingPeriods: [(title: LocalizedStringKey, days: Int)] = [
+        ("Week", 7),
+        ("Month", 30),
+        ("Year", 365)
+    ]
 }
 #endif

--- a/LiveWallpaper/Views/Workshop/WorkshopBrowsePane.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopBrowsePane.swift
@@ -19,6 +19,9 @@ struct WorkshopBrowsePane: View {
 
     private let ticker = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
+    /// Stable scroll anchor pinned at the top of the grid (for page steps).
+    private static let gridTopAnchor = "workshop.browse.grid.top"
+
     // Square tiles sized to the ~192px source thumbnails — large enough to read
     // the preview crisply without upscaling into blur, so the window width alone
     // drives how many fit per row (no manual density control).
@@ -65,8 +68,8 @@ struct WorkshopBrowsePane: View {
         .onChange(of: viewModel.isLoading) { _, loading in
             if loading { WorkshopRequestCounter.increment() }
         }
-        .onChange(of: viewModel.isLoadingMore) { _, loading in
-            if loading { WorkshopRequestCounter.increment() }
+        .onChange(of: viewModel.isPaging) { _, paging in
+            if paging { WorkshopRequestCounter.increment() }
         }
         .inspector(isPresented: Binding(
             get: { selectedItem != nil },
@@ -74,7 +77,9 @@ struct WorkshopBrowsePane: View {
         )) {
             Group {
                 if let selectedItem {
-                    WorkshopInspectorContent(item: selectedItem, doctor: doctor)
+                    WorkshopInspectorContent(item: selectedItem, doctor: doctor) {
+                        self.selectedItem = nil
+                    }
                 } else {
                     inspectorPlaceholder
                 }
@@ -99,35 +104,86 @@ struct WorkshopBrowsePane: View {
     }
 
     private var populatedGrid: some View {
-        ScrollView {
-            LazyVGrid(columns: gridColumns, spacing: DesignTokens.Spacing.lg) {
-                ForEach(viewModel.items) { item in
-                    WorkshopBrowseCard(
-                        item: item,
-                        isInLibrary: installedWorkshopIDs.contains(String(item.id))
-                    ) { selectedItem = item }
+        ScrollViewReader { proxy in
+            ScrollView {
+                // Top anchor so a page step returns the user to item 1.
+                Color.clear.frame(height: 0).id(Self.gridTopAnchor)
+
+                LazyVGrid(columns: gridColumns, spacing: DesignTokens.Spacing.lg) {
+                    ForEach(viewModel.items) { item in
+                        WorkshopBrowseCard(
+                            item: item,
+                            isInLibrary: installedWorkshopIDs.contains(String(item.id))
+                        ) { selectedItem = item }
+                        .id(item.id)
+                    }
+                }
+                .padding(.horizontal, DesignTokens.Settings.formHorizontalMargin)
+                .padding(.vertical, DesignTokens.Settings.formVerticalMargin)
+
+                paginationBar
+            }
+            // Opening the inspector narrows the grid and reflows the rows, which
+            // can push the selected tile off-screen — re-center it so it stays
+            // visible next to the detail panel. The brief delay lets the
+            // inspector's width animation settle before we measure.
+            .onChange(of: selectedItem?.id) { _, id in
+                guard let id else { return }
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 60_000_000)
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        proxy.scrollTo(id, anchor: .center)
+                    }
                 }
             }
-            .padding(.horizontal, DesignTokens.Settings.formHorizontalMargin)
-            .padding(.vertical, DesignTokens.Settings.formVerticalMargin)
+            .onChange(of: viewModel.pageIndex) { _, _ in
+                proxy.scrollTo(Self.gridTopAnchor, anchor: .top)
+            }
+        }
+    }
 
-            if viewModel.nextCursor != nil, viewModel.nextCursor != "*" {
+    /// Cursor-based prev/next pager. Steam's QueryFiles cursor only walks
+    /// forward (no jump-to-page-N), so we step the cursor stack; each page
+    /// replaces the previous results, keeping memory flat.
+    @ViewBuilder
+    private var paginationBar: some View {
+        if viewModel.pageIndex > 1 || viewModel.canGoNextPage {
+            HStack(spacing: DesignTokens.Spacing.md) {
                 Button {
-                    Task { await viewModel.loadMore() }
+                    Task { await viewModel.goToPrevPage() }
                 } label: {
-                    if viewModel.isLoadingMore {
-                        HStack(spacing: 6) {
-                            ProgressView().controlSize(.small)
-                            Text("Loading…")
-                        }
-                    } else {
-                        Text("Load more")
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text("Previous")
                     }
                 }
                 .buttonStyle(.bordered)
-                .disabled(viewModel.isLoadingMore || viewModel.isRateLimited)
-                .padding(.bottom, DesignTokens.Spacing.xl)
+                .controlSize(.small)
+                .disabled(!viewModel.canGoPrevPage)
+
+                if viewModel.isPaging {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text("Page \(viewModel.pageIndex)")
+                        .font(.system(size: 12, weight: .medium))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+
+                Button {
+                    Task { await viewModel.goToNextPage() }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text("Next")
+                        Image(systemName: "chevron.right")
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(!viewModel.canGoNextPage)
             }
+            .padding(.vertical, DesignTokens.Spacing.lg)
+            .frame(maxWidth: .infinity)
         }
     }
 

--- a/LiveWallpaper/Views/Workshop/WorkshopBrowseViewModel.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopBrowseViewModel.swift
@@ -30,23 +30,86 @@ enum WorkshopContentTypeFilter: String, CaseIterable, Identifiable {
     }
 }
 
-/// Maturity filter. `.everyone` excludes Mature-tagged items (the default);
-/// `.mature` applies no exclusion.
+/// Maturity threshold — Wallpaper Engine tags items with one of three age
+/// ratings. This is a ceiling, expressed via `excludedTags` so it works whether
+/// or not "Everyone" is a literal tag: each tier hides the ratings above it.
 enum WorkshopAgeRatingFilter: String, CaseIterable, Identifiable {
     case everyone
+    case questionable
     case mature
 
     var id: String { rawValue }
 
     var displayName: String {
         switch self {
-        case .everyone: return String(localized: "Everyone", comment: "Workshop maturity filter: hide mature content.")
-        case .mature: return String(localized: "Mature", comment: "Workshop maturity filter: include mature content.")
+        case .everyone: return String(localized: "Everyone", comment: "Workshop maturity filter: hide questionable + mature content.")
+        case .questionable: return String(localized: "Questionable", comment: "Workshop maturity filter: allow questionable, hide mature.")
+        case .mature: return String(localized: "Mature", comment: "Workshop maturity filter: include all content.")
         }
     }
 
+    /// Hide every rating stricter than the chosen ceiling.
     var excludedTags: [String] {
-        self == .everyone ? ["Mature"] : []
+        switch self {
+        case .everyone: return ["Questionable", "Mature"]
+        case .questionable: return ["Mature"]
+        case .mature: return []
+        }
+    }
+}
+
+/// Official Wallpaper Engine Workshop genre tags (exact display strings — Steam
+/// matches `requiredtags` by exact case). Selecting more than one ANDs them,
+/// mirroring Steam's own Workshop browse (an item must carry every chosen tag).
+enum WorkshopGenre {
+    static let allTags: [String] = [
+        "Abstract", "Animal", "Anime", "Cartoon", "CGI", "Cyberpunk", "Fantasy",
+        "Game", "Girls", "Guys", "Landscape", "Medieval", "Memes", "MMD", "Music",
+        "Nature", "Pixel art", "Relaxing", "Retro", "Sci-Fi", "Sports",
+        "Technology", "Television", "Vehicle", "Unspecified"
+    ]
+}
+
+/// Resolution filter. An item targets a single resolution, so this is a
+/// single-select threshold mapping to one exact Workshop resolution tag (the
+/// core buckets — multi-select would AND to nothing). `.any` applies no tag.
+enum WorkshopResolutionFilter: String, CaseIterable, Identifiable {
+    case any
+    case standardDefinition
+    case fullHD1080
+    case quadHD1440
+    case ultraHD4K
+    case ultrawide
+    case portrait
+    case dual
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .any: return String(localized: "All resolutions", comment: "Workshop resolution filter: no restriction.")
+        case .standardDefinition: return String(localized: "SD", comment: "Workshop resolution filter: standard definition.")
+        case .fullHD1080: return String(localized: "1080p", comment: "Workshop resolution filter.")
+        case .quadHD1440: return String(localized: "1440p", comment: "Workshop resolution filter.")
+        case .ultraHD4K: return String(localized: "4K", comment: "Workshop resolution filter.")
+        case .ultrawide: return String(localized: "Ultrawide", comment: "Workshop resolution filter.")
+        case .portrait: return String(localized: "Portrait", comment: "Workshop resolution filter.")
+        case .dual: return String(localized: "Dual monitor", comment: "Workshop resolution filter.")
+        }
+    }
+
+    /// Exact Steam Workshop resolution tag, or `nil` for `.any`.
+    var tag: String? {
+        switch self {
+        case .any: return nil
+        case .standardDefinition: return "Standard Definition"
+        case .fullHD1080: return "1920 x 1080"
+        case .quadHD1440: return "2560 x 1440"
+        case .ultraHD4K: return "3840 x 2160"
+        case .ultrawide: return "3440 x 1440"
+        case .portrait: return "1080 x 1920"
+        case .dual: return "Dual 3840 x 1080"
+        }
     }
 }
 
@@ -66,22 +129,46 @@ final class WorkshopBrowseViewModel {
     var preferredSort: WorkshopSortMode = .topRated
     var typeFilter: WorkshopContentTypeFilter = .all
     var ageRating: WorkshopAgeRatingFilter = .everyone
+    /// Multi-select genre tags (AND semantics, Steam-native).
+    private(set) var selectedGenres: Set<String> = []
+    var resolution: WorkshopResolutionFilter = .any
+    /// Trending window in days (week / month / year …); only used when the sort
+    /// is `.trending`.
+    private(set) var trendingDays: Int = 7
     private(set) var currentRequest: WorkshopQueryRequest
     private(set) var items: [WorkshopQueryItem] = []
     private(set) var nextCursor: String?
     private(set) var totalAvailable: Int?
     private(set) var isLoading: Bool = false
-    private(set) var isLoadingMore: Bool = false
+    /// True while stepping to an adjacent page (prev/next) — current results
+    /// stay on screen until the new page replaces them, so memory stays bounded.
+    private(set) var isPaging: Bool = false
     private(set) var lastError: WorkshopQueryError?
     /// Set when Steam returns HTTP 429; controls stay disabled until it lapses.
     private(set) var rateLimitUntil: Date?
+
+    /// 1-based page number for the prev/next pager. Steam's QueryFiles cursor
+    /// pagination only walks forward, so we keep the cursor that opened each
+    /// visited page and step the stack instead of jumping to an arbitrary page.
+    private(set) var pageIndex: Int = 1
+    @ObservationIgnored private var cursorStack: [String] = ["*"]
 
     var isRateLimited: Bool {
         (rateLimitUntil ?? .distantPast) > Date()
     }
 
+    var canGoNextPage: Bool {
+        guard !isRateLimited, !isLoading, !isPaging, let cursor = nextCursor else { return false }
+        return !cursor.isEmpty && cursor != "*"
+    }
+
+    var canGoPrevPage: Bool {
+        !isRateLimited && !isLoading && !isPaging && cursorStack.count > 1
+    }
+
     @ObservationIgnored private var debounceTask: Task<Void, Never>?
-    @ObservationIgnored private var inflightFetch: Task<Void, Never>?
+    @ObservationIgnored private var filterDebounceTask: Task<Void, Never>?
+    @ObservationIgnored private var inflightFetch: Task<Bool, Never>?
     @ObservationIgnored private var currentRequestToken: UInt64 = 0
 
     init(services: WorkshopServices) {
@@ -99,21 +186,45 @@ final class WorkshopBrowseViewModel {
         guard !isRateLimited else { return }
         inflightFetch?.cancel()
         debounceTask?.cancel()
+        filterDebounceTask?.cancel()
+        cursorStack = ["*"]
+        pageIndex = 1
         let request = makeRequest(cursor: "*")
         currentRequest = request
         items = []
         nextCursor = nil
         totalAvailable = nil
         isLoading = true
+        isPaging = false
         lastError = nil
-        await runFetch(request, append: false)
+        _ = await runFetch(request, replacingItems: true, paging: false)
     }
 
-    func loadMore() async {
-        guard !isRateLimited, !isLoading, !isLoadingMore, let cursor = nextCursor, !cursor.isEmpty, cursor != "*" else { return }
+    /// Step forward one page (cursor walk). Current results stay visible until
+    /// the new page arrives; the stack only advances on success so a failed
+    /// step leaves the pager consistent.
+    func goToNextPage() async {
+        guard canGoNextPage, let cursor = nextCursor else { return }
+        isPaging = true
         let request = makeRequest(cursor: cursor)
-        isLoadingMore = true
-        await runFetch(request, append: true)
+        let ok = await runFetch(request, replacingItems: true, paging: true)
+        if ok {
+            cursorStack.append(cursor)
+            pageIndex += 1
+        }
+    }
+
+    /// Step back to the previously visited page using its remembered cursor.
+    func goToPrevPage() async {
+        guard canGoPrevPage, cursorStack.count > 1 else { return }
+        let target = cursorStack[cursorStack.count - 2]
+        isPaging = true
+        let request = makeRequest(cursor: target)
+        let ok = await runFetch(request, replacingItems: true, paging: true)
+        if ok {
+            cursorStack.removeLast()
+            pageIndex -= 1
+        }
     }
 
     func updateSearch(_ text: String) {
@@ -133,42 +244,86 @@ final class WorkshopBrowseViewModel {
     func updateSort(_ sort: WorkshopSortMode) {
         guard !isRateLimited, sort != preferredSort else { return }
         preferredSort = sort
-        Task { await reload() }
+        scheduleFilterReload()
     }
 
     func updateType(_ type: WorkshopContentTypeFilter) {
         guard !isRateLimited, type != typeFilter else { return }
         typeFilter = type
-        Task { await reload() }
+        scheduleFilterReload()
     }
 
     func updateAgeRating(_ rating: WorkshopAgeRatingFilter) {
         guard !isRateLimited, rating != ageRating else { return }
         ageRating = rating
-        Task { await reload() }
+        scheduleFilterReload()
     }
 
-    private func runFetch(_ request: WorkshopQueryRequest, append: Bool) async {
+    func updateResolution(_ resolution: WorkshopResolutionFilter) {
+        guard !isRateLimited, resolution != self.resolution else { return }
+        self.resolution = resolution
+        scheduleFilterReload()
+    }
+
+    func updateTrendingDays(_ days: Int) {
+        guard !isRateLimited, days != trendingDays else { return }
+        trendingDays = days
+        if preferredSort == .trending { scheduleFilterReload() }
+    }
+
+    func toggleGenre(_ tag: String) {
+        guard !isRateLimited else { return }
+        if selectedGenres.contains(tag) {
+            selectedGenres.remove(tag)
+        } else {
+            selectedGenres.insert(tag)
+        }
+        scheduleFilterReload()
+    }
+
+    func clearGenres() {
+        guard !isRateLimited, !selectedGenres.isEmpty else { return }
+        selectedGenres.removeAll()
+        scheduleFilterReload()
+    }
+
+    /// Coalesce rapid multi-select toggles (and back-to-back single-select
+    /// changes) into ONE request — the key API-economy lever: checking three
+    /// genres fires a single reload, not three. The 5-minute query cache then
+    /// de-dupes any repeated combination.
+    private func scheduleFilterReload() {
+        filterDebounceTask?.cancel()
+        filterDebounceTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 450_000_000)
+            guard let self, !Task.isCancelled else { return }
+            await self.reload()
+        }
+    }
+
+    /// Runs the query; returns `true` on a successful page load. `replacingItems`
+    /// swaps the visible set (reload + pagination both replace — there is no
+    /// unbounded append), `paging` selects which loading flag to clear.
+    @discardableResult
+    private func runFetch(_ request: WorkshopQueryRequest, replacingItems: Bool, paging: Bool) async -> Bool {
         currentRequestToken &+= 1
         let token = currentRequestToken
-        let task = Task { [weak self] in
-            guard let self else { return }
+        let task = Task { [weak self] () -> Bool in
+            guard let self else { return false }
+            var succeeded = false
             do {
                 let page = try await self.services.queryService.fetch(request)
                 // Drop the result if a newer fetch has started since.
-                guard token == self.currentRequestToken else { return }
-                if append {
-                    let existingIDs = Set(self.items.map(\.id))
-                    self.items.append(contentsOf: page.items.filter { !existingIDs.contains($0.id) })
-                } else {
+                guard token == self.currentRequestToken else { return false }
+                if replacingItems {
                     self.items = page.items
                 }
                 self.nextCursor = page.nextCursor
                 self.totalAvailable = page.totalAvailable
                 self.lastError = nil
                 self.rateLimitUntil = nil
+                succeeded = true
             } catch let error as WorkshopQueryError {
-                guard token == self.currentRequestToken else { return }
+                guard token == self.currentRequestToken else { return false }
                 self.lastError = error
                 if case .rateLimited(let retryAfter) = error {
                     self.rateLimitUntil = Date().addingTimeInterval(retryAfter ?? 60)
@@ -176,28 +331,34 @@ final class WorkshopBrowseViewModel {
             } catch is CancellationError {
                 // ignore — user-triggered reload
             } catch {
-                guard token == self.currentRequestToken else { return }
+                guard token == self.currentRequestToken else { return false }
                 self.lastError = .responseParseFailure
             }
-            guard token == self.currentRequestToken else { return }
-            if append {
-                self.isLoadingMore = false
+            guard token == self.currentRequestToken else { return false }
+            if paging {
+                self.isPaging = false
             } else {
                 self.isLoading = false
             }
+            return succeeded
         }
         inflightFetch = task
-        await task.value
+        return await task.value
     }
 
     private func makeRequest(cursor: String) -> WorkshopQueryRequest {
         let trimmed = searchInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        var required = typeFilter.requiredTags + selectedGenres.sorted()
+        if let resolutionTag = resolution.tag {
+            required.append(resolutionTag)
+        }
         return WorkshopQueryRequest(
             sort: preferredSort,
             searchText: trimmed,
             cursor: cursor,
             numPerPage: 50,
-            requiredTags: typeFilter.requiredTags,
+            days: preferredSort == .trending ? trendingDays : nil,
+            requiredTags: required,
             excludedTags: ageRating.excludedTags
         )
     }

--- a/LiveWallpaper/Views/Workshop/WorkshopDetailSheet.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopDetailSheet.swift
@@ -12,6 +12,9 @@ import SwiftUI
 struct WorkshopInspectorContent: View {
     let item: WorkshopQueryItem
     let doctor: SteamCMDDoctorService
+    /// Dismisses the inspector. The native `.inspector` only auto-shows a toggle
+    /// when a toolbar hosts one, so we surface an explicit close control here.
+    var onClose: () -> Void = {}
 
     @Environment(\.openURL) private var openURL
 
@@ -29,6 +32,7 @@ struct WorkshopInspectorContent: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignTokens.Spacing.lg) {
+                closeHeader
                 hero
 
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.md) {
@@ -56,6 +60,26 @@ struct WorkshopInspectorContent: View {
             }
         }
         .background(DesignTokens.Colors.pageBackground)
+    }
+
+    // MARK: - Close
+
+    private var closeHeader: some View {
+        HStack {
+            Spacer(minLength: 0)
+            Button(action: onClose) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 16))
+                    .foregroundStyle(.secondary)
+                    .symbolRenderingMode(.hierarchical)
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .help(Text("Close"))
+            .accessibilityLabel(Text("Close details"))
+        }
+        .padding(.horizontal, DesignTokens.Spacing.lg)
+        .padding(.top, DesignTokens.Spacing.md)
     }
 
     // MARK: - Hero

--- a/LiveWallpaper/Views/Workshop/WorkshopInstalledView.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopInstalledView.swift
@@ -17,7 +17,10 @@ struct WorkshopInstalledView: View {
     @State private var bookmarkStore = BookmarkStore.shared
     @State private var entries: [WPEHistoryEntry] = []
     @State private var searchText: String = ""
-    @State private var typeFilter: WPELibraryTypeFilter = .all
+    /// Multi-select type filter — empty means "all". Client-side OR (an item
+    /// matches if its kind is among the selected set), unlike the online Browse
+    /// type chip which must single-select against Steam's AND-only tag query.
+    @State private var selectedTypes: Set<WPELibraryTypeKind> = []
     @State private var sortOrder: WPELibrarySortOrder = .recommended
     @State private var errorMessage: String?
     /// Drives the drag-to-apply screen bar — set true when a card drag starts,
@@ -66,16 +69,7 @@ struct WorkshopInstalledView: View {
                     resultCount: visibleEntries.count,
                     totalCount: entries.count
                 ) {
-                    Picker("Type", selection: $typeFilter) {
-                        ForEach(WPELibraryTypeFilter.allCases) { filter in
-                            Text(verbatim: filter.title).tag(filter)
-                        }
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.menu)
-                    .controlSize(.small)
-                    .frame(width: 118)
-                    .help(Text("Filter by project type"))
+                    typeChipRow
 
                     Picker("Sort", selection: $sortOrder) {
                         ForEach(WPELibrarySortOrder.allCases) { order in
@@ -192,7 +186,7 @@ struct WorkshopInstalledView: View {
     private var visibleEntries: [WPEHistoryEntry] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         let filtered = entries.filter { entry in
-            typeFilter.includes(entry) && matchesSearch(entry, query: query)
+            typeMatches(entry) && matchesSearch(entry, query: query)
         }
         switch sortOrder {
         case .recommended:
@@ -230,6 +224,37 @@ struct WorkshopInstalledView: View {
         case .application: return 3
         case .unknown: return 4
         }
+    }
+
+    // MARK: - Type filter chips (multi-select)
+
+    private var typeChipRow: some View {
+        HStack(spacing: 6) {
+            FilterChip(title: Text("All"), isSelected: selectedTypes.isEmpty) {
+                selectedTypes.removeAll()
+            }
+            .help(Text("Show every installed wallpaper"))
+
+            ForEach(WPELibraryTypeKind.allCases) { kind in
+                FilterChip(title: Text(verbatim: kind.title), isSelected: selectedTypes.contains(kind)) {
+                    toggleType(kind)
+                }
+                .help(kind.helpText)
+            }
+        }
+    }
+
+    private func toggleType(_ kind: WPELibraryTypeKind) {
+        if selectedTypes.contains(kind) {
+            selectedTypes.remove(kind)
+        } else {
+            selectedTypes.insert(kind)
+        }
+    }
+
+    private func typeMatches(_ entry: WPEHistoryEntry) -> Bool {
+        guard !selectedTypes.isEmpty else { return true }
+        return selectedTypes.contains { $0.matches(entry) }
     }
 
     // MARK: - Actions
@@ -484,14 +509,16 @@ struct WorkshopInstalledView: View {
 
 // MARK: - Filters
 
-private enum WPELibraryTypeFilter: String, CaseIterable, Identifiable {
-    case all, video, web, scene, unsupported
+/// Concrete library type kinds for the multi-select chip row (no `.all` case —
+/// an empty selection means "all"). `.unsupported` collects the project types
+/// macOS can't run.
+private enum WPELibraryTypeKind: String, CaseIterable, Identifiable {
+    case video, web, scene, unsupported
 
     var id: Self { self }
 
     var title: String {
         switch self {
-        case .all: return String(localized: "All", comment: "Workshop library type filter.")
         case .video: return WPEType.video.localizedDisplayName
         case .web: return WPEType.web.localizedDisplayName
         case .scene: return WPEType.scene.localizedDisplayName
@@ -499,9 +526,19 @@ private enum WPELibraryTypeFilter: String, CaseIterable, Identifiable {
         }
     }
 
-    func includes(_ entry: WPEHistoryEntry) -> Bool {
+    var helpText: Text {
         switch self {
-        case .all: return true
+        case .video: return Text("Show only video wallpapers")
+        case .web: return Text("Show only web / HTML wallpapers")
+        case .scene: return Text("Show only scene wallpapers")
+        case .unsupported:
+            // Explains issue #9's "when does unsupported appear?".
+            return Text("Windows-only items — a Windows .exe application wallpaper, or a project type macOS can't recognize. These can't run here.")
+        }
+    }
+
+    func matches(_ entry: WPEHistoryEntry) -> Bool {
+        switch self {
         case .video: return entry.origin.originalType == .video
         case .web: return entry.origin.originalType == .web
         case .scene: return entry.origin.originalType == .scene

--- a/LiveWallpaper/Views/Workshop/WorkshopPaneView.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopPaneView.swift
@@ -17,6 +17,8 @@ struct WorkshopPaneView: View {
     @State private var isShowingPasteSheet = false
     @State private var isShowingOnboarding = false
     @State private var isShowingKeyEntry = false
+    /// Installed-library size, for the header's statistics subtext.
+    @State private var installedCount = 0
 
     var body: some View {
         DetailPageScaffold(
@@ -37,6 +39,10 @@ struct WorkshopPaneView: View {
         .task {
             await doctor.autoConfirmDownloadReadinessIfNeeded()
             await folderImport.ingestSteamCMDDownloads(using: doctor)
+        }
+        .onAppear { refreshInstalledCount() }
+        .onReceive(NotificationCenter.default.publisher(for: .wpeHistoryDidChange)) { _ in
+            refreshInstalledCount()
         }
         .sheet(isPresented: $isShowingOnboarding) {
             WorkshopOnboardingSheet { isShowingPasteSheet = true }
@@ -75,25 +81,51 @@ struct WorkshopPaneView: View {
         .padding(.vertical, DesignTokens.DetailHeader.verticalPadding)
     }
 
+    // Bold title + statistics subtext, matching the Bookmarks / Aerials hero
+    // (`DetailHeaderBar`): icon disc, primary semibold title, caption stat line.
     private var brandMark: some View {
         HStack(spacing: DesignTokens.Spacing.sm) {
             ZStack {
                 Circle()
                     .fill(Color.accentColor.opacity(0.15))
-                    .frame(width: 34, height: 34)
+                    .frame(
+                        width: DesignTokens.DetailHeader.iconSize,
+                        height: DesignTokens.DetailHeader.iconSize
+                    )
                 Image(systemName: "cube.transparent.fill")
-                    .font(.system(size: 17))
+                    .font(.system(size: DesignTokens.DetailHeader.iconSymbolSize))
                     .foregroundStyle(Color.accentColor)
                     .symbolRenderingMode(.hierarchical)
             }
             .accessibilityHidden(true)
 
-            Text("Steam Workshop")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .accessibilityAddTraits(.isHeader)
+            VStack(alignment: .leading, spacing: DesignTokens.DetailHeader.textSpacing) {
+                Text("Steam Workshop")
+                    .font(.system(size: DesignTokens.DetailHeader.titleSize, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .accessibilityAddTraits(.isHeader)
+                Text(verbatim: headerStat)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
         }
+    }
+
+    /// Context-aware statistics subtext: library size on Installed, today's
+    /// honest request count on Workshop.
+    private var headerStat: String {
+        switch selectedTab {
+        case .installed:
+            return String(localized: "\(installedCount) installed", comment: "Workshop header stat: number of installed wallpapers.")
+        case .browseOnline:
+            return String(localized: "\(WorkshopRequestCounter.countForToday()) requests today", comment: "Workshop header stat: Steam Web API requests issued today.")
+        }
+    }
+
+    private func refreshInstalledCount() {
+        installedCount = SettingsManager.shared.loadGlobalSettings().recentWPEImports.count
     }
 
     private var tabSwitcher: some View {


### PR DESCRIPTION
Addresses an 11-item review pass on the redesigned Steam Workshop pages. One commit, isolated to the Workshop UI (no renderer/scene files touched — the branch is simply behind `main` on the unrelated WPE transpiler work, so the merge-base diff stays clean).

## What changed

| # | Item | Approach |
|---|------|----------|
| 1 | A few GIF previews didn't show | Preview transfer + decode cap **8 → 32 MiB**; oversized/long animations now **degrade to a static poster** instead of returning `nil` (which had blanked the tile). |
| 2 | Filter taxonomy + tag bug | **Fixes a dead-filter bug:** `canonicalTags` no longer lower-cases tags — Steam matches `requiredtags`/`excludedtags` by **exact display name**, so every prior tag filter silently matched nothing. Adds the core-set taxonomy: 3-tier maturity threshold (via `excludedtags`), single-select Resolution bucket, and **multi-select Genre checkboxes**. |
| 3 | Inspector reflow hid the selection | `ScrollViewReader` re-centers the selected tile when opening the inspector reflows the grid; page steps scroll back to top. |
| 4 | Resolution tag | Resolution badge on the card thumbnail (derived from the item's resolution tag); subscriber count moves to the detail inspector. |
| 5 | Sort periods | Trending sort gains a **week / month / year** window (days 7 / 30 / 365). |
| 6a | Couldn't close the detail | Inspector now has an explicit **✕ close** button (+ Esc / `cancelAction`). |
| 6b | Pagination | Bottom "Load more" → **prev/next cursor pager**. Steam's QueryFiles cursor only walks forward (no jump-to-page-N), so a cursor stack steps pages and **each page replaces results** — flat memory, no infinite-scroll bloat. |
| 7 | Reduce API calls | All filter changes route through one **450 ms debounce** so multi-select toggles coalesce into a single request (the 5-minute query cache de-dupes repeats). |
| 8 | Installed Apply control | Now a prominent **blue `borderedProminent` button** — native hover, no more glass-capsule hover jitter. |
| 9 | Installed type filter | **Multi-select chips** (client-side OR; empty = all) with an "Unsupported" chip that explains itself (Windows `.exe` / unrecognized type). |
| 10 | Workshop header | Upgraded to the **bold hero** used by Bookmarks/Aerials (icon disc + primary semibold title + statistics subtext). |

## Design notes for reviewers

- **AND semantics**: Steam ANDs `requiredtags` (default `match_all_tags=true`), matching Steam's own Workshop browse. So multi-select is used for **Genre** (selecting several narrows, Steam-native) and the **Installed** type filter (client-side OR, unconstrained); online **Type** and **Resolution** stay single-select because an item has exactly one of each and a multi-select AND would match nothing.
- `WPEHistoryRow.applyControl` is restyled, but it only renders when `allowsInlineApply` is set (the Installed library) — the Scene tab leaves it off, so that view is unchanged.
- Built clean (`Debug` / `DIRECT_DISTRIBUTION`).

## Not yet runtime-validated

Several pieces (cursor pager, filter debounce, inspector re-centering) were built + self-reviewed but not runtime-tested. The most important thing to confirm live: **#2's tag-case fix** — picking a Type/Genre should now actually filter results. The **#4 resolution badge** depends on Steam returning resolution tags (graceful no-op if absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)