### PR TITLE
feat(wpe): scene camera parallax + Metal render/text/particle fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ docs/
 .claude/
 
 .vm-bridge/
+cache/

--- a/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
@@ -129,7 +129,7 @@ enum WPESceneDocumentParser {
 
         for key in generalDict.keys {
             let lowered = key.lowercased()
-            if lowered.hasPrefix("bloom") || lowered.hasPrefix("cameraparallax") || lowered.hasPrefix("camerashake") {
+            if lowered.hasPrefix("bloom") || lowered.hasPrefix("camerashake") {
                 diagnostics.append(.init(severity: .info, message: "general.\(key) is unsupported in Phase 2.0"))
             }
         }
@@ -667,7 +667,18 @@ enum WPESceneDocumentParser {
             ))
             projection = WPESceneGeneral.defaultGeneral.orthogonalProjection
         }
-        return WPESceneGeneral(clearColor: clearColor, orthogonalProjection: projection)
+        let parallaxDefaults = WPESceneCameraParallaxSettings.disabled
+        let cameraParallax = WPESceneCameraParallaxSettings(
+            enabled: parseBool(dict["cameraparallax"]) ?? parallaxDefaults.enabled,
+            amount: parseDouble(dict["cameraparallaxamount"]) ?? parallaxDefaults.amount,
+            delay: parseDouble(dict["cameraparallaxdelay"]) ?? parallaxDefaults.delay,
+            mouseInfluence: parseDouble(dict["cameraparallaxmouseinfluence"]) ?? parallaxDefaults.mouseInfluence
+        )
+        return WPESceneGeneral(
+            clearColor: clearColor,
+            orthogonalProjection: projection,
+            cameraParallax: cameraParallax
+        )
     }
 
     // MARK: - Image objects

--- a/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
@@ -395,6 +395,12 @@ enum WPESceneDocumentParser {
         let vert = unwrapString(dict["verticalalign"]) ?? "middle"
         let maxWidth = unwrapDouble(dict["maxwidth"]) ?? unwrapDouble(dict["limitwidth"])
         let parallaxDepth = unwrapDouble(dict["parallaxDepth"]) ?? unwrapDouble(dict["parallaxdepth"]) ?? 0
+        // WPE text-box footprint ("size") + transparent margin ("padding"). A
+        // text object renders like an image layer whose texture is this box, so
+        // the rendered text must fill the box (minus padding) × scale — not the
+        // raw rasterized bounds at pointsize, which are far smaller.
+        let boxSize = parseVector3(dict["size"]).map { SIMD2<Double>($0.x, $0.y) }
+        let padding = parseDouble(dict["padding"]) ?? 0
 
         return WPESceneTextObject(
             id: id,
@@ -412,7 +418,9 @@ enum WPESceneDocumentParser {
             horizontalAlignment: horiz.lowercased(),
             verticalAlignment: vert.lowercased(),
             maxWidth: maxWidth.map { max(1, $0) },
-            parallaxDepth: parallaxDepth
+            parallaxDepth: parallaxDepth,
+            boxSize: (boxSize.map { $0.x > 0 && $0.y > 0 } ?? false) ? boxSize : nil,
+            padding: max(0, padding)
         )
     }
 

--- a/LiveWallpaper/Runtime/WPEMetalFrameState.swift
+++ b/LiveWallpaper/Runtime/WPEMetalFrameState.swift
@@ -46,6 +46,9 @@ struct WPEMetalFrameState {
     /// blends, culls, or rejects fragments via depth.
     var initializedTextures: Set<ObjectIdentifier> = []
     var depthTextures: [WPEMetalDepthTextureKey: MTLTexture] = [:]
+    /// Scene-level camera parallax for this frame; object-quad (scene-targeted)
+    /// draws translate each layer by `cameraParallax.pixelOffset(depth:…)`.
+    var cameraParallax: WPECameraParallaxFrame = .neutral
 
     init(
         output: MTLTexture,

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -1603,21 +1603,33 @@ final class WPEMetalRenderExecutor {
     }
 
     /// Phase 2D-D: pack scene uniforms for the genericimage* built-ins.
+    private static let imageUniformDebugEnabled = UserDefaults.standard.bool(forKey: "WPEAudioDebugLog")
+    nonisolated(unsafe) private static var loggedImageUniformNames = Set<String>()
+
     func genericImageUniforms(
         for pass: WPEPreparedRenderPass,
         layer: WPERenderLayer,
         hasMask: Bool
     ) -> WPEGenericImageUniforms {
-        WPEGenericImageUniforms(
-            color: WPEMetalShaderInputs.colorVector(for: pass),
-            alphaMaskUV: SIMD4<Float>(
-                WPEMetalShaderInputs.floatScalar(named: ["g_Alpha", "u_Alpha", "alpha"], in: pass, default: 1)
-                    * Float(layer.geometry.alpha),
-                WPEMetalShaderInputs.floatScalar(named: ["g_Brightness", "u_Brightness", "brightness"], in: pass, default: 1)
-                    * Float(layer.geometry.brightness),
-                hasMask ? 1 : 0,
-                0
+        let color = WPEMetalShaderInputs.colorVector(for: pass)
+        let gAlpha = WPEMetalShaderInputs.floatScalar(named: ["g_Alpha", "u_Alpha", "alpha"], in: pass, default: 1)
+        let gBrightness = WPEMetalShaderInputs.floatScalar(named: ["g_Brightness", "u_Brightness", "brightness"], in: pass, default: 1)
+        let alpha = gAlpha * Float(layer.geometry.alpha)
+        let brightness = gBrightness * Float(layer.geometry.brightness)
+        // Diagnostic for the "black silhouette" bug: genericimage shaders do
+        // `rgb = sampled.rgb * color.rgb * brightness`, so brightness==0 OR
+        // color==0 blacks out the layer while alpha (a separate term) survives.
+        // One line per object so the log isn't spammed.
+        if Self.imageUniformDebugEnabled,
+           Self.loggedImageUniformNames.insert(layer.objectName).inserted {
+            Logger.notice(
+                "[ImgUniform] \(layer.objectName) shader=\(pass.pass.shader) g_Brightness=\(gBrightness) layerBright=\(layer.geometry.brightness) → brightness=\(brightness) color=(\(color.x),\(color.y),\(color.z)) alpha=\(alpha)",
+                category: .wpeRender
             )
+        }
+        return WPEGenericImageUniforms(
+            color: color,
+            alphaMaskUV: SIMD4<Float>(alpha, brightness, hasMask ? 1 : 0, 0)
         )
     }
 

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -221,6 +221,7 @@ final class WPEMetalRenderExecutor {
             previousSceneTexture: reusableHistory?.sceneTexture,
             previousNamedTextures: reusableHistory?.namedTextures ?? [:]
         )
+        frameState.cameraParallax = runtimeUniforms.cameraParallax
         var didEncode = false
         let bypassEffects = Self.bypassEffectsForDebug
 
@@ -1154,6 +1155,7 @@ final class WPEMetalRenderExecutor {
     func objectQuadUniforms(
         for layer: WPERenderLayer,
         sceneSize: CGSize,
+        cameraParallax: WPECameraParallaxFrame = .neutral,
         sourceTexture: MTLTexture
     ) -> WPEObjectQuadUniforms {
         let geometry = layer.geometry
@@ -1177,7 +1179,7 @@ final class WPEMetalRenderExecutor {
             alignment: geometry.alignment,
             width: width,
             height: height
-        )
+        ) + cameraParallax.pixelOffset(depth: layer.parallaxDepth, sceneSize: sceneSize)
         return WPEObjectQuadUniforms(
             centerAndSize: SIMD4<Float>(center.x, center.y, width, height),
             sceneSizeAndRotation: SIMD4<Float>(
@@ -1435,6 +1437,7 @@ final class WPEMetalRenderExecutor {
             var quadUniforms = objectQuadUniforms(
                 for: layer,
                 sceneSize: frameState.sceneSize,
+                cameraParallax: frameState.cameraParallax,
                 sourceTexture: texture
             )
             encoder.setVertexBytes(
@@ -1592,6 +1595,7 @@ final class WPEMetalRenderExecutor {
             var quadUniforms = objectQuadUniforms(
                 for: layer,
                 sceneSize: frameState.sceneSize,
+                cameraParallax: frameState.cameraParallax,
                 sourceTexture: sourceTexture
             )
             encoder.setVertexBytes(

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -342,7 +342,8 @@ final class WPEMetalRenderExecutor {
         systems: [WPEParticleSystem],
         texturesByMaterial: [ObjectIdentifier: MTLTexture],
         sceneSize: CGSize,
-        output: MTLTexture
+        output: MTLTexture,
+        cameraParallax: WPECameraParallaxFrame = .neutral
     ) throws {
         let alive = systems.filter { $0.liveInstanceCount > 0 }
         guard !alive.isEmpty else { return }
@@ -378,6 +379,11 @@ final class WPEMetalRenderExecutor {
                 blendMode: system.blendMode
             )
             encoder.setRenderPipelineState(pipelineState)
+            // Translate the whole system by its camera-parallax depth (pixels),
+            // carried in `padding.xy` and added to each particle's screen
+            // position in the vertex shader.
+            let parallax = cameraParallax.pixelOffset(depth: system.parallaxDepth, sceneSize: sceneSize)
+            projection.padding = SIMD4<Float>(parallax.x, parallax.y, 0, 0)
             encoder.setVertexBuffer(system.instanceBuffer, offset: 0, index: 1)
             encoder.setVertexBytes(&projection, length: MemoryLayout<WPEParticleProjection>.stride, index: 2)
             var sprite = WPEParticleSpriteParams(grid: SIMD4<Float>(
@@ -1134,21 +1140,27 @@ final class WPEMetalRenderExecutor {
         )
     }
 
-    func usesObjectQuadGeometry(for pass: WPEPreparedRenderPass, layer: WPERenderLayer) -> Bool {
-        guard layer.geometry != .identity else { return false }
-        switch pass.pass.target {
-        case .scene:
-            // WPE fullscreen/passthrough utility layers (compose/project/fullscreen)
-            // render fullscreen and copy the captured frame 1:1, never as a shrunken
-            // object quad — unless the per-scene legacy rollback gate restores the
-            // old object-quad behavior.
-            if WPEMetalComposeLayerCompatibility.isSceneCaptureUtilityModelPath(layer.imagePath) {
-                return activeLegacyComposeLayer
-            }
-            return true
-        default:
-            return false
+    func usesObjectQuadGeometry(
+        for pass: WPEPreparedRenderPass,
+        layer: WPERenderLayer,
+        cameraParallax: WPECameraParallaxFrame = .neutral
+    ) -> Bool {
+        guard case .scene = pass.pass.target else { return false }
+        if layer.geometry == .identity {
+            // Identity full-frame layers normally take the fullscreen copy path.
+            // Route them through the object quad (an identical full-scene quad)
+            // only when there's an actual parallax shift to apply, leaving the
+            // common no-parallax path byte-for-byte unchanged.
+            return layer.parallaxDepth != 0 && cameraParallax.smoothed != SIMD2<Float>(0, 0)
         }
+        // WPE fullscreen/passthrough utility layers (compose/project/fullscreen)
+        // render fullscreen and copy the captured frame 1:1, never as a shrunken
+        // object quad — unless the per-scene legacy rollback gate restores the
+        // old object-quad behavior.
+        if WPEMetalComposeLayerCompatibility.isSceneCaptureUtilityModelPath(layer.imagePath) {
+            return activeLegacyComposeLayer
+        }
+        return true
     }
 
     func objectQuadUniforms(
@@ -1160,6 +1172,18 @@ final class WPEMetalRenderExecutor {
         let geometry = layer.geometry
         let sceneWidth = Float(max(sceneSize.width, 1))
         let sceneHeight = Float(max(sceneSize.height, 1))
+        // Identity (full-frame) layers map to a scene-sized quad centered at the
+        // origin — identical coverage + UV to `wpe_fullscreen_vertex` — plus the
+        // camera-parallax shift. (Only reached when parallax is active; see
+        // `usesObjectQuadGeometry`.)
+        if geometry == .identity {
+            let parallax = cameraParallax.pixelOffset(depth: layer.parallaxDepth, sceneSize: sceneSize)
+            return WPEObjectQuadUniforms(
+                centerAndSize: SIMD4<Float>(parallax.x, parallax.y, sceneWidth, sceneHeight),
+                sceneSizeAndRotation: SIMD4<Float>(sceneWidth, sceneHeight, 0, 0),
+                uvSignAndPadding: SIMD4<Float>(1, 1, 0, 0)
+            )
+        }
         let baseWidth = Float(geometry.size?.width ?? CGFloat(sourceTexture.width))
         let baseHeight = Float(geometry.size?.height ?? CGFloat(sourceTexture.height))
         let scaleX = Float(geometry.scale.x)
@@ -1414,7 +1438,7 @@ final class WPEMetalRenderExecutor {
         depthPixelFormat: MTLPixelFormat,
         uniforms: U
     ) throws {
-        let usesObjectQuad = usesObjectQuadGeometry(for: pass, layer: layer)
+        let usesObjectQuad = usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
         encoder.setRenderPipelineState(try renderPipeline(
             vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : "wpe_fullscreen_vertex",
             fragmentName: fragmentName,
@@ -1544,7 +1568,7 @@ final class WPEMetalRenderExecutor {
         encoder: MTLRenderCommandEncoder,
         depthPixelFormat: MTLPixelFormat
     ) throws {
-        let usesObjectQuad = usesObjectQuadGeometry(for: pass, layer: layer)
+        let usesObjectQuad = usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
         encoder.setRenderPipelineState(try renderPipeline(
             vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : "wpe_fullscreen_vertex",
             fragmentName: "wpe_effect_opacity_fragment",

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -1107,12 +1107,11 @@ final class WPEMetalRenderExecutor {
             ),
             index: 0
         )
-        var uniforms = WPECopyUniforms(
-            uvOffset: WPEMetalShaderInputs.parallaxUVOffset(
-                pointerPosition: runtimeUniforms.pointerPosition,
-                parallaxDepth: layer.parallaxDepth
-            )
-        )
+        // Parallax is a geometry translation applied in object-quad scene
+        // passes; the legacy raw-pointer UV shift is removed here too. (Plain
+        // full-frame layers routed through this fullscreen copy don't parallax —
+        // see the camera-parallax limitations note.)
+        var uniforms = WPECopyUniforms(uvOffset: SIMD2<Float>(0, 0))
         encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPECopyUniforms>.stride, index: 0)
         encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
         frameState.registerWrite(texture: destination.texture, targetID: destination.id)

--- a/LiveWallpaper/Runtime/WPEMetalRuntimeUniforms.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRuntimeUniforms.swift
@@ -21,11 +21,17 @@ struct WPECameraParallaxFrame: Equatable, Sendable {
     /// geometry shift. X is negated and Y kept so the layer moves with the
     /// cursor in the renderer's top-left scene space.
     func pixelOffset(depth: Double, sceneSize: CGSize) -> SIMD2<Float> {
-        guard depth != 0, smoothed != SIMD2<Float>(0, 0) else { return SIMD2<Float>(0, 0) }
-        let d = Float(depth) * 0.1
-        let ux = min(max(smoothed.x * d, -0.05), 0.05)
-        let uy = min(max(smoothed.y * d, -0.05), 0.05)
-        return SIMD2<Float>(-ux * Float(sceneSize.width), uy * Float(sceneSize.height))
+        let d = Float(depth)
+        let width = Float(sceneSize.width)
+        let height = Float(sceneSize.height)
+        guard d.isFinite, width.isFinite, height.isFinite,
+              d != 0, smoothed != SIMD2<Float>(0, 0) else {
+            return SIMD2<Float>(0, 0)
+        }
+        let scaledDepth = d * 0.1
+        let ux = min(max(smoothed.x * scaledDepth, -0.05), 0.05)
+        let uy = min(max(smoothed.y * scaledDepth, -0.05), 0.05)
+        return SIMD2<Float>(-ux * max(width, 1), uy * max(height, 1))
     }
 }
 
@@ -65,13 +71,17 @@ struct WPECameraParallaxSmoother: Equatable, Sendable {
             Float(pointer.x - 0.5) * effectiveGlobal,
             Float(pointer.y - 0.5) * effectiveGlobal
         )
-        guard let last = lastTime else {
+        let rawDt = lastTime.map { max(time - $0, 0) }
+        lastTime = time
+        // First frame, or a long gap (resume from suspend / idle), snaps to the
+        // cursor instead of a slow catch-up. Otherwise clamp `dt` to a 10 FPS
+        // floor so a single heavy frame can't over-step yet low frame rates stay
+        // frame-rate independent.
+        guard let rawDt, rawDt <= 0.5 else {
             smoothed = target
-            lastTime = time
             return WPECameraParallaxFrame(smoothed: smoothed)
         }
-        let dt = min(max(time - last, 0), 1.0 / 30.0)
-        lastTime = time
+        let dt = min(rawDt, 1.0 / 10.0)
         let alpha: Float = settings.delay <= 0
             ? 1
             : Float(1 - exp(-dt / max(settings.delay, 1.0 / 240.0)))

--- a/LiveWallpaper/Runtime/WPEMetalRuntimeUniforms.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRuntimeUniforms.swift
@@ -243,12 +243,18 @@ struct WPEMetalCameraUniforms: Equatable, Sendable {
 }
 
 extension WallpaperPerformanceProfile {
+    /// `g_Brightness` fed to image shaders, which compute
+    /// `rgb = sampled.rgb * color.rgb * g_Brightness`. This MUST stay 1 in
+    /// both states: returning 0 for `.suspended` rendered every `genericimage*`
+    /// layer as a pure-black silhouette (alpha is a separate term, so the shape
+    /// survived) whenever a frame was produced while suspended — most visibly
+    /// the first frame during load and any not-fully-occluded paused wallpaper.
+    /// Suspension saves power via `mtkView.isPaused`, not by dimming content to
+    /// black; a paused wallpaper should show its scene frozen, not blanked.
     var metalBrightnessUniformValue: Double {
         switch self {
-        case .quality:
+        case .quality, .suspended:
             return 1
-        case .suspended:
-            return 0
         }
     }
 }

--- a/LiveWallpaper/Runtime/WPEMetalRuntimeUniforms.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRuntimeUniforms.swift
@@ -7,11 +7,86 @@ import QuartzCore
 /// into prepared pass uniforms before the Metal executor runs. Built-in
 /// shaders ignore the entries they do not bind, so this layer can ship before
 /// the Phase 2D custom-shader translator consumes them.
+/// Per-frame, smoothed camera-parallax state. `smoothed` is the cursor offset
+/// from screen center (−0.5…0.5 per axis) after exponential smoothing and the
+/// scene's amount/mouse-influence calibration. `pixelOffset` turns it into a
+/// per-layer scene-pixel translation scaled by that layer's `parallaxDepth`.
+struct WPECameraParallaxFrame: Equatable, Sendable {
+    var smoothed: SIMD2<Float>
+
+    static let neutral = WPECameraParallaxFrame(smoothed: SIMD2<Float>(0, 0))
+
+    /// Scene-pixel translation for a layer at `depth`. Mirrors the historical
+    /// UV-parallax magnitude (`× depth × 0.1`, clamped ±0.05) but expressed as a
+    /// geometry shift. X is negated and Y kept so the layer moves with the
+    /// cursor in the renderer's top-left scene space.
+    func pixelOffset(depth: Double, sceneSize: CGSize) -> SIMD2<Float> {
+        guard depth != 0, smoothed != SIMD2<Float>(0, 0) else { return SIMD2<Float>(0, 0) }
+        let d = Float(depth) * 0.1
+        let ux = min(max(smoothed.x * d, -0.05), 0.05)
+        let uy = min(max(smoothed.y * d, -0.05), 0.05)
+        return SIMD2<Float>(-ux * Float(sceneSize.width), uy * Float(sceneSize.height))
+    }
+}
+
+/// Frame-rate-independent exponential smoother for camera parallax. Holds the
+/// smoothed cursor offset across frames; `frame(...)` advances it toward the
+/// (calibrated) cursor target each frame. Neutral when the scene disables
+/// parallax or zeroes amount / mouse-influence. Kept as a value type so it can
+/// be unit-tested independently of the renderer.
+struct WPECameraParallaxSmoother: Equatable, Sendable {
+    private(set) var smoothed = SIMD2<Float>(0, 0)
+    private var lastTime: Double?
+
+    mutating func reset() {
+        smoothed = SIMD2<Float>(0, 0)
+        lastTime = nil
+    }
+
+    /// `time` is monotonic scene-elapsed seconds. WPE defaults (amount 0.5,
+    /// mouseInfluence 0.5) → `effectiveGlobal == 1`, preserving the historical
+    /// per-layer depth magnitude. `dt` is clamped so a long suspend doesn't
+    /// snap on resume; the first frame snaps directly to the cursor.
+    mutating func frame(
+        settings: WPESceneCameraParallaxSettings,
+        pointerPosition: SIMD2<Double>,
+        time: Double
+    ) -> WPECameraParallaxFrame {
+        let amount = max(settings.amount, 0)
+        let influence = max(settings.mouseInfluence, 0)
+        guard settings.enabled, amount > 0, influence > 0 else {
+            smoothed = SIMD2<Float>(0, 0)
+            lastTime = time
+            return .neutral
+        }
+        let effectiveGlobal = Float((amount / 0.5) * (influence / 0.5))
+        let pointer = pointerPosition.clampedToUnitSquare
+        let target = SIMD2<Float>(
+            Float(pointer.x - 0.5) * effectiveGlobal,
+            Float(pointer.y - 0.5) * effectiveGlobal
+        )
+        guard let last = lastTime else {
+            smoothed = target
+            lastTime = time
+            return WPECameraParallaxFrame(smoothed: smoothed)
+        }
+        let dt = min(max(time - last, 0), 1.0 / 30.0)
+        lastTime = time
+        let alpha: Float = settings.delay <= 0
+            ? 1
+            : Float(1 - exp(-dt / max(settings.delay, 1.0 / 240.0)))
+        smoothed += (target - smoothed) * alpha
+        return WPECameraParallaxFrame(smoothed: smoothed)
+    }
+}
+
 struct WPEMetalRuntimeUniforms: Equatable, Sendable {
     let time: Double
     let daytime: Double
     let brightness: Double
     let pointerPosition: SIMD2<Double>
+    /// Scene-level camera parallax for this frame (neutral when disabled).
+    var cameraParallax: WPECameraParallaxFrame = .neutral
     /// Per-channel spectrum, 64 bins each, normalized 0…1, low frequency → high.
     /// Fed from the shared system-audio broker. Audio-reactive shaders consume
     /// 16/32/64-element slices per channel via the resolution combo. Mono

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -102,6 +102,11 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
     private var cachedSnapshot: NSImage?
     private var didLoad = false
     private var isThrottled = false
+    /// Scene-level camera parallax: the parsed settings plus the per-frame
+    /// exponential smoother that drives every layer's depth shift. Neutral when
+    /// the scene disables parallax.
+    private var cameraParallaxSettings: WPESceneCameraParallaxSettings = .disabled
+    private var cameraParallaxSmoother = WPECameraParallaxSmoother()
     private var currentProfile: WallpaperPerformanceProfile = .quality
     /// User-selected frame rate ceiling, applied to `mtkView.preferredFramesPerSecond`
     /// whenever the renderer is not throttled / suspended. Defaults to the
@@ -417,6 +422,8 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
             orthogonalProjection: document.general.orthogonalProjection,
             sceneCamera: document.camera
         )
+        cameraParallaxSettings = document.general.cameraParallax
+        cameraParallaxSmoother.reset()
         sceneRenderSize = cameraUniforms.renderSize
         debugStage("camera", "renderSize=\(Int(sceneRenderSize.width))x\(Int(sceneRenderSize.height))")
 
@@ -936,9 +943,17 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
         guard let pipeline = renderPipeline else {
             throw WPEMetalRenderExecutorError.noRenderablePasses
         }
+        let pointer = pointerSampler.sample(mtkView)
         var uniforms = frameClock.runtimeUniforms(
             profile: currentProfile,
-            pointerPosition: pointerSampler.sample(mtkView)
+            pointerPosition: pointer
+        )
+        // Compute once per frame (advances smoothing state); assigned below
+        // after the audio path may have rebuilt `uniforms`.
+        let parallaxFrame = cameraParallaxSmoother.frame(
+            settings: cameraParallaxSettings,
+            pointerPosition: pointer,
+            time: uniforms.time
         )
         // Audio-reactive uniforms follow the shared system-audio capture (the
         // loopback of whatever is playing), not the scene's own sounds — those
@@ -971,6 +986,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
                 audioSpectrumRight: audio.right.map(Double.init)
             )
         }
+        uniforms.cameraParallax = parallaxFrame
         lastRuntimeUniforms = uniforms
         let currentTextures = texturesForCurrentFrame(time: uniforms.time)
         let frame = try executor.render(
@@ -1003,9 +1019,13 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
                 guard let entry = textRenderer.rasterize(liveObject) else { continue }
                 let halfWidth = Double(sceneRenderSize.width) * 0.5
                 let halfHeight = Double(sceneRenderSize.height) * 0.5
+                let textParallax = parallaxFrame.pixelOffset(
+                    depth: liveObject.parallaxDepth,
+                    sceneSize: sceneRenderSize
+                )
                 let center = SIMD2<Float>(
-                    Float(liveObject.origin.x - halfWidth),
-                    Float(liveObject.origin.y - halfHeight)
+                    Float(liveObject.origin.x - halfWidth) + textParallax.x,
+                    Float(liveObject.origin.y - halfHeight) + textParallax.y
                 )
                 let scale = SIMD2<Float>(
                     Float(max(liveObject.scale.x, 0.0001)),

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -1460,6 +1460,8 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
         textScriptInstances.removeAll(keepingCapacity: false)
         soundRuntime?.stop()
         soundRuntime = nil
+        cameraParallaxSettings = .disabled
+        cameraParallaxSmoother.reset()
         lastRuntimeUniforms = nil
         cachedSnapshot = nil
         resolutionTracer.reset()

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -998,68 +998,8 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
             for object in textObjects where liveTextVisibility[object.id] ?? object.visible {
                 let resolvedAlpha = object.resolvedAlpha(at: uniforms.time)
                 guard resolvedAlpha > 0 else { continue }
-                let liveObject: WPESceneTextObject
-                if let instance = textScriptInstances[object.id] {
-                    let updated = instance.tickString()
-                    if updated != object.text {
-                        liveObject = WPESceneTextObject(
-                            id: object.id,
-                            name: object.name,
-                            text: updated,
-                            textScript: object.textScript,
-                            fontRelativePath: object.fontRelativePath,
-                            pointSize: object.pointSize,
-                            color: object.color,
-                            alpha: resolvedAlpha,
-                            alphaAnimation: object.alphaAnimation,
-                            origin: object.origin,
-                            scale: object.scale,
-                            visible: object.visible,
-                            horizontalAlignment: object.horizontalAlignment,
-                            verticalAlignment: object.verticalAlignment,
-                            maxWidth: object.maxWidth,
-                            parallaxDepth: object.parallaxDepth
-                        )
-                    } else {
-                        liveObject = WPESceneTextObject(
-                            id: object.id,
-                            name: object.name,
-                            text: object.text,
-                            textScript: object.textScript,
-                            fontRelativePath: object.fontRelativePath,
-                            pointSize: object.pointSize,
-                            color: object.color,
-                            alpha: resolvedAlpha,
-                            alphaAnimation: object.alphaAnimation,
-                            origin: object.origin,
-                            scale: object.scale,
-                            visible: object.visible,
-                            horizontalAlignment: object.horizontalAlignment,
-                            verticalAlignment: object.verticalAlignment,
-                            maxWidth: object.maxWidth,
-                            parallaxDepth: object.parallaxDepth
-                        )
-                    }
-                } else {
-                    liveObject = WPESceneTextObject(
-                        id: object.id,
-                        name: object.name,
-                        text: object.text,
-                        textScript: object.textScript,
-                        fontRelativePath: object.fontRelativePath,
-                        pointSize: object.pointSize,
-                        color: object.color,
-                        alpha: resolvedAlpha,
-                        alphaAnimation: object.alphaAnimation,
-                        origin: object.origin,
-                        scale: object.scale,
-                        visible: object.visible,
-                        horizontalAlignment: object.horizontalAlignment,
-                        verticalAlignment: object.verticalAlignment,
-                        maxWidth: object.maxWidth,
-                        parallaxDepth: object.parallaxDepth
-                    )
-                }
+                let liveText = textScriptInstances[object.id]?.tickString() ?? object.text
+                let liveObject = object.withLiveText(liveText, alpha: resolvedAlpha)
                 guard let entry = textRenderer.rasterize(liveObject) else { continue }
                 let halfWidth = Double(sceneRenderSize.width) * 0.5
                 let halfHeight = Double(sceneRenderSize.height) * 0.5

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -1005,7 +1005,8 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
                 systems: particleSystems,
                 texturesByMaterial: particleTextures,
                 sceneSize: sceneRenderSize,
-                output: frame
+                output: frame,
+                cameraParallax: parallaxFrame
             )
         }
         if let textRenderer, !textObjects.isEmpty {
@@ -1266,6 +1267,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
             sceneTransform: sceneTransform,
             spriteSheet: spriteSheet
         ) else { return }
+        system.parallaxDepth = object.parallaxDepth
         // Spread `startDelay + 2s` worth of spawn/integration across
         // the first frame so the user doesn't see a one-particle-
         // per-frame cold start — matches WPE's behaviour where the

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -78,6 +78,12 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
     /// audio-reactive scenes that don't move.
     private let audioDebugLogEnabled = UserDefaults.standard.bool(forKey: "WPEAudioDebugLog")
     private var audioDiagCounter = 0
+    /// Last throttle state we logged, so a focus/unfocus transition (which
+    /// flips the scene between 60 FPS and `throttledPreferredFPS` = 1) emits a
+    /// line immediately instead of waiting out the per-60-frame cadence. This
+    /// is the key signal for "the bars look frozen": when the app's own
+    /// console window is key, the scene on that screen drops to 1 FPS.
+    private var audioDiagLastThrottled: Bool?
     /// Phase 2D-P: per-text-object SceneScript instances. Keyed by
     /// the text object's id so the renderer can look up the latest
     /// scripted value when rasterizing.
@@ -935,11 +941,16 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
             let audio = SystemAudioCaptureManager.broker.snapshot()
             if audioDebugLogEnabled {
                 audioDiagCounter += 1
-                if audioDiagCounter % 60 == 1 {
+                // Log every ~60 frames, OR immediately when the throttle flips
+                // (focus/unfocus of the app's console window). The latter makes
+                // the "frozen bars" cause visible: throttled=true ⇒ fps=1.
+                let throttledNow = isThrottled
+                if audioDiagCounter % 60 == 1 || audioDiagLastThrottled != throttledNow {
+                    audioDiagLastThrottled = throttledNow
                     let peakL = audio.left.max() ?? 0
                     let peakR = audio.right.max() ?? 0
                     Logger.notice(
-                        "[AudioCapture] renderer: capturing=true peakL=\(String(format: "%.3f", peakL)) peakR=\(String(format: "%.3f", peakR)) → feeding g_AudioSpectrum*",
+                        "[AudioCapture] renderer: capturing=true peakL=\(String(format: "%.3f", peakL)) peakR=\(String(format: "%.3f", peakR)) throttled=\(throttledNow) fps=\(mtkView.preferredFramesPerSecond) → feeding g_AudioSpectrum*",
                         category: .audioCapture
                     )
                 }

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -1804,9 +1804,23 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
     /// Visible to `@testable` test suites that probe the candidate generator without spinning up a full renderer fixture.
     func textureCandidates(for path: String) -> [String] {
         let extensionName = (path as NSString).pathExtension.lowercased()
-        if !extensionName.isEmpty,
-           Self.knownRawImageExtensions.contains(extensionName) || extensionName == "tex" || extensionName == "json" {
+        if extensionName == "tex" || extensionName == "json" {
             return [path]
+        }
+        if !extensionName.isEmpty, Self.knownRawImageExtensions.contains(extensionName) {
+            // WPE converts source images to `<name>.<ext>.tex` (e.g. a particle
+            // sprite `workshop/…/雪花.jpg` is stored as
+            // `materials/workshop/…/雪花.jpg.tex`). Try the literal image, then
+            // the converted `.tex`, including under the `materials/` root —
+            // otherwise extension-bearing refs never find their `.tex`.
+            var candidates = [path, "\(path).tex"]
+            let anchored = ["materials/", "models/", "shaders/", "fonts/",
+                            "scripts/", "particles/", "sounds/", "scenes/", "../", "_"]
+            if !anchored.contains(where: path.hasPrefix) {
+                candidates.append("materials/\(path)")
+                candidates.append("materials/\(path).tex")
+            }
+            return candidates
         }
 
         if let dependency = dependencyReference(path) {

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -117,6 +117,12 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
     private(set) var loadDiagnostics: SceneLoadDiagnostic?
     private(set) var renderGraph: WPERenderGraph?
     private(set) var renderPipeline: WPEPreparedRenderPipeline?
+    /// True when the pipeline has effect / custom-shader passes (scroll,
+    /// waterwaves, pulse, audio bars, …). These animate every frame via
+    /// `g_Time` / `g_AudioSpectrum*`, so the view must run continuously even
+    /// when there are no dynamic textures or particles — otherwise the scene
+    /// renders one frame and freezes. Computed once per load.
+    private var hasAnimatedShaderPasses = false
     private(set) var lastRuntimeUniforms: WPEMetalRuntimeUniforms?
     /// Property-key → render-target bindings for the loaded scene, used by the
     /// incremental settings-apply path. Empty until `load()` completes.
@@ -394,6 +400,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
 
         renderGraph = graph
         renderPipeline = pipeline
+        hasAnimatedShaderPasses = Self.pipelineHasAnimatedPasses(pipeline)
         // Seed incremental-apply state. The graph builder already baked each
         // layer's authored `visible` into the pipeline, so these baselines
         // simply mirror it for later diffing in `applyScenePropertyPatch`.
@@ -1443,7 +1450,23 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
     /// the first frame (the operator and turbulence updates would never
     /// run again).
     private var needsContinuousFrames: Bool {
-        !dynamicTextureSources.isEmpty || !particleSystems.isEmpty
+        hasAnimatedShaderPasses
+            || !dynamicTextureSources.isEmpty
+            || !particleSystems.isEmpty
+    }
+
+    /// A pass animates per-frame when its shader samples `g_Time` /
+    /// `g_AudioSpectrum*` — i.e. WPE local effects (`effects/…`) and workshop
+    /// custom shaders (`workshop/…`). The static base shaders (`solidcolor`,
+    /// `genericimage2/4`, `compose`, `copy`) do not, so a scene built only on
+    /// those is genuinely static and may stay on the paused/on-demand path.
+    private static func pipelineHasAnimatedPasses(_ pipeline: WPEPreparedRenderPipeline) -> Bool {
+        pipeline.layers.contains { layer in
+            layer.passes.contains { prepared in
+                let shader = prepared.pass.shader.lowercased()
+                return shader.contains("effects/") || shader.contains("workshop/")
+            }
+        }
     }
 
     func applyPerformanceProfile(_ profile: WallpaperPerformanceProfile) {

--- a/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
+++ b/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
@@ -33,7 +33,7 @@ struct WPEMetalShaderDispatcher {
 
         switch WPEMetalShaderInputs.normalizedBuiltinShaderName(pass.pass.shader) {
         case "solidcolor":
-            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer)
+            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
             encoder.setRenderPipelineState(try executor.renderPipeline(
                 vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : "wpe_fullscreen_vertex",
                 fragmentName: "wpe_solidcolor_fragment",
@@ -58,7 +58,7 @@ struct WPEMetalShaderDispatcher {
             }
 
         case "solidlayer":
-            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer)
+            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
             encoder.setRenderPipelineState(try executor.renderPipeline(
                 vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : "wpe_fullscreen_vertex",
                 fragmentName: "wpe_solidlayer_fragment",
@@ -86,7 +86,7 @@ struct WPEMetalShaderDispatcher {
             let fragmentName = pass.pass.shader == "commands/copy"
                 ? "wpe_copy_fragment"
                 : "wpe_util_copy_fragment"
-            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer)
+            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
             encoder.setRenderPipelineState(try executor.renderPipeline(
                 vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : "wpe_fullscreen_vertex",
                 fragmentName: fragmentName,
@@ -340,7 +340,7 @@ struct WPEMetalShaderDispatcher {
             encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPEWaterUniforms>.stride, index: 0)
 
         case "genericimage2":
-            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer)
+            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
             encoder.setRenderPipelineState(try executor.renderPipeline(
                 vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : "wpe_fullscreen_vertex",
                 fragmentName: "wpe_genericimage2_fragment",
@@ -373,7 +373,7 @@ struct WPEMetalShaderDispatcher {
             }
 
         case "genericimage4":
-            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer)
+            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
             encoder.setRenderPipelineState(try executor.renderPipeline(
                 vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : "wpe_fullscreen_vertex",
                 fragmentName: "wpe_genericimage4_fragment",
@@ -693,7 +693,7 @@ struct WPEMetalShaderDispatcher {
             encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPEGenericParticleUniforms>.stride, index: 0)
 
         case "effect_shake":
-            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer)
+            let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
             encoder.setRenderPipelineState(try executor.renderPipeline(
                 vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : "wpe_fullscreen_vertex",
                 fragmentName: "wpe_effect_shake_fragment",
@@ -764,7 +764,7 @@ struct WPEMetalShaderDispatcher {
         depthPixelFormat: MTLPixelFormat
     ) throws {
         let result = try executor.compileCustomShader(for: pass)
-        let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer)
+        let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
         // Diagnostic for the hair/cloth "ghost": a displacement effect whose
         // custom .vert builds v_Direction / a resolution-scaled mask UV gets
         // that .vert discarded when usesObjectQuad forces the builtin

--- a/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
+++ b/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
@@ -47,6 +47,7 @@ struct WPEMetalShaderDispatcher {
                 var quadUniforms = executor.objectQuadUniforms(
                     for: layer,
                     sceneSize: frameState.sceneSize,
+                    cameraParallax: frameState.cameraParallax,
                     sourceTexture: destination.texture
                 )
                 encoder.setVertexBytes(
@@ -71,6 +72,7 @@ struct WPEMetalShaderDispatcher {
                 var quadUniforms = executor.objectQuadUniforms(
                     for: layer,
                     sceneSize: frameState.sceneSize,
+                    cameraParallax: frameState.cameraParallax,
                     sourceTexture: destination.texture
                 )
                 encoder.setVertexBytes(
@@ -108,6 +110,7 @@ struct WPEMetalShaderDispatcher {
                 var quadUniforms = executor.objectQuadUniforms(
                     for: layer,
                     sceneSize: frameState.sceneSize,
+                    cameraParallax: frameState.cameraParallax,
                     sourceTexture: texture
                 )
                 encoder.setVertexBytes(
@@ -359,6 +362,7 @@ struct WPEMetalShaderDispatcher {
                 var quadUniforms = executor.objectQuadUniforms(
                     for: layer,
                     sceneSize: frameState.sceneSize,
+                    cameraParallax: frameState.cameraParallax,
                     sourceTexture: texture
                 )
                 encoder.setVertexBytes(
@@ -429,6 +433,7 @@ struct WPEMetalShaderDispatcher {
                 var quadUniforms = executor.objectQuadUniforms(
                     for: layer,
                     sceneSize: frameState.sceneSize,
+                    cameraParallax: frameState.cameraParallax,
                     sourceTexture: primary
                 )
                 encoder.setVertexBytes(
@@ -726,6 +731,7 @@ struct WPEMetalShaderDispatcher {
                 var quadUniforms = executor.objectQuadUniforms(
                     for: layer,
                     sceneSize: frameState.sceneSize,
+                    cameraParallax: frameState.cameraParallax,
                     sourceTexture: texture
                 )
                 encoder.setVertexBytes(
@@ -853,6 +859,7 @@ struct WPEMetalShaderDispatcher {
             var quadUniforms = executor.objectQuadUniforms(
                 for: layer,
                 sceneSize: frameState.sceneSize,
+                cameraParallax: frameState.cameraParallax,
                 sourceTexture: primary ?? destination.texture
             )
             encoder.setVertexBytes(

--- a/LiveWallpaper/Runtime/WPEMetalShaderInputs.swift
+++ b/LiveWallpaper/Runtime/WPEMetalShaderInputs.swift
@@ -152,17 +152,12 @@ enum WPEMetalShaderInputs {
     }
 
     static func copyUniforms(for pass: WPEPreparedRenderPass, layer: WPERenderLayer) -> WPECopyUniforms {
-        let vector = pass.uniformValues["g_PointerPosition"]?.vectorValue ?? [0.5, 0.5]
-        let pointer = SIMD2<Double>(
-            vector[safe: 0] ?? 0.5,
-            vector[safe: 1] ?? 0.5
-        )
-        return WPECopyUniforms(
-            uvOffset: parallaxUVOffset(
-                pointerPosition: pointer,
-                parallaxDepth: layer.parallaxDepth
-            )
-        )
+        // Parallax is applied as a geometry translation in `objectQuadUniforms`
+        // (scene-targeted passes only), gated by the scene's camera-parallax
+        // settings. The legacy raw-pointer UV shift here is intentionally
+        // removed so it can't double-shift non-identity copy passes or move
+        // layers when camera parallax is disabled.
+        WPECopyUniforms(uvOffset: SIMD2<Float>(0, 0))
     }
 
     static func parallaxUVOffset(

--- a/LiveWallpaper/Runtime/WPEParticleSystem.swift
+++ b/LiveWallpaper/Runtime/WPEParticleSystem.swift
@@ -152,6 +152,9 @@ final class WPEParticleSystem {
     /// frame static texture, the executor binds a full-UV pass-through
     /// sprite-sheet uniform (cols=rows=frames=1, mask=0).
     let spriteSheet: WPEParticleSpriteSheet?
+    /// Camera-parallax depth of the owning particle object; drives the
+    /// per-frame parallax translation applied to the whole system at draw time.
+    var parallaxDepth: Double = 0
 
     private var aliveCount: Int = 0
     private var particles: [Particle]

--- a/LiveWallpaper/Runtime/WPETextRenderer.swift
+++ b/LiveWallpaper/Runtime/WPETextRenderer.swift
@@ -45,10 +45,11 @@ final class WPETextRenderer {
     /// Rasterize `object` to an MTLTexture sized to its measured bounds.
     func rasterize(_ object: WPESceneTextObject) -> (texture: MTLTexture, size: CGSize)? {
         ensureFontRegistered(object.fontRelativePath)
+        let fontSize = effectiveFontSize(for: object)
         let key = CacheKey(
             text: object.text,
             fontPath: object.fontRelativePath,
-            pointSize: Int(object.pointSize.rounded()),
+            pointSize: Int(fontSize.rounded()),
             colorRGB: SIMD3<Int>(
                 Int((object.color.x * 255).rounded()),
                 Int((object.color.y * 255).rounded()),
@@ -62,7 +63,7 @@ final class WPETextRenderer {
             return (cached.texture, cached.renderedSize)
         }
 
-        let attrString = makeAttributedString(object: object)
+        let attrString = makeAttributedString(object: object, fontSize: fontSize)
         let bounds = measureBounds(attrString, maxWidth: object.maxWidth)
         let width = max(1, ceil(bounds.width))
         let height = max(1, ceil(bounds.height))
@@ -99,10 +100,28 @@ final class WPETextRenderer {
         unmanagedError?.release()
     }
 
-    private func makeAttributedString(object: WPESceneTextObject) -> NSAttributedString {
+    /// Effective font size: when the object carries a WPE `boxSize`, scale the
+    /// font so the text fills the box minus `padding` (preserving aspect),
+    /// matching WPE which renders text as an image whose texture is `size`.
+    /// Without a box, fall back to the raw authored `pointSize`.
+    private func effectiveFontSize(for object: WPESceneTextObject) -> CGFloat {
+        let base = CGFloat(max(object.pointSize, 1))
+        guard let box = object.boxSize, box.x > 0, box.y > 0 else { return base }
+        let baseAttr = makeAttributedString(object: object, fontSize: base)
+        let natural = measureBounds(baseAttr, maxWidth: object.maxWidth)
+        let innerW = max(box.x - 2 * object.padding, 1)
+        let innerH = max(box.y - 2 * object.padding, 1)
+        let nw = max(Double(natural.width), 0.5)
+        let nh = max(Double(natural.height), 0.5)
+        let fit = min(innerW / nw, innerH / nh)
+        guard fit.isFinite, fit > 0 else { return base }
+        return base * CGFloat(fit)
+    }
+
+    private func makeAttributedString(object: WPESceneTextObject, fontSize: CGFloat) -> NSAttributedString {
         let font = resolveFont(
             relativePath: object.fontRelativePath,
-            size: CGFloat(object.pointSize)
+            size: fontSize
         )
         let color = CGColor(
             srgbRed: CGFloat(object.color.x),

--- a/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
+++ b/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
@@ -571,7 +571,13 @@ vertex WPETextOverlayVertexOut wpe_text_overlay_vertex(
         u.centerAndSize.w / halfHeight
     );
     WPETextOverlayVertexOut out;
-    out.position = float4(centerNDC + cornerNDC, 0.0, 1.0);
+    // WPE authors text in a top-left-origin space (y grows downward) and image
+    // layers map that to NDC via the camera's top-left ortho matrix. This
+    // overlay pass has no such matrix, so negate Y here — otherwise the text is
+    // placed in the wrong vertical half AND rendered upside-down (both halves of
+    // the same missing flip).
+    float2 ndc = centerNDC + cornerNDC;
+    out.position = float4(ndc.x, -ndc.y, 0.0, 1.0);
     out.uv = uv;
     return out;
 }

--- a/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
+++ b/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
@@ -469,9 +469,11 @@ vertex WPEParticleVertexOut wpe_particle_vertex(
                                   s * corner.x + c * corner.y);
     float halfWidth = max(projection.sceneSize.x, 1.0) * 0.5;
     float halfHeight = max(projection.sceneSize.y, 1.0) * 0.5;
+    // padding.xy = camera-parallax pixel offset for this system's depth.
+    float2 parallaxPixels = projection.padding.xy;
     float2 centerNDC = float2(
-        instance.positionAndSize.x / halfWidth,
-        instance.positionAndSize.y / halfHeight
+        (instance.positionAndSize.x + parallaxPixels.x) / halfWidth,
+        (instance.positionAndSize.y + parallaxPixels.y) / halfHeight
     );
     float2 cornerNDC = rotatedCorner * (instance.positionAndSize.w * 2.0)
         / float2(halfWidth * 2.0, halfHeight * 2.0);

--- a/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
+++ b/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
@@ -571,13 +571,16 @@ vertex WPETextOverlayVertexOut wpe_text_overlay_vertex(
         u.centerAndSize.w / halfHeight
     );
     WPETextOverlayVertexOut out;
-    // WPE authors text in a top-left-origin space (y grows downward) and image
-    // layers map that to NDC via the camera's top-left ortho matrix. This
-    // overlay pass has no such matrix, so negate Y here — otherwise the text is
-    // placed in the wrong vertical half AND rendered upside-down (both halves of
-    // the same missing flip).
-    float2 ndc = centerNDC + cornerNDC;
-    out.position = float4(ndc.x, -ndc.y, 0.0, 1.0);
+    // The vertical POSITION (centerNDC.y) is already correct in WPE's text
+    // space — the clock sits next to Miku's face — so it must NOT be flipped.
+    // Only the glyph's own vertical extent (cornerNDC.y) was inverted, which
+    // rendered the text upside-down; negate just that so the text reads upright
+    // while staying in the right place. X is untouched.
+    out.position = float4(
+        centerNDC.x + cornerNDC.x,
+        centerNDC.y - cornerNDC.y,
+        0.0, 1.0
+    );
     out.uv = uv;
     return out;
 }

--- a/LiveWallpaperTests/WPECameraParallaxTests.swift
+++ b/LiveWallpaperTests/WPECameraParallaxTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import LiveWallpaperCore
+import Testing
+@testable import LiveWallpaper
+
+@Suite("WPE camera parallax")
+struct WPECameraParallaxTests {
+
+    private func parse(_ payload: [String: Any]) throws -> WPESceneDocument {
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        return try WPESceneDocumentParser.parse(data: data)
+    }
+
+    private func minimalScene(general: [String: Any]) -> [String: Any] {
+        [
+            "camera": ["center": "0 0 0"],
+            "general": general,
+            "objects": [[
+                "id": "1", "name": "Solid", "type": "image",
+                "image": "models/util/solidlayer.json", "visible": true
+            ]]
+        ]
+    }
+
+    // MARK: - Parser
+
+    @Test("Parses camera parallax settings")
+    func parsesSettings() throws {
+        let doc = try parse(minimalScene(general: [
+            "orthogonalprojection": ["width": 2560, "height": 1440, "auto": true],
+            "cameraparallax": true,
+            "cameraparallaxamount": 0.8,
+            "cameraparallaxdelay": 0.2,
+            "cameraparallaxmouseinfluence": 0.4
+        ]))
+        let p = doc.general.cameraParallax
+        #expect(p.enabled == true)
+        #expect(abs(p.amount - 0.8) < 1e-9)
+        #expect(abs(p.delay - 0.2) < 1e-9)
+        #expect(abs(p.mouseInfluence - 0.4) < 1e-9)
+    }
+
+    @Test("Defaults to disabled with WPE default scalars when absent")
+    func defaultsWhenAbsent() throws {
+        let doc = try parse(minimalScene(general: [
+            "orthogonalprojection": ["width": 2560, "height": 1440, "auto": true]
+        ]))
+        #expect(doc.general.cameraParallax == .disabled)
+        #expect(doc.general.cameraParallax.enabled == false)
+        #expect(abs(doc.general.cameraParallax.amount - 0.5) < 1e-9)
+    }
+
+    // MARK: - pixelOffset
+
+    @Test("pixelOffset is zero for depth 0")
+    func pixelOffsetDepthZero() {
+        let frame = WPECameraParallaxFrame(smoothed: SIMD2<Float>(0.5, 0.5))
+        #expect(frame.pixelOffset(depth: 0, sceneSize: CGSize(width: 2560, height: 1440)) == SIMD2<Float>(0, 0))
+    }
+
+    @Test("pixelOffset sign: X negated, Y kept; magnitude scales with depth")
+    func pixelOffsetSign() {
+        let frame = WPECameraParallaxFrame(smoothed: SIMD2<Float>(0.2, 0.2))
+        let off = frame.pixelOffset(depth: 1.0, sceneSize: CGSize(width: 1000, height: 1000))
+        // uv = clamp(0.2 * 1.0 * 0.1, ±0.05) = 0.02 → (-0.02*1000, 0.02*1000)
+        #expect(abs(off.x - (-20)) < 1e-3)
+        #expect(abs(off.y - 20) < 1e-3)
+    }
+
+    @Test("pixelOffset clamps to ±0.05 UV regardless of depth/offset")
+    func pixelOffsetClamp() {
+        let frame = WPECameraParallaxFrame(smoothed: SIMD2<Float>(0.5, -0.5))
+        let off = frame.pixelOffset(depth: 10.0, sceneSize: CGSize(width: 1000, height: 1000))
+        // raw uv = 0.5 * 10 * 0.1 = 0.5 → clamps to 0.05 → (-50, ...)
+        #expect(abs(off.x - (-50)) < 1e-3)
+        #expect(abs(off.y - (-50)) < 1e-3)
+    }
+
+    // MARK: - Smoother
+
+    @Test("Disabled / amount 0 / mouseInfluence 0 produce neutral")
+    func smootherNoOp() {
+        var s = WPECameraParallaxSmoother()
+        let cursor = SIMD2<Double>(1, 1)
+        #expect(s.frame(settings: .disabled, pointerPosition: cursor, time: 0) == .neutral)
+        s.reset()
+        #expect(s.frame(settings: .init(enabled: true, amount: 0, delay: 0.1, mouseInfluence: 0.5),
+                        pointerPosition: cursor, time: 0) == .neutral)
+        s.reset()
+        #expect(s.frame(settings: .init(enabled: true, amount: 0.5, delay: 0.1, mouseInfluence: 0),
+                        pointerPosition: cursor, time: 0) == .neutral)
+    }
+
+    @Test("First frame snaps to the calibrated cursor target")
+    func smootherFirstFrameSnap() {
+        var s = WPECameraParallaxSmoother()
+        // WPE defaults → effectiveGlobal 1; cursor at right edge → target.x = 0.5
+        let frame = s.frame(settings: .init(enabled: true, amount: 0.5, delay: 0.1, mouseInfluence: 0.5),
+                            pointerPosition: SIMD2<Double>(1.0, 0.5), time: 0)
+        #expect(abs(frame.smoothed.x - 0.5) < 1e-5)
+        #expect(abs(frame.smoothed.y - 0.0) < 1e-5)
+    }
+
+    @Test("Smoothing converges to the same offset at 30 vs 144 FPS over equal elapsed time")
+    func smootherFrameRateIndependent() {
+        let settings = WPESceneCameraParallaxSettings(enabled: true, amount: 0.5, delay: 0.2, mouseInfluence: 0.5)
+        let cursor = SIMD2<Double>(1.0, 0.5)
+        func run(fps: Double) -> SIMD2<Float> {
+            var s = WPECameraParallaxSmoother()
+            let dt = 1.0 / fps
+            // prime first frame at the center so the snap doesn't dominate
+            _ = s.frame(settings: settings, pointerPosition: SIMD2<Double>(0.5, 0.5), time: 0)
+            var t = 0.0
+            // advance 1 second of cursor-at-edge
+            while t < 1.0 { t += dt; _ = s.frame(settings: settings, pointerPosition: cursor, time: t) }
+            return s.smoothed
+        }
+        let a = run(fps: 30)
+        let b = run(fps: 144)
+        #expect(abs(a.x - b.x) < 0.02)
+        #expect(abs(a.y - b.y) < 0.02)
+    }
+}

--- a/LiveWallpaperTests/WPEMetalSceneRendererTests.swift
+++ b/LiveWallpaperTests/WPEMetalSceneRendererTests.swift
@@ -182,7 +182,10 @@ struct WPEMetalSceneRendererTests {
         let uniforms = try #require(renderer.lastRuntimeUniforms)
         #expect(abs(uniforms.time - 1.25) < 0.0001)
         #expect(abs(uniforms.daytime - 0.5) < 0.0001)
-        #expect(uniforms.brightness == 0)
+        // Suspended renders at full brightness: g_Brightness multiplies image
+        // albedo, so 0 here would render every genericimage layer as a black
+        // silhouette. Suspension pauses via isPaused, not by dimming to black.
+        #expect(uniforms.brightness == 1)
         #expect(uniforms.pointerPosition == SIMD2<Double>(0.25, 0.75))
     }
 

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
@@ -365,7 +365,12 @@ public struct WPESceneCameraParallaxSettings: Equatable, Sendable {
     public let delay: Double
     public let mouseInfluence: Double
 
-    public init(enabled: Bool, amount: Double, delay: Double, mouseInfluence: Double) {
+    public init(
+        enabled: Bool = false,
+        amount: Double = 0.5,
+        delay: Double = 0.1,
+        mouseInfluence: Double = 0.5
+    ) {
         self.enabled = enabled
         self.amount = amount
         self.delay = delay

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
@@ -165,6 +165,13 @@ public struct WPESceneTextObject: Equatable, Sendable, Identifiable {
     public let verticalAlignment: String
     public let maxWidth: Double?
     public let parallaxDepth: Double
+    /// WPE's authored text-box size in scene pixels (`size`). A WPE text object
+    /// is an image layer whose texture is sized to this box; the text fills the
+    /// box minus `padding`, then the layer is placed at `origin × scale`. When
+    /// nil the renderer falls back to the rasterized text bounds.
+    public let boxSize: SIMD2<Double>?
+    /// Transparent margin (scene pixels) inside `boxSize` around the text.
+    public let padding: Double
 
     public init(
         id: String,
@@ -182,7 +189,9 @@ public struct WPESceneTextObject: Equatable, Sendable, Identifiable {
         horizontalAlignment: String,
         verticalAlignment: String,
         maxWidth: Double?,
-        parallaxDepth: Double
+        parallaxDepth: Double,
+        boxSize: SIMD2<Double>? = nil,
+        padding: Double = 0
     ) {
         self.id = id
         self.name = name
@@ -200,10 +209,38 @@ public struct WPESceneTextObject: Equatable, Sendable, Identifiable {
         self.verticalAlignment = verticalAlignment
         self.maxWidth = maxWidth
         self.parallaxDepth = parallaxDepth
+        self.boxSize = boxSize
+        self.padding = padding
     }
 
     public func resolvedAlpha(at time: Double) -> Double {
         alphaAnimation?.scalar(at: time) ?? alpha
+    }
+
+    /// Returns a copy carrying the live (scripted) text + resolved alpha while
+    /// preserving every other field — so the renderer's per-frame copy never
+    /// drops geometry like `boxSize`/`padding`.
+    public func withLiveText(_ liveText: String, alpha liveAlpha: Double) -> WPESceneTextObject {
+        WPESceneTextObject(
+            id: id,
+            name: name,
+            text: liveText,
+            textScript: textScript,
+            fontRelativePath: fontRelativePath,
+            pointSize: pointSize,
+            color: color,
+            alpha: liveAlpha,
+            alphaAnimation: alphaAnimation,
+            origin: origin,
+            scale: scale,
+            visible: visible,
+            horizontalAlignment: horizontalAlignment,
+            verticalAlignment: verticalAlignment,
+            maxWidth: maxWidth,
+            parallaxDepth: parallaxDepth,
+            boxSize: boxSize,
+            padding: padding
+        )
     }
 }
 

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
@@ -337,15 +337,43 @@ public struct WPESceneCamera: Equatable, Sendable {
 public struct WPESceneGeneral: Equatable, Sendable {
     public let clearColor: SIMD3<Double>
     public let orthogonalProjection: WPESceneOrthogonalProjection
+    public let cameraParallax: WPESceneCameraParallaxSettings
 
-    public init(clearColor: SIMD3<Double>, orthogonalProjection: WPESceneOrthogonalProjection) {
+    public init(
+        clearColor: SIMD3<Double>,
+        orthogonalProjection: WPESceneOrthogonalProjection,
+        cameraParallax: WPESceneCameraParallaxSettings = .disabled
+    ) {
         self.clearColor = clearColor
         self.orthogonalProjection = orthogonalProjection
+        self.cameraParallax = cameraParallax
     }
 
     public static let defaultGeneral = WPESceneGeneral(
         clearColor: SIMD3<Double>(0, 0, 0),
         orthogonalProjection: WPESceneOrthogonalProjection(width: 1920, height: 1080, auto: true)
+    )
+}
+
+/// WPE scene-level camera parallax: the whole scene follows the cursor, each
+/// layer shifting by its `parallaxDepth`. `amount`/`delay`/`mouseInfluence`
+/// mirror the WPE general settings; defaults match WPE so an enabled scene that
+/// omits them behaves like Wallpaper Engine. Disabled by default (no-op).
+public struct WPESceneCameraParallaxSettings: Equatable, Sendable {
+    public let enabled: Bool
+    public let amount: Double
+    public let delay: Double
+    public let mouseInfluence: Double
+
+    public init(enabled: Bool, amount: Double, delay: Double, mouseInfluence: Double) {
+        self.enabled = enabled
+        self.amount = amount
+        self.delay = delay
+        self.mouseInfluence = mouseInfluence
+    }
+
+    public static let disabled = WPESceneCameraParallaxSettings(
+        enabled: false, amount: 0.5, delay: 0.1, mouseInfluence: 0.5
     )
 }
 

--- a/cache/projects.json
+++ b/cache/projects.json
@@ -1,0 +1,3 @@
+{
+  "/Users/taijial/Xcode/LiveWallpaper/.claude/worktrees/vigorous-dijkstra-ccdb4f": "0644b8cb-8041-4f52-a1db-a4eb56fd2697"
+}

--- a/cache/projects.json
+++ b/cache/projects.json
@@ -1,3 +1,0 @@
-{
-  "/Users/taijial/Xcode/LiveWallpaper/.claude/worktrees/vigorous-dijkstra-ccdb4f": "0644b8cb-8041-4f52-a1db-a4eb56fd2697"
-}


### PR DESCRIPTION
Adds WPE scene-level **camera parallax** (`cameraparallax`/amount/delay/mouseinfluence): a frame-rate-independent smoothed cursor offset translates each layer by its `parallaxDepth` — applied to image quads, text overlays, particles, and full-frame layers (geometry shift, WPE-style clear-color borders; no-op when disabled). Planned + reviewed via codex/antigravity.

Also a batch of Metal-renderer fixes surfaced while validating it: suspended-profile black-silhouette (`g_Brightness=0`), scenes freezing after one frame when only shader effects animate, text overlay orientation + WPE box sizing, and `.jpg`→`.jpg.tex` particle-texture resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
