### PR TITLE
refactor(workshop): multi-select maturity, restore multi-select insta…

### DIFF
--- a/LiveWallpaper/Views/Workshop/WorkshopBrowseFilterRibbon.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopBrowseFilterRibbon.swift
@@ -75,6 +75,10 @@ struct WorkshopBrowseFilterRibbon: View {
             sortMenu
             filtersToggle
 
+            if viewModel.hasPendingChanges {
+                searchButton
+            }
+
             refreshButton
 
             Spacer(minLength: DesignTokens.Spacing.sm)
@@ -160,13 +164,13 @@ struct WorkshopBrowseFilterRibbon: View {
                     ForEach(WorkshopAgeRatingFilter.allCases) { rating in
                         FilterChip(
                             title: Text(verbatim: rating.displayName),
-                            isSelected: viewModel.ageRating == rating
+                            isSelected: viewModel.selectedAgeRatings.contains(rating)
                         ) {
-                            viewModel.updateAgeRating(rating)
+                            viewModel.toggleAgeRating(rating)
                         }
                     }
                 }
-                .help(Text("Maximum maturity to show — hides ratings above the chosen level."))
+                .help(Text("Pick which maturity ratings to show — independent, multi-select."))
             }
 
             filterRow("Resolution") {
@@ -195,12 +199,21 @@ struct WorkshopBrowseFilterRibbon: View {
                 }
             }
 
-            if activeFilterCount > 0 {
-                Button("Clear filters") { clearFilters() }
-                    .buttonStyle(.borderless)
-                    .controlSize(.small)
-                    .padding(.leading, 74 + DesignTokens.Spacing.sm)
+            HStack(spacing: DesignTokens.Spacing.md) {
+                if viewModel.hasPendingChanges {
+                    Button("Search") { Task { await viewModel.submitSearch() } }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(controlsDisabled)
+                        .help(Text("Apply these filters"))
+                }
+                if activeFilterCount > 0 {
+                    Button("Clear filters") { viewModel.resetFilters() }
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                }
             }
+            .padding(.leading, 74 + DesignTokens.Spacing.sm)
         }
         .padding(.horizontal, DesignTokens.Spacing.md)
         .padding(.vertical, DesignTokens.Spacing.sm)
@@ -284,6 +297,20 @@ struct WorkshopBrowseFilterRibbon: View {
         .opacity(controlsDisabled ? 0.5 : 1)
     }
 
+    /// Appears only when there are unapplied filter/search edits — the single
+    /// "apply everything now" action (issue: stop querying on every tag toggle).
+    private var searchButton: some View {
+        Button {
+            Task { await viewModel.submitSearch() }
+        } label: {
+            Text("Search")
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .disabled(controlsDisabled)
+        .help(Text("Apply filters and search"))
+    }
+
     private var refreshButton: some View {
         Button {
             Task { await viewModel.reload() }
@@ -334,19 +361,10 @@ struct WorkshopBrowseFilterRibbon: View {
     private var activeFilterCount: Int {
         var count = 0
         if viewModel.typeFilter != .all { count += 1 }
-        if viewModel.ageRating != .everyone { count += 1 }
+        if viewModel.selectedAgeRatings != WorkshopAgeRatingFilter.defaultSelection { count += 1 }
         if viewModel.resolution != .any { count += 1 }
         count += viewModel.selectedGenres.count
         return count
-    }
-
-    private func clearFilters() {
-        // Each call schedules the same debounced reload, so they coalesce into
-        // a single query rather than firing one per cleared filter.
-        if viewModel.typeFilter != .all { viewModel.updateType(.all) }
-        if viewModel.ageRating != .everyone { viewModel.updateAgeRating(.everyone) }
-        if viewModel.resolution != .any { viewModel.updateResolution(.any) }
-        if !viewModel.selectedGenres.isEmpty { viewModel.clearGenres() }
     }
 
     // MARK: - Sort options (Trending period folded in)

--- a/LiveWallpaper/Views/Workshop/WorkshopBrowsePane.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopBrowsePane.swift
@@ -311,7 +311,7 @@ struct WorkshopBrowsePane: View {
     private var hasActiveFilters: Bool {
         !viewModel.searchInput.isEmpty
             || viewModel.typeFilter != .all
-            || viewModel.ageRating != .everyone
+            || viewModel.selectedAgeRatings != WorkshopAgeRatingFilter.defaultSelection
             || viewModel.resolution != .any
             || !viewModel.selectedGenres.isEmpty
     }
@@ -331,11 +331,9 @@ struct WorkshopBrowsePane: View {
     }
 
     private func clearFilters() {
-        viewModel.updateType(.all)
-        viewModel.updateAgeRating(.everyone)
-        viewModel.updateResolution(.any)
-        viewModel.clearGenres()
-        if !viewModel.searchInput.isEmpty { Task { await viewModel.clearSearch() } }
+        viewModel.searchInput = ""
+        viewModel.resetFilters()
+        Task { await viewModel.submitSearch() }
     }
 
     private func reloadInstalledIDs() {

--- a/LiveWallpaper/Views/Workshop/WorkshopBrowseViewModel.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopBrowseViewModel.swift
@@ -30,9 +30,10 @@ enum WorkshopContentTypeFilter: String, CaseIterable, Identifiable {
     }
 }
 
-/// Maturity threshold — Wallpaper Engine tags items with one of three age
-/// ratings. This is a ceiling, expressed via `excludedTags` so it works whether
-/// or not "Everyone" is a literal tag: each tier hides the ratings above it.
+/// One of Wallpaper Engine's three maturity ratings, each an independent
+/// multi-select toggle (verbatim WPE text). Inclusion is expressed by EXCLUDING
+/// the unchecked ratings (`excludedtags`), so e.g. checking only Everyone hides
+/// Questionable + Mature.
 enum WorkshopAgeRatingFilter: String, CaseIterable, Identifiable {
     case everyone
     case questionable
@@ -40,21 +41,23 @@ enum WorkshopAgeRatingFilter: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    /// Verbatim Wallpaper Engine maturity label / tag.
     var displayName: String {
         switch self {
-        case .everyone: return String(localized: "Everyone", comment: "Workshop maturity filter: hide questionable + mature content.")
-        case .questionable: return String(localized: "Questionable", comment: "Workshop maturity filter: allow questionable, hide mature.")
-        case .mature: return String(localized: "Mature", comment: "Workshop maturity filter: include all content.")
+        case .everyone: return "Everyone"
+        case .questionable: return "Questionable"
+        case .mature: return "Mature"
         }
     }
 
-    /// Hide every rating stricter than the chosen ceiling.
-    var excludedTags: [String] {
-        switch self {
-        case .everyone: return ["Questionable", "Mature"]
-        case .questionable: return ["Mature"]
-        case .mature: return []
-        }
+    var tag: String { displayName }
+
+    /// Default selection: hide Questionable + Mature.
+    static let defaultSelection: Set<WorkshopAgeRatingFilter> = [.everyone]
+
+    /// `excludedtags` for a given inclusion set — the ratings NOT checked.
+    static func excludedTags(for selection: Set<WorkshopAgeRatingFilter>) -> [String] {
+        allCases.filter { !selection.contains($0) }.map(\.tag)
     }
 }
 
@@ -129,12 +132,14 @@ final class WorkshopBrowseViewModel {
 
     @ObservationIgnored private let services: WorkshopServices
 
-    /// Current search input as the user types it. The view-model debounces
-    /// `searchText` changes into `currentRequest` updates.
+    /// Pending search text. Edits here do NOT query — the user applies the whole
+    /// filter set with the Search control (or Return). See `hasPendingChanges`.
     var searchInput: String = ""
     var preferredSort: WorkshopSortMode = .topRated
     var typeFilter: WorkshopContentTypeFilter = .all
-    var ageRating: WorkshopAgeRatingFilter = .everyone
+    /// Multi-select maturity ratings (independent toggles). Inclusion via the
+    /// complement as `excludedtags`.
+    private(set) var selectedAgeRatings: Set<WorkshopAgeRatingFilter> = WorkshopAgeRatingFilter.defaultSelection
     /// Multi-select genre tags (AND semantics, Steam-native).
     private(set) var selectedGenres: Set<String> = []
     var resolution: WorkshopResolutionFilter = .any
@@ -172,13 +177,25 @@ final class WorkshopBrowseViewModel {
         !isRateLimited && !isLoading && !isPaging && cursorStack.count > 1
     }
 
-    @ObservationIgnored private var filterDebounceTask: Task<Void, Never>?
     @ObservationIgnored private var inflightFetch: Task<Bool, Never>?
     @ObservationIgnored private var currentRequestToken: UInt64 = 0
 
+    /// True when the pending filter/search state differs from what's currently
+    /// displayed — drives the "Search" button's enabled/prominent state. Filter
+    /// edits accumulate here and only hit the network when the user applies them.
+    var hasPendingChanges: Bool {
+        makeRequest(cursor: "*") != currentRequest
+    }
+
     init(services: WorkshopServices) {
         self.services = services
-        self.currentRequest = WorkshopQueryRequest(sort: .topRated)
+        // Seed with the default filter state's request so `hasPendingChanges`
+        // is false before the first load (default age selection excludes
+        // Questionable + Mature).
+        self.currentRequest = WorkshopQueryRequest(
+            sort: .topRated,
+            excludedTags: WorkshopAgeRatingFilter.excludedTags(for: WorkshopAgeRatingFilter.defaultSelection)
+        )
     }
 
     func onAppear() {
@@ -190,7 +207,6 @@ final class WorkshopBrowseViewModel {
     func reload() async {
         guard !isRateLimited else { return }
         inflightFetch?.cancel()
-        filterDebounceTask?.cancel()
         cursorStack = ["*"]
         pageIndex = 1
         let request = makeRequest(cursor: "*")
@@ -246,63 +262,51 @@ final class WorkshopBrowseViewModel {
         await reload()
     }
 
-    /// Combined sort + trending-window update (the period is folded into the
-    /// sort menu, so there's a single control). Days are ignored for non-trending
-    /// sorts.
+    // Filter mutations below are PURE STATE EDITS — none of them query. The user
+    // batches selections and applies them all at once via `submitSearch()`
+    // (the Search control / Return), so adding five tags costs one request, not
+    // five. `hasPendingChanges` reflects unapplied edits.
+
+    /// Combined sort + trending-window update (period folded into the sort menu).
     func updateSortOption(_ sort: WorkshopSortMode, days: Int) {
-        guard !isRateLimited else { return }
-        let changed = sort != preferredSort || (sort == .trending && days != trendingDays)
-        guard changed else { return }
         preferredSort = sort
         if sort == .trending { trendingDays = days }
-        scheduleFilterReload()
     }
 
     func updateType(_ type: WorkshopContentTypeFilter) {
-        guard !isRateLimited, type != typeFilter else { return }
         typeFilter = type
-        scheduleFilterReload()
     }
 
-    func updateAgeRating(_ rating: WorkshopAgeRatingFilter) {
-        guard !isRateLimited, rating != ageRating else { return }
-        ageRating = rating
-        scheduleFilterReload()
+    func toggleAgeRating(_ rating: WorkshopAgeRatingFilter) {
+        if selectedAgeRatings.contains(rating) {
+            selectedAgeRatings.remove(rating)
+        } else {
+            selectedAgeRatings.insert(rating)
+        }
     }
 
     func updateResolution(_ resolution: WorkshopResolutionFilter) {
-        guard !isRateLimited, resolution != self.resolution else { return }
         self.resolution = resolution
-        scheduleFilterReload()
     }
 
     func toggleGenre(_ tag: String) {
-        guard !isRateLimited else { return }
         if selectedGenres.contains(tag) {
             selectedGenres.remove(tag)
         } else {
             selectedGenres.insert(tag)
         }
-        scheduleFilterReload()
     }
 
     func clearGenres() {
-        guard !isRateLimited, !selectedGenres.isEmpty else { return }
         selectedGenres.removeAll()
-        scheduleFilterReload()
     }
 
-    /// Coalesce rapid multi-select toggles (and back-to-back single-select
-    /// changes) into ONE request — the key API-economy lever: checking three
-    /// genres fires a single reload, not three. The 5-minute query cache then
-    /// de-dupes any repeated combination.
-    private func scheduleFilterReload() {
-        filterDebounceTask?.cancel()
-        filterDebounceTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 450_000_000)
-            guard let self, !Task.isCancelled else { return }
-            await self.reload()
-        }
+    /// Reset every filter (not search/sort) to defaults. Pending until applied.
+    func resetFilters() {
+        typeFilter = .all
+        selectedAgeRatings = WorkshopAgeRatingFilter.defaultSelection
+        resolution = .any
+        selectedGenres = []
     }
 
     /// Runs the query; returns `true` on a successful page load. `replacingItems`
@@ -364,7 +368,7 @@ final class WorkshopBrowseViewModel {
             numPerPage: 50,
             days: preferredSort == .trending ? trendingDays : nil,
             requiredTags: required,
-            excludedTags: ageRating.excludedTags
+            excludedTags: WorkshopAgeRatingFilter.excludedTags(for: selectedAgeRatings)
         )
     }
 }

--- a/LiveWallpaper/Views/Workshop/WorkshopInstalledView.swift
+++ b/LiveWallpaper/Views/Workshop/WorkshopInstalledView.swift
@@ -17,9 +17,10 @@ struct WorkshopInstalledView: View {
     @State private var bookmarkStore = BookmarkStore.shared
     @State private var entries: [WPEHistoryEntry] = []
     @State private var searchText: String = ""
-    /// Single-select type filter — `nil` means "all". Rendered as chip buttons
-    /// (pick one), matching the online Browse type chips.
-    @State private var selectedType: WPELibraryTypeKind? = nil
+    /// Multi-select type filter — empty means "all". This is a client-side OR
+    /// (no API), so multi-select is correct here (an item matches if its kind is
+    /// among the selected set), unlike the online Browse type chip.
+    @State private var selectedTypes: Set<WPELibraryTypeKind> = []
     @State private var sortOrder: WPELibrarySortOrder = .recommended
     @State private var errorMessage: String?
     /// Drives the drag-to-apply screen bar — set true when a card drag starts,
@@ -229,23 +230,31 @@ struct WorkshopInstalledView: View {
 
     private var typeChipRow: some View {
         HStack(spacing: 6) {
-            FilterChip(title: Text("All"), isSelected: selectedType == nil) {
-                selectedType = nil
+            FilterChip(title: Text("All"), isSelected: selectedTypes.isEmpty) {
+                selectedTypes.removeAll()
             }
             .help(Text("Show every installed wallpaper"))
 
             ForEach(WPELibraryTypeKind.allCases) { kind in
-                FilterChip(title: Text(verbatim: kind.title), isSelected: selectedType == kind) {
-                    selectedType = (selectedType == kind) ? nil : kind
+                FilterChip(title: Text(verbatim: kind.title), isSelected: selectedTypes.contains(kind)) {
+                    toggleType(kind)
                 }
                 .help(kind.helpText)
             }
         }
     }
 
+    private func toggleType(_ kind: WPELibraryTypeKind) {
+        if selectedTypes.contains(kind) {
+            selectedTypes.remove(kind)
+        } else {
+            selectedTypes.insert(kind)
+        }
+    }
+
     private func typeMatches(_ entry: WPEHistoryEntry) -> Bool {
-        guard let selectedType else { return true }
-        return selectedType.matches(entry)
+        guard !selectedTypes.isEmpty else { return true }
+        return selectedTypes.contains { $0.matches(entry) }
     }
 
     // MARK: - Actions


### PR DESCRIPTION
…lled type, manual-apply filters

1. Maturity filter → three independent multi-select toggles (Everyone / Questionable / Mature, verbatim WPE text). Inclusion is expressed by EXCLUDING the unchecked ratings (excludedtags), so checking only Everyone hides Questionable + Mature (the default). Replaces the single-select threshold.
2. Installed type filter restored to MULTI-select chips (video/web/scene/ unsupported, empty = all). It's a client-side OR with no API cost, so multi-select is correct here — the prior single-select was a regression.
3. Online filters are now MANUAL-APPLY: type / maturity / resolution / genre / sort edits are pure state changes that no longer query on each toggle. A "Search" button (top row + filter panel, shown when there are unapplied edits) / Return / the search-field magnifier applies the whole set at once, so adding five tags costs one request, not five. Removes the per-change debounce; adds viewModel.hasPendingChanges + resetFilters().

Built clean (Debug/DIRECT_DISTRIBUTION).