### PR TITLE
feat(wpe-2.8): GPU MSDF text + 2.8 migration (C–D)

### DIFF
--- a/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
@@ -401,6 +401,16 @@ enum WPESceneDocumentParser {
         // raw rasterized bounds at pointsize, which are far smaller.
         let boxSize = parseVector3(dict["size"]).map { SIMD2<Double>($0.x, $0.y) }
         let padding = parseDouble(dict["padding"]) ?? 0
+        // WPE 2.8 MSDF text effects. Keys are case-insensitive in the corpus, so
+        // accept both spaced and lowercased variants; all default to disabled.
+        let outlineSize = unwrapDouble(dict["outlinesize"]) ?? unwrapDouble(dict["outlineSize"]) ?? 0
+        let outlineColor = unwrapVector3(dict["outlinecolor"]) ?? SIMD3<Double>(0, 0, 0)
+        let blurSize = unwrapDouble(dict["blursize"]) ?? unwrapDouble(dict["blurSize"]) ?? 0
+        let shadowSize = unwrapDouble(dict["shadowsize"]) ?? unwrapDouble(dict["shadowSize"]) ?? 0
+        let shadowColor = unwrapVector3(dict["shadowcolor"]) ?? SIMD3<Double>(0, 0, 0)
+        let shadowOffsetVec = parseVector3(dict["shadowoffset"]).map { SIMD2<Double>($0.x, $0.y) }
+        let shadowOffset = shadowOffsetVec ?? SIMD2<Double>(0, 0)
+        let letterSpacing = unwrapDouble(dict["letterspacing"]) ?? unwrapDouble(dict["spacing"]) ?? 0
 
         return WPESceneTextObject(
             id: id,
@@ -420,7 +430,14 @@ enum WPESceneDocumentParser {
             maxWidth: maxWidth.map { max(1, $0) },
             parallaxDepth: parallaxDepth,
             boxSize: (boxSize.map { $0.x > 0 && $0.y > 0 } ?? false) ? boxSize : nil,
-            padding: max(0, padding)
+            padding: max(0, padding),
+            outlineSize: max(0, outlineSize),
+            outlineColor: outlineColor,
+            blurSize: max(0, blurSize),
+            shadowSize: max(0, shadowSize),
+            shadowColor: shadowColor,
+            shadowOffset: shadowOffset,
+            letterSpacing: letterSpacing
         )
     }
 

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
@@ -164,7 +164,7 @@ final class WPEMSDFAtlas {
             return cached
         }
 
-        guard let generated = generator.generate(glyph: key.glyph, font: font) else { return nil }
+        guard let generated = generator.generate(glyph: key.glyph, font: font, maxCellSide: pageSize) else { return nil }
         let bitmap = generated.bitmap
         guard bitmap.width <= pageSize, bitmap.height <= pageSize else { return nil }
         guard let allocation = allocate(width: bitmap.width, height: bitmap.height) else { return nil }

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
@@ -1,0 +1,272 @@
+#if !LITE_BUILD
+import CoreGraphics
+import CoreText
+import Foundation
+import Metal
+
+struct WPEMSDFGlyphKey: Hashable {
+    let fontID: String
+    let glyph: CGGlyph
+    let pixelSize: Int
+
+    init(fontID: String, glyph: CGGlyph, pixelSize: Int) {
+        self.fontID = fontID
+        self.glyph = glyph
+        self.pixelSize = max(pixelSize, 1)
+    }
+}
+
+struct WPEMSDFAtlasEntry {
+    let page: Int
+    let uvRect: CGRect
+    let pixelRect: CGRect
+    let metrics: WPEMSDFGlyphMetrics
+}
+
+@MainActor
+final class WPEMSDFAtlas {
+    private struct SkylineNode {
+        var x: Int
+        var y: Int
+        var width: Int
+    }
+
+    private final class Page {
+        let id: Int
+        let size: Int
+        var skyline: [SkylineNode]
+        var keys: Set<WPEMSDFGlyphKey> = []
+        var texture: MTLTexture?
+        var lastUsed: UInt64 = 0
+
+        init(id: Int, size: Int) {
+            self.id = id
+            self.size = size
+            self.skyline = [SkylineNode(x: 0, y: 0, width: size)]
+        }
+
+        func allocate(width: Int, height: Int) -> (x: Int, y: Int)? {
+            guard width > 0, height > 0, width <= size, height <= size else { return nil }
+            guard let position = findPosition(width: width, height: height) else { return nil }
+            addSkylineLevel(index: position.index, x: position.x, y: position.y, width: width, height: height)
+            return (x: position.x, y: position.y)
+        }
+
+        func reset() {
+            skyline = [SkylineNode(x: 0, y: 0, width: size)]
+            keys.removeAll(keepingCapacity: true)
+            texture = nil
+            lastUsed = 0
+        }
+
+        func ensureTexture(device: MTLDevice) -> MTLTexture? {
+            if let texture { return texture }
+            let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+                pixelFormat: .rgba8Unorm,
+                width: size,
+                height: size,
+                mipmapped: false
+            )
+            descriptor.usage = [.shaderRead]
+            descriptor.storageMode = .shared
+            guard let texture = device.makeTexture(descriptor: descriptor) else { return nil }
+            texture.label = "WPE MSDF atlas page \(id)"
+            WPEMetalTextureMetadataRegistry.shared.register(texture: texture)
+            self.texture = texture
+            return texture
+        }
+
+        private func findPosition(width: Int, height: Int) -> (index: Int, x: Int, y: Int)? {
+            var best: (index: Int, x: Int, y: Int)?
+            for index in skyline.indices {
+                let x = skyline[index].x
+                guard let y = fitY(index: index, width: width, height: height) else { continue }
+                if best == nil || y < best!.y || (y == best!.y && x < best!.x) {
+                    best = (index: index, x: x, y: y)
+                }
+            }
+            return best
+        }
+
+        private func fitY(index: Int, width: Int, height: Int) -> Int? {
+            let x = skyline[index].x
+            guard x + width <= size else { return nil }
+
+            var widthLeft = width
+            var y = skyline[index].y
+            var cursor = index
+            while widthLeft > 0 {
+                guard cursor < skyline.count else { return nil }
+                y = max(y, skyline[cursor].y)
+                guard y + height <= size else { return nil }
+                widthLeft -= skyline[cursor].width
+                cursor += 1
+            }
+            return y
+        }
+
+        private func addSkylineLevel(index: Int, x: Int, y: Int, width: Int, height: Int) {
+            skyline.insert(SkylineNode(x: x, y: y + height, width: width), at: index)
+
+            var cursor = index + 1
+            while cursor < skyline.count {
+                let previous = skyline[cursor - 1]
+                var current = skyline[cursor]
+                let previousEnd = previous.x + previous.width
+                guard current.x < previousEnd else { break }
+
+                let shrink = previousEnd - current.x
+                current.x += shrink
+                current.width -= shrink
+                if current.width <= 0 {
+                    skyline.remove(at: cursor)
+                } else {
+                    skyline[cursor] = current
+                    cursor += 1
+                }
+            }
+            mergeSkyline()
+        }
+
+        private func mergeSkyline() {
+            var index = 0
+            while index + 1 < skyline.count {
+                if skyline[index].y == skyline[index + 1].y {
+                    skyline[index].width += skyline[index + 1].width
+                    skyline.remove(at: index + 1)
+                } else {
+                    index += 1
+                }
+            }
+        }
+    }
+
+    private let device: MTLDevice
+    private let pageSize: Int
+    private let maxPages: Int
+    private var pages: [Page] = []
+    private var entries: [WPEMSDFGlyphKey: WPEMSDFAtlasEntry] = [:]
+    private var clock: UInt64 = 0
+
+    init(device: MTLDevice, pageSize: Int = 1024, maxPages: Int = 4) {
+        self.device = device
+        self.pageSize = max(pageSize, 1)
+        self.maxPages = max(maxPages, 1)
+    }
+
+    func entry(
+        for key: WPEMSDFGlyphKey,
+        generator: WPEMSDFGlyphGenerator,
+        font: CTFont
+    ) -> WPEMSDFAtlasEntry? {
+        if let cached = entries[key], let page = page(for: cached.page) {
+            touch(page)
+            return cached
+        }
+
+        guard let generated = generator.generate(glyph: key.glyph, font: font) else { return nil }
+        let bitmap = generated.bitmap
+        guard bitmap.width <= pageSize, bitmap.height <= pageSize else { return nil }
+        guard let allocation = allocate(width: bitmap.width, height: bitmap.height) else { return nil }
+        guard let texture = allocation.page.ensureTexture(device: device) else {
+            if allocation.page.keys.isEmpty {
+                allocation.page.reset()
+            }
+            return nil
+        }
+
+        let bytes = bitmap.rgba8Data()
+        let region = MTLRegionMake2D(allocation.x, allocation.y, bitmap.width, bitmap.height)
+        bytes.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            texture.replace(
+                region: region,
+                mipmapLevel: 0,
+                withBytes: baseAddress,
+                bytesPerRow: bitmap.width * 4
+            )
+        }
+
+        let inverseSize = 1.0 / CGFloat(pageSize)
+        let pixelRect = CGRect(
+            x: CGFloat(allocation.x),
+            y: CGFloat(allocation.y),
+            width: CGFloat(bitmap.width),
+            height: CGFloat(bitmap.height)
+        )
+        let entry = WPEMSDFAtlasEntry(
+            page: allocation.page.id,
+            uvRect: CGRect(
+                x: CGFloat(allocation.x) * inverseSize,
+                y: CGFloat(allocation.y) * inverseSize,
+                width: CGFloat(bitmap.width) * inverseSize,
+                height: CGFloat(bitmap.height) * inverseSize
+            ),
+            pixelRect: pixelRect,
+            metrics: generated.metrics
+        )
+        allocation.page.keys.insert(key)
+        entries[key] = entry
+        touch(allocation.page)
+        return entry
+    }
+
+    func texture(page id: Int) -> MTLTexture? {
+        guard let page = page(for: id), let texture = page.texture else { return nil }
+        touch(page)
+        return texture
+    }
+
+    func livePages() -> [(page: Int, texture: MTLTexture)] {
+        pages.compactMap { page in
+            guard let texture = page.texture else { return nil }
+            return (page: page.id, texture: texture)
+        }
+    }
+
+    private func allocate(width: Int, height: Int) -> (page: Page, x: Int, y: Int)? {
+        for page in pages.sorted(by: { $0.id < $1.id }) {
+            if let origin = page.allocate(width: width, height: height) {
+                return (page: page, x: origin.x, y: origin.y)
+            }
+        }
+
+        if pages.count < maxPages {
+            let page = Page(id: pages.count, size: pageSize)
+            pages.append(page)
+            guard let origin = page.allocate(width: width, height: height) else { return nil }
+            return (page: page, x: origin.x, y: origin.y)
+        }
+
+        guard let page = leastRecentlyUsedPage() else { return nil }
+        evict(page)
+        guard let origin = page.allocate(width: width, height: height) else { return nil }
+        return (page: page, x: origin.x, y: origin.y)
+    }
+
+    private func evict(_ page: Page) {
+        for key in page.keys {
+            entries[key] = nil
+        }
+        page.reset()
+    }
+
+    private func touch(_ page: Page) {
+        clock &+= 1
+        page.lastUsed = clock
+    }
+
+    private func leastRecentlyUsedPage() -> Page? {
+        pages.min { lhs, rhs in
+            if lhs.lastUsed == rhs.lastUsed {
+                return lhs.id < rhs.id
+            }
+            return lhs.lastUsed < rhs.lastUsed
+        }
+    }
+
+    private func page(for id: Int) -> Page? {
+        pages.first { $0.id == id }
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFEdgeColoring.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFEdgeColoring.swift
@@ -1,0 +1,121 @@
+#if !LITE_BUILD
+import Foundation
+
+enum WPEMSDFEdgeColoring {
+    private static let palette: [WPEMSDFEdgeColor] = [.yellow, .cyan, .magenta]
+
+    static func colorShape(_ shape: inout WPEMSDFShape, angleThreshold: Double) {
+        let threshold = max(angleThreshold, 0)
+        for contourIndex in shape.contours.indices {
+            colorContour(&shape.contours[contourIndex], angleThreshold: threshold)
+        }
+    }
+
+    private static func colorContour(_ contour: inout WPEMSDFContour, angleThreshold: Double) {
+        guard !contour.segments.isEmpty else { return }
+
+        var corners = cornerIndices(in: contour, angleThreshold: angleThreshold)
+        guard !corners.isEmpty else {
+            setAllSegments(in: &contour, to: .white)
+            return
+        }
+
+        if contour.segments.count == 1 {
+            contour.segments = splitIntoThirds(contour.segments[0])
+            corners = cornerIndices(in: contour, angleThreshold: angleThreshold)
+            if corners.isEmpty { corners = [0] }
+        } else if contour.segments.count == 2 {
+            contour.segments = contour.segments.flatMap { segment -> [WPEMSDFSegment] in
+                let halves = segment.split(at: 0.5)
+                return [halves.0, halves.1]
+            }
+            corners = cornerIndices(in: contour, angleThreshold: angleThreshold)
+            if corners.isEmpty { corners = [0, contour.segments.count / 2] }
+        }
+
+        if corners.count == 1 {
+            colorSingleCornerContour(&contour, corner: corners[0])
+            return
+        }
+
+        let colors = colorsForCornerCount(corners.count)
+        for offset in corners.indices {
+            let start = corners[offset]
+            let end = corners[(offset + 1) % corners.count]
+            assignSpan(in: &contour, start: start, end: end, color: colors[offset])
+        }
+    }
+
+    private static func cornerIndices(in contour: WPEMSDFContour, angleThreshold: Double) -> [Int] {
+        let count = contour.segments.count
+        guard count > 0 else { return [] }
+        var indices: [Int] = []
+        for index in 0..<count {
+            let previous = contour.segments[(index + count - 1) % count]
+            let current = contour.segments[index]
+            if cornerAngle(previous: previous, current: current) > angleThreshold {
+                indices.append(index)
+            }
+        }
+        return indices
+    }
+
+    private static func cornerAngle(previous: WPEMSDFSegment, current: WPEMSDFSegment) -> Double {
+        let a = previous.direction(at: 1)
+        let b = current.direction(at: 0)
+        guard WPEMSDFGeometryMath.length(a) > WPEMSDFGeometryMath.epsilon,
+              WPEMSDFGeometryMath.length(b) > WPEMSDFGeometryMath.epsilon else {
+            return 0
+        }
+        let dot = WPEMSDFGeometryMath.clamp(WPEMSDFGeometryMath.dot(a, b), -1, 1)
+        return acos(dot)
+    }
+
+    private static func splitIntoThirds(_ segment: WPEMSDFSegment) -> [WPEMSDFSegment] {
+        let firstSplit = segment.split(at: 1.0 / 3.0)
+        let secondSplit = firstSplit.1.split(at: 0.5)
+        return [firstSplit.0, secondSplit.0, secondSplit.1]
+    }
+
+    private static func colorSingleCornerContour(_ contour: inout WPEMSDFContour, corner: Int) {
+        let count = contour.segments.count
+        guard count > 0 else { return }
+        for offset in 0..<count {
+            let colorIndex = min(offset * palette.count / count, palette.count - 1)
+            let index = (corner + offset) % count
+            contour.segments[index].color = palette[colorIndex]
+        }
+    }
+
+    private static func colorsForCornerCount(_ count: Int) -> [WPEMSDFEdgeColor] {
+        guard count > 0 else { return [] }
+        var colors = (0..<count).map { palette[$0 % palette.count] }
+        if count > 1, colors.last == colors.first {
+            colors[colors.count - 1] = .cyan
+        }
+        return colors
+    }
+
+    private static func assignSpan(
+        in contour: inout WPEMSDFContour,
+        start: Int,
+        end: Int,
+        color: WPEMSDFEdgeColor
+    ) {
+        let count = contour.segments.count
+        guard count > 0 else { return }
+        var index = start
+        while true {
+            contour.segments[index].color = color
+            index = (index + 1) % count
+            if index == end { break }
+        }
+    }
+
+    private static func setAllSegments(in contour: inout WPEMSDFContour, to color: WPEMSDFEdgeColor) {
+        for index in contour.segments.indices {
+            contour.segments[index].color = color
+        }
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFFontMaterial.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFFontMaterial.swift
@@ -1,0 +1,59 @@
+#if !LITE_BUILD
+import Foundation
+import LiveWallpaperProWPE
+
+enum WPEMSDFFontMaterial {
+    struct Material {
+        let uniforms: [String: WPESceneShaderConstantValue]
+        let combos: [String: Int]
+    }
+
+    static func make(object: WPESceneTextObject, parameters: WPEMSDFParameters) -> Material {
+        let outlineEnabled = object.outlineSize > 0
+        let blurEnabled = object.blurSize > 0
+        let shadowEnabled = object.shadowSize > 0 || object.shadowOffset.x != 0 || object.shadowOffset.y != 0
+        let uniforms: [String: WPESceneShaderConstantValue] = [
+            "g_Color4": .vector([
+                clamped(object.color.x),
+                clamped(object.color.y),
+                clamped(object.color.z),
+                clamped(object.alpha)
+            ]),
+            "g_RenderVar0": .vector([
+                max(parameters.pixelRange, 0.001),
+                max(object.outlineSize, 0),
+                max(object.blurSize, 0),
+                max(object.shadowSize, 0)
+            ]),
+            "g_RenderVar1": .vector([
+                clamped(object.outlineColor.x),
+                clamped(object.outlineColor.y),
+                clamped(object.outlineColor.z),
+                object.shadowOffset.x
+            ]),
+            "g_RenderVar2": .vector([
+                clamped(object.shadowColor.x),
+                clamped(object.shadowColor.y),
+                clamped(object.shadowColor.z),
+                object.shadowOffset.y
+            ]),
+            "g_RenderVar3": .vector([shadowEnabled ? 1 : 0, 0, 0, 0]),
+            "g_HDRParams": .vector([1, 0.5, 0, 0])
+        ]
+        return Material(
+            uniforms: uniforms,
+            combos: [
+                "MSDF": 1,
+                "OUTLINE_ENABLED": outlineEnabled ? 1 : 0,
+                "BLUR_ENABLED": blurEnabled ? 1 : 0,
+                "DROP_SHADOW_ENABLED": shadowEnabled ? 1 : 0,
+                "COLORFONT": 0
+            ]
+        )
+    }
+
+    private static func clamped(_ value: Double) -> Double {
+        min(max(value, 0), 1)
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFGeometry.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFGeometry.swift
@@ -1,0 +1,367 @@
+#if !LITE_BUILD
+import CoreGraphics
+import Foundation
+import simd
+
+enum WPEMSDFGeometryMath {
+    static let epsilon = 1.0e-9
+
+    static func dot(_ a: WPEMSDFPoint, _ b: WPEMSDFPoint) -> Double {
+        a.x * b.x + a.y * b.y
+    }
+
+    static func cross(_ a: WPEMSDFPoint, _ b: WPEMSDFPoint) -> Double {
+        a.x * b.y - a.y * b.x
+    }
+
+    static func length(_ value: WPEMSDFPoint) -> Double {
+        sqrt(dot(value, value))
+    }
+
+    static func normalized(_ value: WPEMSDFPoint) -> WPEMSDFPoint {
+        let len = length(value)
+        guard len > epsilon else { return WPEMSDFPoint(0, 0) }
+        return value / len
+    }
+
+    static func clamp(_ value: Double, _ lower: Double, _ upper: Double) -> Double {
+        min(max(value, lower), upper)
+    }
+
+    static func lerp(_ a: WPEMSDFPoint, _ b: WPEMSDFPoint, _ t: Double) -> WPEMSDFPoint {
+        a + (b - a) * t
+    }
+}
+
+enum WPEMSDFSegment {
+    case linear(p0: WPEMSDFPoint, p1: WPEMSDFPoint, color: WPEMSDFEdgeColor)
+    case quadratic(p0: WPEMSDFPoint, c: WPEMSDFPoint, p1: WPEMSDFPoint, color: WPEMSDFEdgeColor)
+    case cubic(p0: WPEMSDFPoint, c0: WPEMSDFPoint, c1: WPEMSDFPoint, p1: WPEMSDFPoint, color: WPEMSDFEdgeColor)
+
+    var color: WPEMSDFEdgeColor {
+        get {
+            switch self {
+            case let .linear(_, _, color),
+                 let .quadratic(_, _, _, color),
+                 let .cubic(_, _, _, _, color):
+                return color
+            }
+        }
+        set {
+            switch self {
+            case let .linear(p0, p1, _):
+                self = .linear(p0: p0, p1: p1, color: newValue)
+            case let .quadratic(p0, c, p1, _):
+                self = .quadratic(p0: p0, c: c, p1: p1, color: newValue)
+            case let .cubic(p0, c0, c1, p1, _):
+                self = .cubic(p0: p0, c0: c0, c1: c1, p1: p1, color: newValue)
+            }
+        }
+    }
+
+    var startPoint: WPEMSDFPoint {
+        switch self {
+        case let .linear(p0, _, _),
+             let .quadratic(p0, _, _, _),
+             let .cubic(p0, _, _, _, _):
+            return p0
+        }
+    }
+
+    var endPoint: WPEMSDFPoint {
+        switch self {
+        case let .linear(_, p1, _),
+             let .quadratic(_, _, p1, _),
+             let .cubic(_, _, _, p1, _):
+            return p1
+        }
+    }
+
+    var controlPoints: [WPEMSDFPoint] {
+        switch self {
+        case let .linear(p0, p1, _):
+            return [p0, p1]
+        case let .quadratic(p0, c, p1, _):
+            return [p0, c, p1]
+        case let .cubic(p0, c0, c1, p1, _):
+            return [p0, c0, c1, p1]
+        }
+    }
+
+    func point(at t: Double) -> WPEMSDFPoint {
+        let t = WPEMSDFGeometryMath.clamp(t, 0, 1)
+        let u = 1 - t
+        switch self {
+        case let .linear(p0, p1, _):
+            return WPEMSDFGeometryMath.lerp(p0, p1, t)
+        case let .quadratic(p0, c, p1, _):
+            return p0 * (u * u) + c * (2 * u * t) + p1 * (t * t)
+        case let .cubic(p0, c0, c1, p1, _):
+            return p0 * (u * u * u) + c0 * (3 * u * u * t) + c1 * (3 * u * t * t) + p1 * (t * t * t)
+        }
+    }
+
+    func direction(at t: Double) -> WPEMSDFPoint {
+        let derivative = rawDerivative(at: t)
+        let normalized = WPEMSDFGeometryMath.normalized(derivative)
+        if WPEMSDFGeometryMath.length(normalized) > WPEMSDFGeometryMath.epsilon {
+            return normalized
+        }
+        return WPEMSDFGeometryMath.normalized(endPoint - startPoint)
+    }
+
+    func signedDistance(to p: WPEMSDFPoint) -> (distance: Double, orthogonality: Double) {
+        let t: Double
+        switch self {
+        case let .linear(p0, p1, _):
+            let edge = p1 - p0
+            let denom = WPEMSDFGeometryMath.dot(edge, edge)
+            t = denom > WPEMSDFGeometryMath.epsilon
+                ? WPEMSDFGeometryMath.clamp(WPEMSDFGeometryMath.dot(p - p0, edge) / denom, 0, 1)
+                : 0
+        case .quadratic:
+            t = nearestParameter(to: p, samples: 32, refinementSteps: 6)
+        case .cubic:
+            t = nearestParameter(to: p, samples: 64, refinementSteps: 8)
+        }
+        return distance(at: t, to: p)
+    }
+
+    func split(at t: Double) -> (WPEMSDFSegment, WPEMSDFSegment) {
+        let t = WPEMSDFGeometryMath.clamp(t, 0, 1)
+        switch self {
+        case let .linear(p0, p1, color):
+            let p = WPEMSDFGeometryMath.lerp(p0, p1, t)
+            return (
+                .linear(p0: p0, p1: p, color: color),
+                .linear(p0: p, p1: p1, color: color)
+            )
+        case let .quadratic(p0, c, p1, color):
+            let p01 = WPEMSDFGeometryMath.lerp(p0, c, t)
+            let p12 = WPEMSDFGeometryMath.lerp(c, p1, t)
+            let p012 = WPEMSDFGeometryMath.lerp(p01, p12, t)
+            return (
+                .quadratic(p0: p0, c: p01, p1: p012, color: color),
+                .quadratic(p0: p012, c: p12, p1: p1, color: color)
+            )
+        case let .cubic(p0, c0, c1, p1, color):
+            let p01 = WPEMSDFGeometryMath.lerp(p0, c0, t)
+            let p12 = WPEMSDFGeometryMath.lerp(c0, c1, t)
+            let p23 = WPEMSDFGeometryMath.lerp(c1, p1, t)
+            let p012 = WPEMSDFGeometryMath.lerp(p01, p12, t)
+            let p123 = WPEMSDFGeometryMath.lerp(p12, p23, t)
+            let p0123 = WPEMSDFGeometryMath.lerp(p012, p123, t)
+            return (
+                .cubic(p0: p0, c0: p01, c1: p012, p1: p0123, color: color),
+                .cubic(p0: p0123, c0: p123, c1: p23, p1: p1, color: color)
+            )
+        }
+    }
+
+    func transformed(scale: Double, translate: WPEMSDFPoint) -> WPEMSDFSegment {
+        func map(_ p: WPEMSDFPoint) -> WPEMSDFPoint { p * scale + translate }
+        switch self {
+        case let .linear(p0, p1, color):
+            return .linear(p0: map(p0), p1: map(p1), color: color)
+        case let .quadratic(p0, c, p1, color):
+            return .quadratic(p0: map(p0), c: map(c), p1: map(p1), color: color)
+        case let .cubic(p0, c0, c1, p1, color):
+            return .cubic(p0: map(p0), c0: map(c0), c1: map(c1), p1: map(p1), color: color)
+        }
+    }
+
+    private func rawDerivative(at t: Double) -> WPEMSDFPoint {
+        let t = WPEMSDFGeometryMath.clamp(t, 0, 1)
+        let u = 1 - t
+        switch self {
+        case let .linear(p0, p1, _):
+            return p1 - p0
+        case let .quadratic(p0, c, p1, _):
+            return (c - p0) * (2 * u) + (p1 - c) * (2 * t)
+        case let .cubic(p0, c0, c1, p1, _):
+            return (c0 - p0) * (3 * u * u) + (c1 - c0) * (6 * u * t) + (p1 - c1) * (3 * t * t)
+        }
+    }
+
+    private func rawSecondDerivative(at t: Double) -> WPEMSDFPoint {
+        let t = WPEMSDFGeometryMath.clamp(t, 0, 1)
+        switch self {
+        case .linear:
+            return WPEMSDFPoint(0, 0)
+        case let .quadratic(p0, c, p1, _):
+            return (p1 - c * 2 + p0) * 2
+        case let .cubic(p0, c0, c1, p1, _):
+            return (c1 - c0 * 2 + p0) * (6 * (1 - t)) + (p1 - c1 * 2 + c0) * (6 * t)
+        }
+    }
+
+    private func nearestParameter(to p: WPEMSDFPoint, samples: Int, refinementSteps: Int) -> Double {
+        var bestT = 0.0
+        var bestDistance = Double.greatestFiniteMagnitude
+        for i in 0...samples {
+            let t = Double(i) / Double(samples)
+            let delta = point(at: t) - p
+            let d2 = WPEMSDFGeometryMath.dot(delta, delta)
+            if d2 < bestDistance {
+                bestDistance = d2
+                bestT = t
+            }
+        }
+
+        var t = bestT
+        for _ in 0..<refinementSteps {
+            let q = point(at: t)
+            let d1 = rawDerivative(at: t)
+            let d2 = rawSecondDerivative(at: t)
+            let delta = q - p
+            let numerator = WPEMSDFGeometryMath.dot(delta, d1)
+            let denominator = WPEMSDFGeometryMath.dot(d1, d1) + WPEMSDFGeometryMath.dot(delta, d2)
+            guard abs(denominator) > WPEMSDFGeometryMath.epsilon else { break }
+            t = WPEMSDFGeometryMath.clamp(t - numerator / denominator, 0, 1)
+        }
+        return t
+    }
+
+    private func distance(at t: Double, to p: WPEMSDFPoint) -> (distance: Double, orthogonality: Double) {
+        let q = point(at: t)
+        let delta = p - q
+        let magnitude = WPEMSDFGeometryMath.length(delta)
+        let tangent = direction(at: t)
+        let sign = WPEMSDFGeometryMath.cross(tangent, delta) >= 0 ? 1.0 : -1.0
+        let orthogonality = magnitude > WPEMSDFGeometryMath.epsilon
+            ? abs(WPEMSDFGeometryMath.dot(delta / magnitude, tangent))
+            : 0
+        return (distance: sign * magnitude, orthogonality: orthogonality)
+    }
+}
+
+struct WPEMSDFContour {
+    var segments: [WPEMSDFSegment]
+}
+
+struct WPEMSDFShape {
+    var contours: [WPEMSDFContour]
+
+    func bounds() -> CGRect {
+        var hasPoint = false
+        var minX = Double.greatestFiniteMagnitude
+        var minY = Double.greatestFiniteMagnitude
+        var maxX = -Double.greatestFiniteMagnitude
+        var maxY = -Double.greatestFiniteMagnitude
+
+        for contour in contours {
+            for segment in contour.segments {
+                for point in segment.controlPoints {
+                    hasPoint = true
+                    minX = min(minX, point.x)
+                    minY = min(minY, point.y)
+                    maxX = max(maxX, point.x)
+                    maxY = max(maxY, point.y)
+                }
+            }
+        }
+
+        guard hasPoint else { return .null }
+        return CGRect(
+            x: CGFloat(minX),
+            y: CGFloat(minY),
+            width: CGFloat(maxX - minX),
+            height: CGFloat(maxY - minY)
+        )
+    }
+
+    mutating func applyTransform(scale: Double, translate: WPEMSDFPoint) {
+        for contourIndex in contours.indices {
+            for segmentIndex in contours[contourIndex].segments.indices {
+                contours[contourIndex].segments[segmentIndex] = contours[contourIndex].segments[segmentIndex].transformed(
+                    scale: scale,
+                    translate: translate
+                )
+            }
+        }
+    }
+
+    func signedDistance(at point: WPEMSDFPoint, channel: WPEMSDFEdgeColor) -> Double {
+        let closest = closestDistance(at: point, channel: channel) ?? closestDistance(at: point, channel: nil)
+        guard let closest else { return 0 }
+        let sign = windingNumber(at: point) == 0 ? -1.0 : 1.0
+        return sign * abs(closest.distance)
+    }
+
+    private func closestDistance(
+        at point: WPEMSDFPoint,
+        channel: WPEMSDFEdgeColor?
+    ) -> (distance: Double, orthogonality: Double)? {
+        var best: (distance: Double, orthogonality: Double)?
+        for contour in contours {
+            for segment in contour.segments {
+                if let channel, !segment.color.contains(channel) {
+                    continue
+                }
+                let candidate = segment.signedDistance(to: point)
+                if isBetter(candidate, than: best) {
+                    best = candidate
+                }
+            }
+        }
+        return best
+    }
+
+    private func isBetter(
+        _ candidate: (distance: Double, orthogonality: Double),
+        than current: (distance: Double, orthogonality: Double)?
+    ) -> Bool {
+        guard let current else { return true }
+        let candidateDistance = abs(candidate.distance)
+        let currentDistance = abs(current.distance)
+        if abs(candidateDistance - currentDistance) > 1.0e-7 {
+            return candidateDistance < currentDistance
+        }
+        return candidate.orthogonality < current.orthogonality
+    }
+
+    private func windingNumber(at point: WPEMSDFPoint) -> Int {
+        var winding = 0
+        for contour in contours {
+            for segment in contour.segments {
+                let steps = flattenedStepCount(for: segment)
+                var previous = segment.point(at: 0)
+                for step in 1...steps {
+                    let t = Double(step) / Double(steps)
+                    let current = segment.point(at: t)
+                    addWindingEdge(from: previous, to: current, point: point, winding: &winding)
+                    previous = current
+                }
+            }
+        }
+        return winding
+    }
+
+    private func flattenedStepCount(for segment: WPEMSDFSegment) -> Int {
+        switch segment {
+        case .linear:
+            return 1
+        case .quadratic:
+            return 24
+        case .cubic:
+            return 48
+        }
+    }
+
+    private func addWindingEdge(
+        from a: WPEMSDFPoint,
+        to b: WPEMSDFPoint,
+        point: WPEMSDFPoint,
+        winding: inout Int
+    ) {
+        guard WPEMSDFGeometryMath.length(b - a) > WPEMSDFGeometryMath.epsilon else { return }
+        if a.y <= point.y {
+            if b.y > point.y && WPEMSDFGeometryMath.cross(b - a, point - a) > 0 {
+                winding += 1
+            }
+        } else if b.y <= point.y && WPEMSDFGeometryMath.cross(b - a, point - a) < 0 {
+            winding -= 1
+        }
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFGlyphGenerator.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFGlyphGenerator.swift
@@ -12,10 +12,14 @@ final class WPEMSDFGlyphGenerator {
         self.parameters = parameters
     }
 
-    func generate(glyph: CGGlyph, font: CTFont) -> (bitmap: WPEMSDFBitmap, metrics: WPEMSDFGlyphMetrics)? {
-        let padding = max(parameters.padding, 0)
-        let pointSize = max(Int(ceil(CTFontGetSize(font))), 1)
-        let cellSide = max(pointSize + padding * 2, 1)
+    func generate(
+        glyph: CGGlyph,
+        font: CTFont,
+        maxCellSide: Int? = nil
+    ) -> (bitmap: WPEMSDFBitmap, metrics: WPEMSDFGlyphMetrics)? {
+        guard let sizing = cellSizing(font: font, maxCellSide: maxCellSide) else { return nil }
+        let padding = sizing.padding
+        let cellSide = sizing.cellSide
         let advance = advanceForGlyph(glyph, font: font)
         let pathUnitsToEm = pathUnitsToEmUnits(font: font)
 
@@ -88,6 +92,23 @@ final class WPEMSDFGlyphGenerator {
             emUnitsPerPixel: pathUnitsToEm / scale
         )
         return (bitmap: bitmap, metrics: metrics)
+    }
+
+    /// Resolves the square cell size, rejecting non-finite or overflowing font
+    /// sizes (so `Int(ceil(...))` never traps) and any cell larger than the
+    /// atlas page can hold.
+    private func cellSizing(font: CTFont, maxCellSide: Int?) -> (padding: Int, cellSide: Int)? {
+        let padding = max(parameters.padding, 0)
+        let limit = max(maxCellSide ?? Int.max, 1)
+        let rawSize = CTFontGetSize(font)
+        guard rawSize.isFinite, rawSize > 0 else { return nil }
+        let roundedSize = ceil(rawSize)
+        guard roundedSize <= CGFloat(Int.max) else { return nil }
+        let pointSize = max(Int(roundedSize), 1)
+        guard padding <= (Int.max - pointSize) / 2 else { return nil }
+        let cellSide = pointSize + padding * 2
+        guard cellSide <= limit else { return nil }
+        return (padding, cellSide)
     }
 
     private func neutralResult(

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFGlyphGenerator.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFGlyphGenerator.swift
@@ -1,0 +1,201 @@
+#if !LITE_BUILD
+import CoreGraphics
+import CoreText
+import Foundation
+import simd
+
+final class WPEMSDFGlyphGenerator {
+    private let parameters: WPEMSDFParameters
+    private static let neutralFill = SIMD4<Float>(0.5, 0.5, 0.5, 1)
+
+    init(parameters: WPEMSDFParameters = WPEMSDFParameters()) {
+        self.parameters = parameters
+    }
+
+    func generate(glyph: CGGlyph, font: CTFont) -> (bitmap: WPEMSDFBitmap, metrics: WPEMSDFGlyphMetrics)? {
+        let padding = max(parameters.padding, 0)
+        let pointSize = max(Int(ceil(CTFontGetSize(font))), 1)
+        let cellSide = max(pointSize + padding * 2, 1)
+        let advance = advanceForGlyph(glyph, font: font)
+        let pathUnitsToEm = pathUnitsToEmUnits(font: font)
+
+        guard let path = CTFontCreatePathForGlyph(font, glyph, nil) else {
+            return neutralResult(
+                cellSide: cellSide,
+                padding: padding,
+                advance: advance * pathUnitsToEm,
+                emUnitsPerPixel: pathUnitsToEm
+            )
+        }
+
+        var shape = buildShape(from: path)
+        let sourceBounds = shape.bounds()
+        guard !shape.contours.isEmpty, !sourceBounds.isNull else {
+            return neutralResult(
+                cellSide: cellSide,
+                padding: padding,
+                advance: advance * pathUnitsToEm,
+                emUnitsPerPixel: pathUnitsToEm
+            )
+        }
+
+        let sourceWidth = Double(sourceBounds.width)
+        let sourceHeight = Double(sourceBounds.height)
+        let available = max(Double(cellSide - padding * 2), 1)
+        let widthScale = sourceWidth > WPEMSDFGeometryMath.epsilon ? available / sourceWidth : Double.greatestFiniteMagnitude
+        let heightScale = sourceHeight > WPEMSDFGeometryMath.epsilon ? available / sourceHeight : Double.greatestFiniteMagnitude
+        let scale = min(widthScale, heightScale)
+        guard scale.isFinite, scale > WPEMSDFGeometryMath.epsilon else {
+            return neutralResult(
+                cellSide: cellSide,
+                padding: padding,
+                advance: advance * pathUnitsToEm,
+                emUnitsPerPixel: pathUnitsToEm
+            )
+        }
+
+        let contentWidth = sourceWidth * scale
+        let contentHeight = sourceHeight * scale
+        let translate = WPEMSDFPoint(
+            Double(padding) + (available - contentWidth) * 0.5 - Double(sourceBounds.minX) * scale,
+            Double(padding) + (available - contentHeight) * 0.5 - Double(sourceBounds.minY) * scale
+        )
+
+        shape.applyTransform(scale: scale, translate: translate)
+        WPEMSDFEdgeColoring.colorShape(&shape, angleThreshold: parameters.angleThreshold)
+
+        let pixelRange = max(parameters.pixelRange, 0.001)
+        var bitmap = WPEMSDFBitmap(width: cellSide, height: cellSide, fill: Self.neutralFill)
+        for y in 0..<bitmap.height {
+            for x in 0..<bitmap.width {
+                let point = WPEMSDFPoint(Double(x) + 0.5, Double(y) + 0.5)
+                bitmap[x, y] = SIMD4<Float>(
+                    encodedDistance(shape.signedDistance(at: point, channel: .red), pixelRange: pixelRange),
+                    encodedDistance(shape.signedDistance(at: point, channel: .green), pixelRange: pixelRange),
+                    encodedDistance(shape.signedDistance(at: point, channel: .blue), pixelRange: pixelRange),
+                    1
+                )
+            }
+        }
+
+        let cellOrigin = WPEMSDFPoint(-translate.x / scale, -translate.y / scale)
+        let metrics = WPEMSDFGlyphMetrics(
+            cellSize: CGSize(width: cellSide, height: cellSide),
+            bearing: cellOrigin * pathUnitsToEm,
+            advance: advance * pathUnitsToEm,
+            scale: scale,
+            translate: translate,
+            emUnitsPerPixel: pathUnitsToEm / scale
+        )
+        return (bitmap: bitmap, metrics: metrics)
+    }
+
+    private func neutralResult(
+        cellSide: Int,
+        padding: Int,
+        advance: WPEMSDFPoint,
+        emUnitsPerPixel: Double
+    ) -> (bitmap: WPEMSDFBitmap, metrics: WPEMSDFGlyphMetrics) {
+        let metrics = WPEMSDFGlyphMetrics(
+            cellSize: CGSize(width: cellSide, height: cellSide),
+            bearing: WPEMSDFPoint(0, 0),
+            advance: advance,
+            scale: 1,
+            translate: WPEMSDFPoint(Double(padding), Double(padding)),
+            emUnitsPerPixel: emUnitsPerPixel
+        )
+        return (
+            bitmap: WPEMSDFBitmap(width: cellSide, height: cellSide, fill: Self.neutralFill),
+            metrics: metrics
+        )
+    }
+
+    private func buildShape(from path: CGPath) -> WPEMSDFShape {
+        var contours: [WPEMSDFContour] = []
+        var segments: [WPEMSDFSegment] = []
+        var currentPoint: WPEMSDFPoint?
+        var contourStart: WPEMSDFPoint?
+
+        func finishContour() {
+            guard !segments.isEmpty else { return }
+            contours.append(WPEMSDFContour(segments: segments))
+            segments.removeAll(keepingCapacity: true)
+            currentPoint = nil
+            contourStart = nil
+        }
+
+        func closeContourIfNeeded() {
+            guard let currentPoint, let contourStart else { return }
+            if Self.distance(currentPoint, contourStart) > WPEMSDFGeometryMath.epsilon {
+                segments.append(.linear(p0: currentPoint, p1: contourStart, color: .white))
+            }
+        }
+
+        path.applyWithBlock { elementPointer in
+            let element = elementPointer.pointee
+            switch element.type {
+            case .moveToPoint:
+                finishContour()
+                let point = Self.point(from: element.points[0])
+                currentPoint = point
+                contourStart = point
+            case .addLineToPoint:
+                guard let current = currentPoint else { return }
+                let point = Self.point(from: element.points[0])
+                if Self.distance(current, point) > WPEMSDFGeometryMath.epsilon {
+                    segments.append(.linear(p0: current, p1: point, color: .white))
+                }
+                currentPoint = point
+            case .addQuadCurveToPoint:
+                guard let current = currentPoint else { return }
+                let control = Self.point(from: element.points[0])
+                let point = Self.point(from: element.points[1])
+                segments.append(.quadratic(p0: current, c: control, p1: point, color: .white))
+                currentPoint = point
+            case .addCurveToPoint:
+                guard let current = currentPoint else { return }
+                let control0 = Self.point(from: element.points[0])
+                let control1 = Self.point(from: element.points[1])
+                let point = Self.point(from: element.points[2])
+                segments.append(.cubic(p0: current, c0: control0, c1: control1, p1: point, color: .white))
+                currentPoint = point
+            case .closeSubpath:
+                closeContourIfNeeded()
+                finishContour()
+            @unknown default:
+                break
+            }
+        }
+
+        finishContour()
+        return WPEMSDFShape(contours: contours)
+    }
+
+    private func encodedDistance(_ distance: Double, pixelRange: Double) -> Float {
+        let value = 0.5 + distance / pixelRange
+        guard value.isFinite else { return 0.5 }
+        return Float(min(max(value, 0), 1))
+    }
+
+    private func advanceForGlyph(_ glyph: CGGlyph, font: CTFont) -> WPEMSDFPoint {
+        var glyphValue = glyph
+        var advance = CGSize.zero
+        CTFontGetAdvancesForGlyphs(font, .horizontal, &glyphValue, &advance, 1)
+        return WPEMSDFPoint(Double(advance.width), Double(advance.height))
+    }
+
+    private func pathUnitsToEmUnits(font: CTFont) -> Double {
+        let unitsPerEm = max(Double(CTFontGetUnitsPerEm(font)), 1)
+        let fontSize = max(Double(CTFontGetSize(font)), 1.0e-6)
+        return unitsPerEm / fontSize
+    }
+
+    private static func point(from point: CGPoint) -> WPEMSDFPoint {
+        WPEMSDFPoint(Double(point.x), Double(point.y))
+    }
+
+    private static func distance(_ a: WPEMSDFPoint, _ b: WPEMSDFPoint) -> Double {
+        WPEMSDFGeometryMath.length(a - b)
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
@@ -1,0 +1,166 @@
+#if !LITE_BUILD
+import CoreGraphics
+import CoreText
+import Foundation
+import LiveWallpaperProWPE
+import simd
+
+struct WPEMSDFTextVertex {
+    var position: SIMD2<Float>
+    var uv: SIMD2<Float>
+}
+
+struct WPEMSDFTextMesh {
+    var perPage: [Int: [WPEMSDFTextVertex]]
+    var size: CGSize
+}
+
+@MainActor
+struct WPEMSDFTextLayout {
+    func layout(
+        object: WPESceneTextObject,
+        font: CTFont,
+        atlas: WPEMSDFAtlas,
+        generator: WPEMSDFGlyphGenerator,
+        fontID: String
+    ) -> WPEMSDFTextMesh? {
+        guard !object.text.isEmpty else { return nil }
+        let attributed = attributedString(for: object, font: font)
+        let line = CTLineCreateWithAttributedString(attributed)
+        var ascent: CGFloat = 0
+        var descent: CGFloat = 0
+        var leading: CGFloat = 0
+        let rawLineWidth = CGFloat(CTLineGetTypographicBounds(line, &ascent, &descent, &leading))
+        let naturalHeight = max(ascent + descent + leading, 1)
+        let padding = CGFloat(max(object.padding, 0))
+        let maxWidth = object.maxWidth.map { CGFloat(max($0, 1)) }
+        let fittedLineWidth = maxWidth.map { min(max(rawLineWidth, 1), $0) } ?? max(rawLineWidth, 1)
+        let xScale = rawLineWidth > 0 ? Double(fittedLineWidth / rawLineWidth) : 1
+        let boxSize = object.boxSize.map {
+            CGSize(width: max($0.x, 1), height: max($0.y, 1))
+        } ?? CGSize(
+            width: fittedLineWidth + padding * 2,
+            height: naturalHeight + padding * 2
+        )
+        let innerWidth = max(boxSize.width - padding * 2, 1)
+        let innerHeight = max(boxSize.height - padding * 2, 1)
+        let alignedLineWidth = min(fittedLineWidth, innerWidth)
+        let xOffset = padding + horizontalOffset(
+            alignment: object.horizontalAlignment,
+            lineWidth: alignedLineWidth,
+            innerWidth: innerWidth
+        )
+        let baseline = padding + baselineOffset(
+            alignment: object.verticalAlignment,
+            ascent: ascent,
+            descent: descent,
+            naturalHeight: naturalHeight,
+            innerHeight: innerHeight
+        )
+        let pathUnitsToEm = Self.pathUnitsToEmUnits(font: font)
+        let pixelSize = max(Int(ceil(CTFontGetSize(font))), 1)
+        let runs = CTLineGetGlyphRuns(line) as! [CTRun]
+        var perPage: [Int: [WPEMSDFTextVertex]] = [:]
+
+        for run in runs {
+            let glyphCount = CTRunGetGlyphCount(run)
+            guard glyphCount > 0 else { continue }
+            let range = CFRange(location: 0, length: glyphCount)
+            var glyphs = [CGGlyph](repeating: 0, count: glyphCount)
+            var positions = [CGPoint](repeating: .zero, count: glyphCount)
+            var advances = [CGSize](repeating: .zero, count: glyphCount)
+            CTRunGetGlyphs(run, range, &glyphs)
+            CTRunGetPositions(run, range, &positions)
+            CTRunGetAdvances(run, range, &advances)
+
+            for index in 0..<glyphCount {
+                let glyph = glyphs[index]
+                let key = WPEMSDFGlyphKey(fontID: fontID, glyph: glyph, pixelSize: pixelSize)
+                guard let entry = atlas.entry(for: key, generator: generator, font: font) else { return nil }
+                let position = positions[index]
+                let bearing = entry.metrics.bearing / pathUnitsToEm
+                let glyphWidth = Double(entry.metrics.cellSize.width) / entry.metrics.scale
+                let glyphHeight = Double(entry.metrics.cellSize.height) / entry.metrics.scale
+                let x = Double(xOffset) + Double(position.x) * xScale + bearing.x * xScale
+                let y = Double(baseline) - Double(position.y) - (bearing.y + glyphHeight)
+                appendQuad(
+                    page: entry.page,
+                    rect: CGRect(x: x, y: y, width: glyphWidth * xScale, height: glyphHeight),
+                    uvRect: entry.uvRect,
+                    perPage: &perPage
+                )
+                _ = advances[index]
+            }
+        }
+
+        guard !perPage.isEmpty else { return nil }
+        return WPEMSDFTextMesh(perPage: perPage, size: boxSize)
+    }
+
+    private func attributedString(for object: WPESceneTextObject, font: CTFont) -> CFAttributedString {
+        var attributes: [CFString: Any] = [kCTFontAttributeName: font]
+        if object.letterSpacing != 0 {
+            attributes[kCTKernAttributeName] = object.letterSpacing
+        }
+        return CFAttributedStringCreate(nil, object.text as CFString, attributes as CFDictionary)!
+    }
+
+    private func horizontalOffset(alignment: String, lineWidth: CGFloat, innerWidth: CGFloat) -> CGFloat {
+        switch alignment.lowercased() {
+        case "left":
+            return 0
+        case "right":
+            return max(innerWidth - lineWidth, 0)
+        default:
+            return max((innerWidth - lineWidth) * 0.5, 0)
+        }
+    }
+
+    private func baselineOffset(
+        alignment: String,
+        ascent: CGFloat,
+        descent: CGFloat,
+        naturalHeight: CGFloat,
+        innerHeight: CGFloat
+    ) -> CGFloat {
+        switch alignment.lowercased() {
+        case "top":
+            return ascent
+        case "bottom":
+            return max(innerHeight - descent, ascent)
+        default:
+            return max((innerHeight - naturalHeight) * 0.5, 0) + ascent
+        }
+    }
+
+    private func appendQuad(
+        page: Int,
+        rect: CGRect,
+        uvRect: CGRect,
+        perPage: inout [Int: [WPEMSDFTextVertex]]
+    ) {
+        let x0 = Float(rect.minX)
+        let y0 = Float(rect.minY)
+        let x1 = Float(rect.maxX)
+        let y1 = Float(rect.maxY)
+        let u0 = Float(uvRect.minX)
+        let v0 = Float(uvRect.minY)
+        let u1 = Float(uvRect.maxX)
+        let v1 = Float(uvRect.maxY)
+        perPage[page, default: []].append(contentsOf: [
+            WPEMSDFTextVertex(position: SIMD2<Float>(x0, y0), uv: SIMD2<Float>(u0, v0)),
+            WPEMSDFTextVertex(position: SIMD2<Float>(x1, y0), uv: SIMD2<Float>(u1, v0)),
+            WPEMSDFTextVertex(position: SIMD2<Float>(x0, y1), uv: SIMD2<Float>(u0, v1)),
+            WPEMSDFTextVertex(position: SIMD2<Float>(x1, y0), uv: SIMD2<Float>(u1, v0)),
+            WPEMSDFTextVertex(position: SIMD2<Float>(x1, y1), uv: SIMD2<Float>(u1, v1)),
+            WPEMSDFTextVertex(position: SIMD2<Float>(x0, y1), uv: SIMD2<Float>(u0, v1))
+        ])
+    }
+
+    private static func pathUnitsToEmUnits(font: CTFont) -> Double {
+        let unitsPerEm = max(Double(CTFontGetUnitsPerEm(font)), 1)
+        let fontSize = max(Double(CTFontGetSize(font)), 1.0e-6)
+        return unitsPerEm / fontSize
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFTextRenderer.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFTextRenderer.swift
@@ -1,0 +1,202 @@
+#if !LITE_BUILD
+import CoreGraphics
+import CoreText
+import Foundation
+import LiveWallpaperProWPE
+import Metal
+import simd
+
+struct WPEMSDFTextPageDraw {
+    let page: Int
+    let vertexBuffer: MTLBuffer
+    let vertexCount: Int
+    let texture: MTLTexture
+}
+
+struct WPEMSDFTextDrawPayload {
+    let pages: [WPEMSDFTextPageDraw]
+    let uniforms: [String: WPESceneShaderConstantValue]
+    let combos: [String: Int]
+    let shaderRequest: WPEShaderCompileRequest
+}
+
+@MainActor
+final class WPEMSDFTextRenderer {
+    private let device: MTLDevice
+    private let resolver: WPEMultiRootResourceResolver
+    private let fontFragmentSource: String
+    private let parameters: WPEMSDFParameters
+    private let atlas: WPEMSDFAtlas
+    private let generator: WPEMSDFGlyphGenerator
+    private let layout = WPEMSDFTextLayout()
+    private var registeredFonts: Set<String> = []
+
+    init(
+        device: MTLDevice,
+        resolver: WPEMultiRootResourceResolver,
+        fontFragmentSource: String,
+        parameters: WPEMSDFParameters = WPEMSDFParameters()
+    ) {
+        self.device = device
+        self.resolver = resolver
+        self.fontFragmentSource = fontFragmentSource
+        self.parameters = parameters
+        self.atlas = WPEMSDFAtlas(device: device)
+        self.generator = WPEMSDFGlyphGenerator(parameters: parameters)
+    }
+
+    func drawPayload(
+        for object: WPESceneTextObject,
+        sceneSize: CGSize,
+        parallaxOffset: SIMD2<Float>
+    ) -> WPEMSDFTextDrawPayload? {
+        let font = resolveFont(for: object)
+        let material = WPEMSDFFontMaterial.make(object: object, parameters: parameters)
+        guard let request = try? shaderRequest(comboValues: material.combos) else { return nil }
+        let fontID = fontIdentifier(font)
+        guard let mesh = layout.layout(
+            object: object,
+            font: font,
+            atlas: atlas,
+            generator: generator,
+            fontID: fontID
+        ) else { return nil }
+
+        let transformed = transform(mesh: mesh, object: object, parallaxOffset: parallaxOffset)
+        let pages = transformed.perPage.keys.sorted().compactMap { page -> WPEMSDFTextPageDraw? in
+            guard let vertices = transformed.perPage[page], !vertices.isEmpty,
+                  let texture = atlas.texture(page: page) else {
+                return nil
+            }
+            let buffer = vertices.withUnsafeBytes { rawBuffer -> MTLBuffer? in
+                guard let baseAddress = rawBuffer.baseAddress else { return nil }
+                return device.makeBuffer(bytes: baseAddress, length: rawBuffer.count, options: [])
+            }
+            guard let buffer else { return nil }
+            return WPEMSDFTextPageDraw(
+                page: page,
+                vertexBuffer: buffer,
+                vertexCount: vertices.count,
+                texture: texture
+            )
+        }
+        guard pages.count == transformed.perPage.count, !pages.isEmpty else { return nil }
+        _ = sceneSize
+        return WPEMSDFTextDrawPayload(
+            pages: pages,
+            uniforms: material.uniforms,
+            combos: material.combos,
+            shaderRequest: request
+        )
+    }
+
+    private func transform(
+        mesh: WPEMSDFTextMesh,
+        object: WPESceneTextObject,
+        parallaxOffset: SIMD2<Float>
+    ) -> WPEMSDFTextMesh {
+        let scale = SIMD2<Double>(
+            max(object.scale.x, 0.0001),
+            max(object.scale.y, 0.0001)
+        )
+        let scaledSize = SIMD2<Double>(
+            Double(mesh.size.width) * scale.x,
+            Double(mesh.size.height) * scale.y
+        )
+        let topLeft = SIMD2<Double>(
+            object.origin.x + Double(parallaxOffset.x) - scaledSize.x * 0.5,
+            object.origin.y + Double(parallaxOffset.y) - scaledSize.y * 0.5
+        )
+        var transformed: [Int: [WPEMSDFTextVertex]] = [:]
+        for (page, vertices) in mesh.perPage {
+            transformed[page] = vertices.map { vertex in
+                let local = SIMD2<Double>(Double(vertex.position.x), Double(vertex.position.y))
+                return WPEMSDFTextVertex(
+                    position: SIMD2<Float>(
+                        Float(topLeft.x + local.x * scale.x),
+                        Float(topLeft.y + local.y * scale.y)
+                    ),
+                    uv: vertex.uv
+                )
+            }
+        }
+        return WPEMSDFTextMesh(perPage: transformed, size: mesh.size)
+    }
+
+    private func shaderRequest(comboValues: [String: Int]) throws -> WPEShaderCompileRequest {
+        let processor = WPEShaderPreprocessor { [resolver] path, _ in
+            Self.readInclude(path: path, resolver: resolver)
+        }
+        return try processor.process(
+            shaderName: "font",
+            vertexSource: Self.vertexStub,
+            fragmentSource: fontFragmentSource,
+            comboValues: comboValues,
+            materialTextureBindings: [:]
+        )
+    }
+
+    private func resolveFont(for object: WPESceneTextObject) -> CTFont {
+        let size = effectiveFontSize(for: object)
+        if let path = object.fontRelativePath {
+            registerFontIfNeeded(path)
+            if let url = try? resolver.resolveExistingFileURL(relativePath: path),
+               let descriptors = CTFontManagerCreateFontDescriptorsFromURL(url as CFURL) as? [CTFontDescriptor],
+               let descriptor = descriptors.first {
+                return CTFontCreateWithFontDescriptor(descriptor, size, nil)
+            }
+        }
+        return CTFontCreateWithName("HelveticaNeue" as CFString, size, nil)
+    }
+
+    private func registerFontIfNeeded(_ path: String) {
+        guard !registeredFonts.contains(path) else { return }
+        registeredFonts.insert(path)
+        guard let url = try? resolver.resolveExistingFileURL(relativePath: path) else { return }
+        var unmanagedError: Unmanaged<CFError>?
+        _ = CTFontManagerRegisterFontsForURL(url as CFURL, .process, &unmanagedError)
+        unmanagedError?.release()
+    }
+
+    private func effectiveFontSize(for object: WPESceneTextObject) -> CGFloat {
+        let base = CGFloat(max(object.pointSize, 1))
+        guard let box = object.boxSize, box.x > 0, box.y > 0 else { return base }
+        let font = CTFontCreateWithName("HelveticaNeue" as CFString, base, nil)
+        let attributed = CFAttributedStringCreate(nil, object.text as CFString, [kCTFontAttributeName: font] as CFDictionary)!
+        let line = CTLineCreateWithAttributedString(attributed)
+        var ascent: CGFloat = 0
+        var descent: CGFloat = 0
+        var leading: CGFloat = 0
+        let width = max(CGFloat(CTLineGetTypographicBounds(line, &ascent, &descent, &leading)), 0.5)
+        let height = max(ascent + descent + leading, 0.5)
+        let innerW = max(CGFloat(box.x - 2 * object.padding), 1)
+        let innerH = max(CGFloat(box.y - 2 * object.padding), 1)
+        let fit = min(innerW / width, innerH / height)
+        guard fit.isFinite, fit > 0 else { return base }
+        return base * fit
+    }
+
+    private func fontIdentifier(_ font: CTFont) -> String {
+        let name = CTFontCopyPostScriptName(font) as String
+        return "\(name)@\(Int(ceil(CTFontGetSize(font))))"
+    }
+
+    private static func readInclude(path: String, resolver: WPEMultiRootResourceResolver) -> String? {
+        let candidates = path.hasPrefix("shaders/") ? [path] : ["shaders/\(path)", path]
+        for candidate in candidates {
+            guard let url = try? resolver.resolveExistingFileURL(relativePath: candidate),
+                  let data = try? Data(contentsOf: url),
+                  let text = String(data: data, encoding: .utf8) else {
+                continue
+            }
+            return text
+        }
+        return nil
+    }
+
+    private static let vertexStub = """
+    #version 410 core
+    void main() {}
+    """
+}
+#endif

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFTypes.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFTypes.swift
@@ -1,0 +1,88 @@
+#if !LITE_BUILD
+import CoreGraphics
+import Foundation
+import simd
+
+struct WPEMSDFParameters {
+    var pixelRange: Double = 4
+    var padding: Int = 4
+    var angleThreshold: Double = 3.0
+}
+
+typealias WPEMSDFPoint = SIMD2<Double>
+
+enum WPEMSDFEdgeColor: UInt8, CaseIterable {
+    case black = 0
+    case red
+    case green
+    case yellow
+    case blue
+    case magenta
+    case cyan
+    case white
+
+    func contains(_ channel: WPEMSDFEdgeColor) -> Bool {
+        rawValue & channel.rawValue != 0
+    }
+
+    var hasRed: Bool { rawValue & WPEMSDFEdgeColor.red.rawValue != 0 }
+    var hasGreen: Bool { rawValue & WPEMSDFEdgeColor.green.rawValue != 0 }
+    var hasBlue: Bool { rawValue & WPEMSDFEdgeColor.blue.rawValue != 0 }
+}
+
+struct WPEMSDFBitmap {
+    let width: Int
+    let height: Int
+    var pixels: [SIMD4<Float>]
+
+    init(width: Int, height: Int, fill: SIMD4<Float> = SIMD4<Float>(0, 0, 0, 1)) {
+        precondition(width >= 0 && height >= 0)
+        self.width = width
+        self.height = height
+        self.pixels = [SIMD4<Float>](repeating: fill, count: width * height)
+    }
+
+    init(width: Int, height: Int, pixels: [SIMD4<Float>]) {
+        precondition(width >= 0 && height >= 0)
+        precondition(pixels.count == width * height)
+        self.width = width
+        self.height = height
+        self.pixels = pixels
+    }
+
+    subscript(x: Int, y: Int) -> SIMD4<Float> {
+        get {
+            pixels[y * width + x]
+        }
+        set {
+            pixels[y * width + x] = newValue
+        }
+    }
+
+    func rgba8Data() -> Data {
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(width * height * 4)
+        for pixel in pixels {
+            bytes.append(Self.byte(pixel.x))
+            bytes.append(Self.byte(pixel.y))
+            bytes.append(Self.byte(pixel.z))
+            bytes.append(Self.byte(pixel.w))
+        }
+        return Data(bytes)
+    }
+
+    private static func byte(_ value: Float) -> UInt8 {
+        let clamped = min(max(value, 0), 1)
+        return UInt8((clamped * 255).rounded())
+    }
+}
+
+struct WPEMSDFGlyphMetrics {
+    let cellSize: CGSize
+    let bearing: WPEMSDFPoint
+    let advance: WPEMSDFPoint
+    let scale: Double
+    let translate: WPEMSDFPoint
+    let emUnitsPerPixel: Double
+}
+#endif

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -109,6 +109,13 @@ final class WPEMetalRenderExecutor {
     /// shaders. Library + blend + format set is the key.
     private var translatedPipelineCache: [TranslatedPipelineKey: MTLRenderPipelineState] = [:]
     private var previousFrameHistory: PreviousFrameHistory?
+    private var msdfTextPipelineCache: [MSDFTextPipelineKey: MTLRenderPipelineState] = [:]
+    private var msdfNeutralWhiteTexture: MTLTexture?
+
+    private struct MSDFTextPipelineKey: Hashable {
+        let libraryID: ObjectIdentifier
+        let colorPixelFormat: UInt
+    }
 
     private struct PreviousFrameHistory {
         let sceneSize: CGSize
@@ -463,6 +470,182 @@ final class WPEMetalRenderExecutor {
         encoder.endEncoding()
         commandBuffer.commit()
         commandBuffer.waitUntilCompleted()
+    }
+
+    /// Draw GPU MSDF text: compile the translated `font.frag` (cached per combo
+    /// set), bind per-page glyph quads + atlas texture, pack the font material
+    /// uniforms by slot, and composite with premultiplied alpha onto `output`.
+    func drawMSDFText(
+        payloads: [WPEMSDFTextDrawPayload],
+        sceneSize: CGSize,
+        output: MTLTexture
+    ) throws {
+        guard !payloads.isEmpty else { return }
+        guard let commandBuffer = commandQueue.makeCommandBuffer() else {
+            throw WPEMetalRenderExecutorError.commandBufferFailed
+        }
+        let descriptor = MTLRenderPassDescriptor()
+        descriptor.colorAttachments[0].texture = output
+        descriptor.colorAttachments[0].loadAction = .load
+        descriptor.colorAttachments[0].storeAction = .store
+        guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor) else {
+            throw WPEMetalRenderExecutorError.commandBufferFailed
+        }
+
+        var sceneSizeValue = SIMD2<Float>(
+            Float(max(sceneSize.width, 1)),
+            Float(max(sceneSize.height, 1))
+        )
+        let whiteTexture = try msdfWhiteTexture()
+        for payload in payloads {
+            let result = try compileMSDFFontShader(payload.shaderRequest)
+            let state = try msdfTextPipelineState(for: result, colorPixelFormat: output.pixelFormat)
+            encoder.setRenderPipelineState(state)
+            encoder.setVertexBytes(&sceneSizeValue, length: MemoryLayout<SIMD2<Float>>.stride, index: 1)
+
+            for page in payload.pages {
+                encoder.setVertexBuffer(page.vertexBuffer, offset: 0, index: 0)
+                encoder.setFragmentTexture(page.texture, index: 0)
+                encoder.setFragmentTexture(whiteTexture, index: 1)
+                var slots = packTranslatedUniforms(
+                    values: payload.uniforms,
+                    layout: result.uniformLayout,
+                    texturesBySlot: [0: page.texture, 1: whiteTexture],
+                    destinationTexture: output
+                )
+                encoder.setFragmentBytes(
+                    &slots,
+                    length: MemoryLayout<SIMD4<Float>>.stride * slots.count,
+                    index: 0
+                )
+                encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: page.vertexCount)
+            }
+        }
+        encoder.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+    }
+
+    private func compileMSDFFontShader(_ request: WPEShaderCompileRequest) throws -> WPEShaderCompileResult {
+        if let cached = translatedShaderCache[request.sourceHash] {
+            return cached
+        }
+        let result = try shaderCompiler.compile(request)
+        translatedShaderCache[request.sourceHash] = result
+        return result
+    }
+
+    private func msdfTextPipelineState(
+        for result: WPEShaderCompileResult,
+        colorPixelFormat: MTLPixelFormat
+    ) throws -> MTLRenderPipelineState {
+        let key = MSDFTextPipelineKey(
+            libraryID: ObjectIdentifier(result.library),
+            colorPixelFormat: colorPixelFormat.rawValue
+        )
+        if let cached = msdfTextPipelineCache[key] {
+            return cached
+        }
+        guard let vertex = device.makeDefaultLibrary()?.makeFunction(name: "wpe_msdf_text_vertex"),
+              let fragment = result.library.makeFunction(name: result.fragmentFunctionName) else {
+            throw WPEMetalRenderExecutorError.pipelineUnavailable(result.fragmentFunctionName)
+        }
+        let pipelineDescriptor = MTLRenderPipelineDescriptor()
+        pipelineDescriptor.vertexFunction = vertex
+        pipelineDescriptor.fragmentFunction = fragment
+        guard let attachment = pipelineDescriptor.colorAttachments[0] else {
+            throw WPEMetalRenderExecutorError.pipelineUnavailable(result.fragmentFunctionName)
+        }
+        attachment.pixelFormat = colorPixelFormat
+        attachment.isBlendingEnabled = true
+        attachment.rgbBlendOperation = .add
+        attachment.alphaBlendOperation = .add
+        attachment.sourceRGBBlendFactor = .one
+        attachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
+        attachment.sourceAlphaBlendFactor = .one
+        attachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
+        let state = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+        msdfTextPipelineCache[key] = state
+        return state
+    }
+
+    private func msdfWhiteTexture() throws -> MTLTexture {
+        if let msdfNeutralWhiteTexture { return msdfNeutralWhiteTexture }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .rgba8Unorm,
+            width: 1,
+            height: 1,
+            mipmapped: false
+        )
+        descriptor.usage = [.shaderRead]
+        descriptor.storageMode = .shared
+        guard let texture = device.makeTexture(descriptor: descriptor) else {
+            throw WPEMetalRenderExecutorError.pipelineUnavailable("wpe_msdf_text_white_texture")
+        }
+        texture.label = "WPE MSDF neutral white"
+        WPEMetalTextureMetadataRegistry.shared.register(texture: texture)
+        var pixel: UInt32 = 0xFFFF_FFFF
+        texture.replace(
+            region: MTLRegionMake2D(0, 0, 1, 1),
+            mipmapLevel: 0,
+            withBytes: &pixel,
+            bytesPerRow: 4
+        )
+        msdfNeutralWhiteTexture = texture
+        return texture
+    }
+
+    /// Packs a `[name: value]` uniform dictionary into the translated shader's
+    /// `WPEUniforms.vals[]` array by the slot indices from its uniform layout.
+    /// Mirrors the per-pass packer but takes a standalone values dict (used by
+    /// the MSDF text path, which builds uniforms outside the render graph).
+    func packTranslatedUniforms(
+        values: [String: WPESceneShaderConstantValue],
+        layout: [WPEUniformSlot],
+        texturesBySlot: [Int: MTLTexture] = [:],
+        destinationTexture: MTLTexture? = nil
+    ) -> [SIMD4<Float>] {
+        var slots = [SIMD4<Float>](repeating: SIMD4<Float>(0, 0, 0, 0), count: WPEShaderTranspiler.uniformSlotMaximum)
+        for u in layout {
+            guard u.slot < slots.count else { continue }
+            let value = Self.textureResolutionValue(
+                named: u.name,
+                texturesBySlot: texturesBySlot,
+                destinationTexture: destinationTexture
+            ) ?? Self.firstValue(
+                in: values,
+                matching: Self.translatedUniformNameCandidates(for: u)
+            ) ?? u.defaultValue
+            if let length = u.arrayLength {
+                let flat = Self.vectorValue(value, count: length * 4)
+                for i in 0..<length {
+                    let slotIndex = u.slot + i
+                    guard slotIndex < slots.count else { break }
+                    let base = i * 4
+                    slots[slotIndex] = SIMD4<Float>(
+                        flat.indices.contains(base) ? flat[base] : 0,
+                        flat.indices.contains(base + 1) ? flat[base + 1] : 0,
+                        flat.indices.contains(base + 2) ? flat[base + 2] : 0,
+                        flat.indices.contains(base + 3) ? flat[base + 3] : 0
+                    )
+                }
+                continue
+            }
+            switch u.glslType {
+            case "vec2":
+                let v = Self.vectorValue(value, count: 2)
+                slots[u.slot] = SIMD4<Float>(v[0], v[1], 0, 0)
+            case "vec3":
+                let v = Self.vectorValue(value, count: 3)
+                slots[u.slot] = SIMD4<Float>(v[0], v[1], v[2], 0)
+            case "vec4":
+                let v = Self.vectorValue(value, count: 4)
+                slots[u.slot] = SIMD4<Float>(v[0], v[1], v[2], v[3])
+            default:
+                slots[u.slot].x = Self.scalarValue(value, default: 0)
+            }
+        }
+        return slots
     }
 
     private var textOverlayPipelineCache: [UInt: MTLRenderPipelineState] = [:]

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -68,6 +68,9 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
     /// frame re-rasterizes via the cached WPETextRenderer (cache hits
     /// the common case) and draws atop the scene output.
     private var textRenderer: WPETextRenderer?
+    /// GPU MSDF text renderer (Milestone D). Built only when the engine's
+    /// `font.frag` resolves; nil → text falls back to the CoreText overlay.
+    private var msdfTextRenderer: WPEMSDFTextRenderer?
     private var textObjects: [WPESceneTextObject] = []
     /// Phase 2D-O: audio runtime publishing live FFT bins into the
     /// runtime uniform that audio-reactive shaders sample. Optional —
@@ -1037,7 +1040,12 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
             )
         }
         if let textRenderer, !textObjects.isEmpty {
+            // CoreText draws for objects that don't take the MSDF path this frame.
             var draws: [WPETextOverlayDraw] = []
+            // Every visible object's CoreText draw, used as the all-or-nothing
+            // fallback if the GPU MSDF pass throws.
+            var allFallbackDraws: [WPETextOverlayDraw] = []
+            var msdfPayloads: [WPEMSDFTextDrawPayload] = []
             draws.reserveCapacity(textObjects.count)
             for object in textObjects where liveTextVisibility[object.id] ?? object.visible {
                 let resolvedAlpha = object.resolvedAlpha(at: uniforms.time)
@@ -1063,7 +1071,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
                     width: entry.size.width * CGFloat(scale.x),
                     height: entry.size.height * CGFloat(scale.y)
                 )
-                draws.append(WPETextOverlayDraw(
+                let fallbackDraw = WPETextOverlayDraw(
                     texture: entry.texture,
                     centerInScenePixels: center,
                     sizeInScenePixels: scaledSize,
@@ -1073,7 +1081,37 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
                         Float(liveObject.color.z)
                     ),
                     alpha: Float(liveObject.alpha)
-                ))
+                )
+                allFallbackDraws.append(fallbackDraw)
+                // Prefer the GPU MSDF path; if it can't build a payload for this
+                // object, render it via the CoreText overlay this frame.
+                if let payload = msdfTextRenderer?.drawPayload(
+                    for: liveObject,
+                    sceneSize: sceneRenderSize,
+                    parallaxOffset: SIMD2<Float>(textParallax.x, textParallax.y)
+                ) {
+                    msdfPayloads.append(payload)
+                } else {
+                    draws.append(fallbackDraw)
+                }
+            }
+            var msdfSucceeded = false
+            if !msdfPayloads.isEmpty {
+                do {
+                    try executor.drawMSDFText(
+                        payloads: msdfPayloads,
+                        sceneSize: sceneRenderSize,
+                        output: frame
+                    )
+                    msdfSucceeded = true
+                } catch {
+                    msdfSucceeded = false
+                }
+            }
+            // If the MSDF pass failed, fall back to CoreText for everything so no
+            // text silently disappears.
+            if !msdfSucceeded, !msdfPayloads.isEmpty {
+                draws = allFallbackDraws
             }
             if !draws.isEmpty {
                 try executor.drawTextOverlays(
@@ -1111,6 +1149,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
         textObjects = document.textObjects
         guard !textObjects.isEmpty else {
             textRenderer = nil
+            msdfTextRenderer = nil
             textScriptInstances.removeAll(keepingCapacity: false)
             return
         }
@@ -1118,6 +1157,15 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
             device: executor.textureSourceDevice,
             resolver: resourceResolver
         )
+        if let fontFragmentSource = resolveMSDFFontFragmentSource() {
+            msdfTextRenderer = WPEMSDFTextRenderer(
+                device: executor.textureSourceDevice,
+                resolver: resourceResolver,
+                fontFragmentSource: fontFragmentSource
+            )
+        } else {
+            msdfTextRenderer = nil
+        }
         textScriptInstances.removeAll(keepingCapacity: false)
         for object in textObjects {
             guard let script = object.textScript else { continue }
@@ -1125,6 +1173,21 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
                 textScriptInstances[object.id] = instance
             }
         }
+    }
+
+    /// Loads the engine's MSDF `font.frag` from the authorized 2.8 install so the
+    /// GPU text path can compile it. Returns nil when unavailable → CoreText only.
+    private func resolveMSDFFontFragmentSource() -> String? {
+        let candidates = ["shaders/font.frag", "shaders/effects/font.frag"]
+        for path in candidates {
+            guard let url = try? resourceResolver.resolveExistingFileURL(relativePath: path),
+                  let data = try? Data(contentsOf: url),
+                  let source = String(data: data, encoding: .utf8) else {
+                continue
+            }
+            return source
+        }
+        return nil
     }
 
     /// Material descriptor extracted from `passes[0]`. Only the fields the
@@ -1333,6 +1396,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
         textObjects.removeAll(keepingCapacity: false)
         textRenderer?.releaseAll()
         textRenderer = nil
+        msdfTextRenderer = nil
         textScriptInstances.removeAll(keepingCapacity: false)
         soundRuntime?.stop()
         soundRuntime = nil
@@ -1520,6 +1584,7 @@ final class WPEMetalSceneRenderer: NSObject, WPESceneRenderer, WPEScenePropertyR
         textObjects.removeAll(keepingCapacity: false)
         textRenderer?.releaseAll()
         textRenderer = nil
+        msdfTextRenderer = nil
         textScriptInstances.removeAll(keepingCapacity: false)
         soundRuntime?.stop()
         soundRuntime = nil

--- a/LiveWallpaper/Runtime/WPESceneScriptBaseclasses.swift
+++ b/LiveWallpaper/Runtime/WPESceneScriptBaseclasses.swift
@@ -1,0 +1,528 @@
+#if !LITE_BUILD
+import JavaScriptCore
+
+enum WPESceneScriptBaseclasses {
+    static func install(in context: JSContext) {
+        let _ = context.evaluateScript(Self.prelude)
+    }
+
+    private static let prelude = #"""
+(function () {
+    var root = (typeof globalThis !== "undefined") ? globalThis : this;
+    var EPSILON = 1e-8;
+    var hasSymbol = typeof Symbol !== "undefined";
+
+    function number(value, fallback) {
+        var n = Number(value);
+        return isFinite(n) ? n : (fallback || 0);
+    }
+
+    function isArrayLike(value) {
+        return value && typeof value !== "function" && typeof value.length === "number";
+    }
+
+    function component(value, key, index, fallback) {
+        if (value == null) { return number(fallback, 0); }
+        if (isArrayLike(value)) { return number(value[index], fallback); }
+        if (typeof value === "object") {
+            if (typeof value[key] !== "undefined") { return number(value[key], fallback); }
+            if (typeof value[index] !== "undefined") { return number(value[index], fallback); }
+        }
+        return number(value, fallback);
+    }
+
+    function finiteOr(value, fallback) {
+        var n = Number(value);
+        return isFinite(n) ? n : fallback;
+    }
+
+    function hypot2(x, y) {
+        return Math.sqrt(x * x + y * y);
+    }
+
+    function hypot3(x, y, z) {
+        return Math.sqrt(x * x + y * y + z * z);
+    }
+
+    function defineGlobal(name, value) {
+        try {
+            if (typeof root[name] !== "undefined") { return; }
+            Object.defineProperty(root, name, {
+                configurable: true,
+                writable: true,
+                value: value
+            });
+        } catch (e) {
+            try { root[name] = value; } catch (ignored) {}
+        }
+    }
+
+    function installMethod(target, name, value) {
+        if (target == null) { return; }
+        try {
+            if (typeof target[name] === "undefined") { target[name] = value; }
+        } catch (e) {}
+    }
+
+    class Vec2 {
+        constructor(x, y) {
+            if (arguments.length === 0) { x = 0; y = 0; }
+            else if (arguments.length === 1) {
+                if (isArrayLike(x) || typeof x === "object") {
+                    var fallback = component(x, "x", 0, 0);
+                    y = component(x, "y", 1, fallback);
+                    x = fallback;
+                } else { y = x; }
+            }
+            this.x = number(x, 0);
+            this.y = number(y, 0);
+        }
+        clone() { return new Vec2(this.x, this.y); }
+        toArray() { return [this.x, this.y]; }
+        add(v) { v = new Vec2(v); return new Vec2(this.x + v.x, this.y + v.y); }
+        sub(v) { v = new Vec2(v); return new Vec2(this.x - v.x, this.y - v.y); }
+        mul(v) { v = new Vec2(v); return new Vec2(this.x * v.x, this.y * v.y); }
+        scale(s) { s = number(s, 0); return new Vec2(this.x * s, this.y * s); }
+        dot(v) { v = new Vec2(v); return this.x * v.x + this.y * v.y; }
+        length() { return hypot2(this.x, this.y); }
+        normalize() { var l = this.length(); return l > EPSILON ? this.scale(1 / l) : new Vec2(0); }
+        lerp(v, t) { v = new Vec2(v); t = number(t, 0); return this.scale(1 - t).add(v.scale(t)); }
+        static add(a, b) { return new Vec2(a).add(b); }
+        static sub(a, b) { return new Vec2(a).sub(b); }
+        static mul(a, b) { return new Vec2(a).mul(b); }
+        static scale(v, s) { return new Vec2(v).scale(s); }
+        static dot(a, b) { return new Vec2(a).dot(b); }
+        static lerp(a, b, t) { return new Vec2(a).lerp(b, t); }
+    }
+
+    class Vec3 {
+        constructor(x, y, z) {
+            if (arguments.length === 0) { x = 0; y = 0; z = 0; }
+            else if (arguments.length === 1) {
+                if (isArrayLike(x) || typeof x === "object") {
+                    var fallback = component(x, "x", 0, 0);
+                    y = component(x, "y", 1, fallback);
+                    z = component(x, "z", 2, fallback);
+                    x = fallback;
+                } else { y = x; z = x; }
+            }
+            this.x = number(x, 0);
+            this.y = number(y, 0);
+            this.z = number(z, 0);
+        }
+        clone() { return new Vec3(this.x, this.y, this.z); }
+        toArray() { return [this.x, this.y, this.z]; }
+        add(v) { v = new Vec3(v); return new Vec3(this.x + v.x, this.y + v.y, this.z + v.z); }
+        sub(v) { v = new Vec3(v); return new Vec3(this.x - v.x, this.y - v.y, this.z - v.z); }
+        mul(v) { v = new Vec3(v); return new Vec3(this.x * v.x, this.y * v.y, this.z * v.z); }
+        scale(s) { s = number(s, 0); return new Vec3(this.x * s, this.y * s, this.z * s); }
+        dot(v) { v = new Vec3(v); return this.x * v.x + this.y * v.y + this.z * v.z; }
+        cross(v) {
+            v = new Vec3(v);
+            return new Vec3(
+                this.y * v.z - this.z * v.y,
+                this.z * v.x - this.x * v.z,
+                this.x * v.y - this.y * v.x
+            );
+        }
+        length() { return hypot3(this.x, this.y, this.z); }
+        normalize() { var l = this.length(); return l > EPSILON ? this.scale(1 / l) : new Vec3(0); }
+        lerp(v, t) { v = new Vec3(v); t = number(t, 0); return this.scale(1 - t).add(v.scale(t)); }
+        toSpherical() { return toSpherical(this); }
+        refract(normal, eta) { return refract(this, normal, eta); }
+        static add(a, b) { return new Vec3(a).add(b); }
+        static sub(a, b) { return new Vec3(a).sub(b); }
+        static mul(a, b) { return new Vec3(a).mul(b); }
+        static scale(v, s) { return new Vec3(v).scale(s); }
+        static dot(a, b) { return new Vec3(a).dot(b); }
+        static cross(a, b) { return new Vec3(a).cross(b); }
+        static lerp(a, b, t) { return new Vec3(a).lerp(b, t); }
+    }
+
+    class Vec4 {
+        constructor(x, y, z, w) {
+            if (arguments.length === 0) { x = 0; y = 0; z = 0; w = 0; }
+            else if (arguments.length === 1) {
+                if (isArrayLike(x) || typeof x === "object") {
+                    var fallback = component(x, "x", 0, 0);
+                    y = component(x, "y", 1, fallback);
+                    z = component(x, "z", 2, fallback);
+                    w = component(x, "w", 3, fallback);
+                    x = fallback;
+                } else { y = x; z = x; w = x; }
+            }
+            this.x = number(x, 0);
+            this.y = number(y, 0);
+            this.z = number(z, 0);
+            this.w = number(w, 0);
+        }
+        clone() { return new Vec4(this.x, this.y, this.z, this.w); }
+        toArray() { return [this.x, this.y, this.z, this.w]; }
+        add(v) { v = new Vec4(v); return new Vec4(this.x + v.x, this.y + v.y, this.z + v.z, this.w + v.w); }
+        sub(v) { v = new Vec4(v); return new Vec4(this.x - v.x, this.y - v.y, this.z - v.z, this.w - v.w); }
+        mul(v) { v = new Vec4(v); return new Vec4(this.x * v.x, this.y * v.y, this.z * v.z, this.w * v.w); }
+        scale(s) { s = number(s, 0); return new Vec4(this.x * s, this.y * s, this.z * s, this.w * s); }
+        dot(v) { v = new Vec4(v); return this.x * v.x + this.y * v.y + this.z * v.z + this.w * v.w; }
+        length() { return Math.sqrt(this.dot(this)); }
+        normalize() { var l = this.length(); return l > EPSILON ? this.scale(1 / l) : new Vec4(0); }
+        lerp(v, t) { v = new Vec4(v); t = number(t, 0); return this.scale(1 - t).add(v.scale(t)); }
+        static add(a, b) { return new Vec4(a).add(b); }
+        static sub(a, b) { return new Vec4(a).sub(b); }
+        static mul(a, b) { return new Vec4(a).mul(b); }
+        static scale(v, s) { return new Vec4(v).scale(s); }
+        static dot(a, b) { return new Vec4(a).dot(b); }
+        static lerp(a, b, t) { return new Vec4(a).lerp(b, t); }
+    }
+
+    function readMatrix(values, size, identity) {
+        if (values && values.m) { values = values.m; }
+        var count = size * size;
+        var out = identity.slice();
+        if (isArrayLike(values) && values.length >= count) {
+            for (var i = 0; i < count; i += 1) { out[i] = number(values[i], identity[i]); }
+        }
+        return out;
+    }
+
+    class Mat3 {
+        constructor(values) { this.m = readMatrix(values, 3, Mat3.identityArray()); }
+        clone() { return new Mat3(this.m); }
+        toArray() { return this.m.slice(); }
+        multiply(other) {
+            var a = this.m, b = new Mat3(other).m, out = new Array(9);
+            for (var c = 0; c < 3; c += 1) {
+                for (var r = 0; r < 3; r += 1) {
+                    out[c * 3 + r] = a[r] * b[c * 3] + a[3 + r] * b[c * 3 + 1] + a[6 + r] * b[c * 3 + 2];
+                }
+            }
+            return new Mat3(out);
+        }
+        transpose() {
+            var m = this.m;
+            return new Mat3([m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]]);
+        }
+        inverse() {
+            var m = this.m;
+            var b01 = m[8] * m[4] - m[5] * m[7];
+            var b11 = -m[8] * m[1] + m[2] * m[7];
+            var b21 = m[5] * m[1] - m[2] * m[4];
+            var det = m[0] * b01 + m[3] * b11 + m[6] * b21;
+            if (Math.abs(det) <= EPSILON) { return Mat3.identity(); }
+            det = 1 / det;
+            return new Mat3([
+                b01 * det,
+                (-m[8] * m[3] + m[5] * m[6]) * det,
+                (m[7] * m[3] - m[4] * m[6]) * det,
+                b11 * det,
+                (m[8] * m[0] - m[2] * m[6]) * det,
+                (-m[7] * m[0] + m[1] * m[6]) * det,
+                b21 * det,
+                (-m[5] * m[0] + m[2] * m[3]) * det,
+                (m[4] * m[0] - m[1] * m[3]) * det
+            ]);
+        }
+        static identityArray() { return [1, 0, 0, 0, 1, 0, 0, 0, 1]; }
+        static identity() { return new Mat3(); }
+        static multiply(a, b) { return new Mat3(a).multiply(b); }
+        static transpose(m) { return new Mat3(m).transpose(); }
+        static inverse(m) { return new Mat3(m).inverse(); }
+        static fromMat4(mat) {
+            var m = new Mat4(mat).m;
+            return new Mat3([m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9], m[10]]);
+        }
+    }
+
+    class Mat4 {
+        constructor(values) { this.m = readMatrix(values, 4, Mat4.identityArray()); }
+        clone() { return new Mat4(this.m); }
+        toArray() { return this.m.slice(); }
+        multiply(other) {
+            var a = this.m, b = new Mat4(other).m, out = new Array(16);
+            for (var c = 0; c < 4; c += 1) {
+                for (var r = 0; r < 4; r += 1) {
+                    out[c * 4 + r] = a[r] * b[c * 4] + a[4 + r] * b[c * 4 + 1] + a[8 + r] * b[c * 4 + 2] + a[12 + r] * b[c * 4 + 3];
+                }
+            }
+            return new Mat4(out);
+        }
+        transpose() {
+            var m = this.m;
+            return new Mat4([
+                m[0], m[4], m[8], m[12],
+                m[1], m[5], m[9], m[13],
+                m[2], m[6], m[10], m[14],
+                m[3], m[7], m[11], m[15]
+            ]);
+        }
+        inverse() {
+            var a = this.m;
+            var b00 = a[0] * a[5] - a[1] * a[4];
+            var b01 = a[0] * a[6] - a[2] * a[4];
+            var b02 = a[0] * a[7] - a[3] * a[4];
+            var b03 = a[1] * a[6] - a[2] * a[5];
+            var b04 = a[1] * a[7] - a[3] * a[5];
+            var b05 = a[2] * a[7] - a[3] * a[6];
+            var b06 = a[8] * a[13] - a[9] * a[12];
+            var b07 = a[8] * a[14] - a[10] * a[12];
+            var b08 = a[8] * a[15] - a[11] * a[12];
+            var b09 = a[9] * a[14] - a[10] * a[13];
+            var b10 = a[9] * a[15] - a[11] * a[13];
+            var b11 = a[10] * a[15] - a[11] * a[14];
+            var det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
+            if (Math.abs(det) <= EPSILON) { return Mat4.identity(); }
+            det = 1 / det;
+            return new Mat4([
+                (a[5] * b11 - a[6] * b10 + a[7] * b09) * det,
+                (a[2] * b10 - a[1] * b11 - a[3] * b09) * det,
+                (a[13] * b05 - a[14] * b04 + a[15] * b03) * det,
+                (a[10] * b04 - a[9] * b05 - a[11] * b03) * det,
+                (a[6] * b08 - a[4] * b11 - a[7] * b07) * det,
+                (a[0] * b11 - a[2] * b08 + a[3] * b07) * det,
+                (a[14] * b02 - a[12] * b05 - a[15] * b01) * det,
+                (a[8] * b05 - a[10] * b02 + a[11] * b01) * det,
+                (a[4] * b10 - a[5] * b08 + a[7] * b06) * det,
+                (a[1] * b08 - a[0] * b10 - a[3] * b06) * det,
+                (a[12] * b04 - a[13] * b02 + a[15] * b00) * det,
+                (a[9] * b02 - a[8] * b04 - a[11] * b00) * det,
+                (a[5] * b07 - a[4] * b09 - a[6] * b06) * det,
+                (a[0] * b09 - a[1] * b07 + a[2] * b06) * det,
+                (a[13] * b01 - a[12] * b03 - a[14] * b00) * det,
+                (a[8] * b03 - a[9] * b01 + a[10] * b00) * det
+            ]);
+        }
+        normalMatrix() {
+            var m = this.inverse().m;
+            return new Mat3([m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9], m[10]]).transpose();
+        }
+        decompose() {
+            var m = this.m;
+            var sx = hypot3(m[0], m[1], m[2]) || 1;
+            var sy = hypot3(m[4], m[5], m[6]) || 1;
+            var sz = hypot3(m[8], m[9], m[10]) || 1;
+            var r00 = m[0] / sx, r11 = m[5] / sy, r12 = m[9] / sz;
+            var r10 = m[1] / sx, r20 = m[2] / sx, r21 = m[6] / sy, r22 = m[10] / sz;
+            var ry = Math.asin(clamp(-r20, -1, 1));
+            var cy = Math.cos(ry);
+            var rx, rz;
+            if (Math.abs(cy) > EPSILON) {
+                rx = Math.atan2(r21, r22);
+                rz = Math.atan2(r10, r00);
+            } else {
+                rx = Math.atan2(-r12, r11);
+                rz = 0;
+            }
+            return {
+                translation: new Vec3(m[12], m[13], m[14]),
+                rotation: new Vec3(rx, ry, rz),
+                scale: new Vec3(sx, sy, sz)
+            };
+        }
+        static identityArray() { return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]; }
+        static identity() { return new Mat4(); }
+        static multiply(a, b) { return new Mat4(a).multiply(b); }
+        static transpose(m) { return new Mat4(m).transpose(); }
+        static inverse(m) { return new Mat4(m).inverse(); }
+        static normalMatrix(m) { return new Mat4(m).normalMatrix(); }
+        static decompose(m) { return new Mat4(m).decompose(); }
+        static fromTranslation(x, y, z) {
+            var v = arguments.length === 1 ? new Vec3(x) : new Vec3(x, y, z);
+            return new Mat4([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, v.x, v.y, v.z, 1]);
+        }
+        static fromScale(x, y, z) {
+            var v = arguments.length === 1 ? new Vec3(x) : new Vec3(x, y, z);
+            return new Mat4([v.x, 0, 0, 0, 0, v.y, 0, 0, 0, 0, v.z, 0, 0, 0, 0, 1]);
+        }
+        static fromScaling(x, y, z) { return Mat4.fromScale.apply(Mat4, arguments); }
+        static fromRotationX(r) {
+            r = number(r, 0);
+            var s = Math.sin(r), c = Math.cos(r);
+            return new Mat4([1, 0, 0, 0, 0, c, s, 0, 0, -s, c, 0, 0, 0, 0, 1]);
+        }
+        static fromRotationY(r) {
+            r = number(r, 0);
+            var s = Math.sin(r), c = Math.cos(r);
+            return new Mat4([c, 0, -s, 0, 0, 1, 0, 0, s, 0, c, 0, 0, 0, 0, 1]);
+        }
+        static fromRotationZ(r) {
+            r = number(r, 0);
+            var s = Math.sin(r), c = Math.cos(r);
+            return new Mat4([c, s, 0, 0, -s, c, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        }
+        static fromRotationXYZ(x, y, z) {
+            var v = arguments.length === 1 ? new Vec3(x) : new Vec3(x, y, z);
+            return Mat4.fromRotationZ(v.z).multiply(Mat4.fromRotationY(v.y)).multiply(Mat4.fromRotationX(v.x));
+        }
+        static perspective(fovy, aspect, near, far) {
+            fovy = number(fovy, 0); aspect = number(aspect, 1); near = number(near, 0.1); far = number(far, 1000);
+            if (Math.abs(aspect) <= EPSILON || Math.abs(near - far) <= EPSILON) { return Mat4.identity(); }
+            var f = 1 / Math.tan(fovy / 2);
+            if (!isFinite(f)) { return Mat4.identity(); }
+            var nf = 1 / (near - far);
+            return new Mat4([f / aspect, 0, 0, 0, 0, f, 0, 0, 0, 0, (far + near) * nf, -1, 0, 0, (2 * far * near) * nf, 0]);
+        }
+        static ortho(left, right, bottom, top, near, far) {
+            left = number(left, -1); right = number(right, 1); bottom = number(bottom, -1); top = number(top, 1);
+            near = number(near, -1); far = number(far, 1);
+            if (Math.abs(left - right) <= EPSILON || Math.abs(bottom - top) <= EPSILON || Math.abs(near - far) <= EPSILON) { return Mat4.identity(); }
+            var lr = 1 / (left - right), bt = 1 / (bottom - top), nf = 1 / (near - far);
+            return new Mat4([-2 * lr, 0, 0, 0, 0, -2 * bt, 0, 0, 0, 0, 2 * nf, 0, (left + right) * lr, (top + bottom) * bt, (far + near) * nf, 1]);
+        }
+        static lookAt(eye, center, up) {
+            eye = new Vec3(eye);
+            center = new Vec3(center);
+            up = new Vec3(up == null ? [0, 1, 0] : up);
+            var z = eye.sub(center).normalize();
+            if (z.length() <= EPSILON) { z = new Vec3(0, 0, 1); }
+            var x = up.cross(z).normalize();
+            if (x.length() <= EPSILON) { x = new Vec3(1, 0, 0); }
+            var y = z.cross(x).normalize();
+            return new Mat4([
+                x.x, y.x, z.x, 0,
+                x.y, y.y, z.y, 0,
+                x.z, y.z, z.z, 0,
+                -x.dot(eye), -y.dot(eye), -z.dot(eye), 1
+            ]);
+        }
+    }
+
+    function mapValue(value, mapper) {
+        if (value instanceof Vec2) { return new Vec2(mapper(value.x), mapper(value.y)); }
+        if (value instanceof Vec3) { return new Vec3(mapper(value.x), mapper(value.y), mapper(value.z)); }
+        if (value instanceof Vec4) { return new Vec4(mapper(value.x), mapper(value.y), mapper(value.z), mapper(value.w)); }
+        if (isArrayLike(value)) {
+            var out = [];
+            for (var i = 0; i < value.length; i += 1) { out.push(mapper(value[i])); }
+            return out;
+        }
+        return mapper(value);
+    }
+
+    function clamp(x, minValue, maxValue) {
+        minValue = finiteOr(minValue, 0);
+        maxValue = finiteOr(maxValue, 1);
+        if (minValue > maxValue) { var t = minValue; minValue = maxValue; maxValue = t; }
+        return mapValue(x, function (v) { return Math.min(Math.max(number(v, 0), minValue), maxValue); });
+    }
+
+    function mix(a, b, t) {
+        t = number(t, 0);
+        if (a instanceof Vec2) { return new Vec2(a).lerp(b, t); }
+        if (a instanceof Vec3) { return new Vec3(a).lerp(b, t); }
+        if (a instanceof Vec4) { return new Vec4(a).lerp(b, t); }
+        if (isArrayLike(a)) {
+            var out = [];
+            for (var i = 0; i < a.length; i += 1) { out.push(number(a[i], 0) * (1 - t) + number(b && b[i], 0) * t); }
+            return out;
+        }
+        return number(a, 0) * (1 - t) + number(b, 0) * t;
+    }
+
+    function saturate(x) { return clamp(x, 0, 1); }
+    function radians(x) { return mapValue(x, function (v) { return number(v, 0) * Math.PI / 180; }); }
+    function degrees(x) { return mapValue(x, function (v) { return number(v, 0) * 180 / Math.PI; }); }
+    function toSpherical(v) {
+        v = new Vec3(v);
+        var radius = v.length();
+        if (radius <= EPSILON) { return new Vec3(0); }
+        return new Vec3(radius, Math.atan2(v.z, v.x), Math.acos(clamp(v.y / radius, -1, 1)));
+    }
+    function refract(incident, normal, eta) {
+        var i = new Vec3(incident).normalize();
+        var n = new Vec3(normal).normalize();
+        eta = number(eta, 1);
+        var d = i.dot(n);
+        var k = 1 - eta * eta * (1 - d * d);
+        if (k < 0) { return new Vec3(0); }
+        return i.scale(eta).sub(n.scale(eta * d + Math.sqrt(k)));
+    }
+
+    function safeGet(object, property, fallback) {
+        if (hasSymbol && property === Symbol.toPrimitive) { return function (hint) { return hint === "string" ? "" : 0; }; }
+        if (hasSymbol && property === Symbol.iterator) { return function () { return { next: function () { return { done: true }; } }; }; }
+        if (property === "then") { return undefined; }
+        if (property === "toString") { return function () { return ""; }; }
+        if (property === "valueOf") { return function () { return 0; }; }
+        if (property === "toJSON") { return function () { return null; }; }
+        if (property === "length") { return 0; }
+        if (property === "x" || property === "y" || property === "z" || property === "w" || property === "width" || property === "height" || property === "alpha" || property === "opacity") { return 0; }
+        if (property === "visible" || property === "enabled") { return true; }
+        try {
+            if (property in object) { return object[property]; }
+        } catch (e) {}
+        return fallback;
+    }
+
+    function createSafeCallable(label) {
+        var proxy;
+        var target = function () { return proxy || target; };
+        target.toString = function () { return ""; };
+        target.valueOf = function () { return 0; };
+        target.toJSON = function () { return null; };
+        if (typeof Proxy === "undefined") { return target; }
+        proxy = new Proxy(target, {
+            get: function (object, property) { return safeGet(object, property, proxy); },
+            set: function () { return true; },
+            apply: function () { return proxy; },
+            construct: function () { return proxy; },
+            has: function () { return true; },
+            getOwnPropertyDescriptor: function (object, property) {
+                var descriptor = Object.getOwnPropertyDescriptor(object, property);
+                return descriptor || { configurable: true, enumerable: false, writable: true, value: proxy };
+            }
+        });
+        return proxy;
+    }
+
+    function createSafeObject(label) {
+        var nested = createSafeCallable(label + ".noop");
+        var target = {};
+        if (typeof Proxy === "undefined") { return nested; }
+        return new Proxy(target, {
+            get: function (object, property) { return safeGet(object, property, nested); },
+            set: function () { return true; },
+            has: function () { return true; },
+            getOwnPropertyDescriptor: function (object, property) {
+                var descriptor = Object.getOwnPropertyDescriptor(object, property);
+                return descriptor || { configurable: true, enumerable: false, writable: true, value: nested };
+            }
+        });
+    }
+
+    var safeScene = createSafeObject("scene");
+    var timerStub = function () { return 0; };
+    var modelAccessor = createSafeCallable("modelAccessor");
+
+    defineGlobal("Vec2", Vec2);
+    defineGlobal("Vec3", Vec3);
+    defineGlobal("Vec4", Vec4);
+    defineGlobal("Mat3", Mat3);
+    defineGlobal("Mat4", Mat4);
+    defineGlobal("clamp", clamp);
+    defineGlobal("mix", mix);
+    defineGlobal("saturate", saturate);
+    defineGlobal("radians", radians);
+    defineGlobal("degrees", degrees);
+    defineGlobal("toSpherical", toSpherical);
+    defineGlobal("refract", refract);
+    defineGlobal("setTimeout", timerStub);
+    defineGlobal("setInterval", timerStub);
+    defineGlobal("clearTimeout", timerStub);
+    defineGlobal("clearInterval", timerStub);
+    defineGlobal("scene", safeScene);
+    defineGlobal("thisScene", safeScene);
+    defineGlobal("thisLayer", createSafeObject("thisLayer"));
+    defineGlobal("thisProperty", createSafeObject("thisProperty"));
+    defineGlobal("IModelData", createSafeCallable("IModelData"));
+    defineGlobal("getModel", modelAccessor);
+    defineGlobal("getModelData", modelAccessor);
+    defineGlobal("getLayer", createSafeCallable("getLayer"));
+    defineGlobal("getScene", createSafeCallable("getScene"));
+
+    installMethod(root.engine, "getModel", modelAccessor);
+    installMethod(root.engine, "getModelData", modelAccessor);
+    installMethod(root.engine, "getLayer", createSafeCallable("engine.getLayer"));
+    installMethod(root.engine, "getScene", createSafeCallable("engine.getScene"));
+}());
+"""#
+}
+#endif

--- a/LiveWallpaper/Runtime/WPESceneScriptBaseclasses.swift
+++ b/LiveWallpaper/Runtime/WPESceneScriptBaseclasses.swift
@@ -204,20 +204,20 @@ enum WPESceneScriptBaseclasses {
         inverse() {
             var m = this.m;
             var b01 = m[8] * m[4] - m[5] * m[7];
-            var b11 = -m[8] * m[1] + m[2] * m[7];
-            var b21 = m[5] * m[1] - m[2] * m[4];
-            var det = m[0] * b01 + m[3] * b11 + m[6] * b21;
+            var b11 = -m[8] * m[3] + m[5] * m[6];
+            var b21 = m[7] * m[3] - m[4] * m[6];
+            var det = m[0] * b01 + m[1] * b11 + m[2] * b21;
             if (Math.abs(det) <= EPSILON) { return Mat3.identity(); }
             det = 1 / det;
             return new Mat3([
                 b01 * det,
-                (-m[8] * m[3] + m[5] * m[6]) * det,
-                (m[7] * m[3] - m[4] * m[6]) * det,
+                (-m[8] * m[1] + m[2] * m[7]) * det,
+                (m[5] * m[1] - m[2] * m[4]) * det,
                 b11 * det,
                 (m[8] * m[0] - m[2] * m[6]) * det,
-                (-m[7] * m[0] + m[1] * m[6]) * det,
-                b21 * det,
                 (-m[5] * m[0] + m[2] * m[3]) * det,
+                b21 * det,
+                (-m[7] * m[0] + m[1] * m[6]) * det,
                 (m[4] * m[0] - m[1] * m[3]) * det
             ]);
         }

--- a/LiveWallpaper/Runtime/WPESceneScriptRuntime.swift
+++ b/LiveWallpaper/Runtime/WPESceneScriptRuntime.swift
@@ -30,6 +30,7 @@ final class WPESceneScriptInstance {
         self.lastValue = initialValue
 
         Self.installSandbox(in: context)
+        WPESceneScriptBaseclasses.install(in: context)
         let prepared = Self.preprocess(script: script)
         context.exceptionHandler = { _, ex in
             _ = ex

--- a/LiveWallpaper/Runtime/WPESwiftShaderCompiler.swift
+++ b/LiveWallpaper/Runtime/WPESwiftShaderCompiler.swift
@@ -8,6 +8,11 @@ import Metal
 /// surfaces as `SceneRenderingError.metalRendererUnsupported`.
 struct WPESwiftShaderCompiler: WPEShaderCompiling {
     let device: MTLDevice
+    /// Fragment-only compiler contract: vertex execution always stays on the
+    /// built-in fullscreen quad. Model/vertex-domain shaders are never compiled
+    /// here — they surface a `.translationFailed`/`.mslLibraryFailed` diagnostic
+    /// and fall back (WebGL) rather than crashing Metal.
+    static let fixedVertexFunctionName = "wpe_fullscreen_vertex"
 
     init(device: MTLDevice) {
         self.device = device
@@ -77,7 +82,7 @@ struct WPESwiftShaderCompiler: WPEShaderCompiling {
 
         return WPEShaderCompileResult(
             library: library,
-            vertexFunctionName: "wpe_fullscreen_vertex",
+            vertexFunctionName: Self.fixedVertexFunctionName,
             fragmentFunctionName: "wpe_translated_fragment",
             mslSource: translation.mslSource,
             diagnostics: [],

--- a/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
+++ b/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
@@ -6,6 +6,27 @@ struct WPEVertexOut {
     float2 uv;
 };
 
+struct WPEMSDFTextVertex {
+    float2 position;
+    float2 uv;
+};
+
+// GPU MSDF text vertex stage. Reads per-glyph quad vertices (scene pixels +
+// atlas UV) and converts to NDC; outputs the same WPEVertexOut layout the
+// translated font.frag consumes via [[stage_in]] (position + uv).
+vertex WPEVertexOut wpe_msdf_text_vertex(
+    uint vid [[vertex_id]],
+    constant WPEMSDFTextVertex* verts [[buffer(0)]],
+    constant float2& sceneSize [[buffer(1)]]
+) {
+    WPEMSDFTextVertex v = verts[vid];
+    float2 halfSize = max(sceneSize * 0.5, float2(0.5));
+    WPEVertexOut out;
+    out.position = float4(v.position.x / halfSize.x - 1.0, 1.0 - v.position.y / halfSize.y, 0.0, 1.0);
+    out.uv = v.uv;
+    return out;
+}
+
 struct WPESolidUniforms {
     float4 color;
 };

--- a/LiveWallpaperTests/WPE28ShaderCompatibilityTests.swift
+++ b/LiveWallpaperTests/WPE28ShaderCompatibilityTests.swift
@@ -97,6 +97,14 @@ struct WPE28ShaderCompatibilityTests {
         try makeLibrary(result.mslSource)
     }
 
+    @Test("Fragment-only compiler keeps the built-in fullscreen vertex (no model-vertex path)")
+    func fragmentOnlyVertexContract() {
+        // The Swift compiler never owns a vertex stage — model/vertex-domain
+        // shaders fall back rather than crash Metal, so this name is the only
+        // vertex function it ever reports.
+        #expect(WPESwiftShaderCompiler.fixedVertexFunctionName == "wpe_fullscreen_vertex")
+    }
+
     @Test("font.frag non-MSDF raster branch (ConvertSampleR8) translates and compiles")
     func fontRasterBranchCompiles() throws {
         // The COLORFONT=0 raster path of font.frag. ConvertSampleR8 is supplied

--- a/LiveWallpaperTests/WPEMSDFAtlasTests.swift
+++ b/LiveWallpaperTests/WPEMSDFAtlasTests.swift
@@ -1,0 +1,56 @@
+import CoreGraphics
+import CoreText
+import Metal
+import Testing
+@testable import LiveWallpaper
+
+@MainActor
+struct WPEMSDFAtlasTests {
+
+    private func glyph(_ character: Character, font: CTFont) -> CGGlyph {
+        var chars = Array(String(character).utf16)
+        var glyphs = [CGGlyph](repeating: 0, count: chars.count)
+        _ = CTFontGetGlyphsForCharacters(font, &chars, &glyphs, chars.count)
+        return glyphs[0]
+    }
+
+    @Test("Atlas packs a glyph, caches the entry, and exposes a page texture")
+    func packsAndCaches() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
+        let generator = WPEMSDFGlyphGenerator()
+        let atlas = WPEMSDFAtlas(device: device)
+        let key = WPEMSDFGlyphKey(fontID: "Helvetica", glyph: glyph("A", font: font), pixelSize: 32)
+
+        let first = try #require(atlas.entry(for: key, generator: generator, font: font))
+        let second = try #require(atlas.entry(for: key, generator: generator, font: font))
+
+        // Cached: same page + UV on the repeat lookup.
+        #expect(first.page == second.page)
+        #expect(first.uvRect == second.uvRect)
+        // UV stays inside the normalized atlas page.
+        #expect(first.uvRect.minX >= 0 && first.uvRect.maxX <= 1)
+        #expect(first.uvRect.minY >= 0 && first.uvRect.maxY <= 1)
+        #expect(atlas.texture(page: first.page) != nil)
+    }
+
+    @Test("Atlas evicts the LRU page when full and regenerates on demand")
+    func evictsLeastRecentlyUsedPage() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
+        let generator = WPEMSDFGlyphGenerator()
+        // A 64px page holds exactly one ~40px glyph cell; maxPages: 1 forces the
+        // second distinct glyph to evict the first.
+        let atlas = WPEMSDFAtlas(device: device, pageSize: 64, maxPages: 1)
+        let keyA = WPEMSDFGlyphKey(fontID: "Helvetica", glyph: glyph("A", font: font), pixelSize: 32)
+        let keyB = WPEMSDFGlyphKey(fontID: "Helvetica", glyph: glyph("B", font: font), pixelSize: 32)
+
+        _ = try #require(atlas.entry(for: keyA, generator: generator, font: font))
+        let b = try #require(atlas.entry(for: keyB, generator: generator, font: font))
+        #expect(atlas.livePages().count <= 1)
+
+        // A was evicted; re-requesting it regenerates onto the same single page.
+        let aAgain = try #require(atlas.entry(for: keyA, generator: generator, font: font))
+        #expect(aAgain.page == b.page)
+    }
+}

--- a/LiveWallpaperTests/WPEMSDFGlyphGeneratorTests.swift
+++ b/LiveWallpaperTests/WPEMSDFGlyphGeneratorTests.swift
@@ -1,0 +1,57 @@
+import CoreGraphics
+import CoreText
+import Testing
+@testable import LiveWallpaper
+
+struct WPEMSDFGlyphGeneratorTests {
+
+    private func glyph(_ character: Character, font: CTFont) -> CGGlyph {
+        var chars = Array(String(character).utf16)
+        var glyphs = [CGGlyph](repeating: 0, count: chars.count)
+        _ = CTFontGetGlyphsForCharacters(font, &chars, &glyphs, chars.count)
+        return glyphs[0]
+    }
+
+    private func median(_ pixel: SIMD4<Float>) -> Float {
+        max(min(pixel.x, pixel.y), min(max(pixel.x, pixel.y), pixel.z))
+    }
+
+    @Test("Filled glyph yields a square MSDF bitmap, inside above 0.5 and padded corner below")
+    func generatesFilledGlyph() throws {
+        let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
+        let generator = WPEMSDFGlyphGenerator()
+        let result = try #require(generator.generate(glyph: glyph("B", font: font), font: font))
+        let bitmap = result.bitmap
+
+        #expect(bitmap.width == bitmap.height)
+        #expect(bitmap.width > 0)
+        #expect(bitmap.pixels.count == bitmap.width * bitmap.height)
+        // The top-left corner is inside the transparent padding → outside the
+        // glyph → median below 0.5.
+        #expect(median(bitmap[0, 0]) < 0.5)
+        // At least one texel sits inside the filled glyph → median above 0.5.
+        #expect(bitmap.pixels.contains { median($0) > 0.5 })
+        // Alpha is always opaque and every channel is finite (no NaN distances).
+        #expect(bitmap.pixels.allSatisfy { $0.w == 1 && $0.x.isFinite && $0.y.isFinite && $0.z.isFinite })
+    }
+
+    @Test("Glyph generation is deterministic")
+    func generationIsDeterministic() throws {
+        let font = CTFontCreateWithName("Helvetica" as CFString, 24, nil)
+        let generator = WPEMSDFGlyphGenerator()
+        let target = glyph("A", font: font)
+        let first = try #require(generator.generate(glyph: target, font: font))
+        let second = try #require(generator.generate(glyph: target, font: font))
+        #expect(first.bitmap.pixels == second.bitmap.pixels)
+    }
+
+    @Test("Whitespace glyph produces a valid neutral bitmap without crashing")
+    func whitespaceGlyphIsNeutral() throws {
+        let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
+        let generator = WPEMSDFGlyphGenerator()
+        let result = try #require(generator.generate(glyph: glyph(" ", font: font), font: font))
+        // No contours → neutral 0.5 fill: opaque, everywhere outside.
+        #expect(result.bitmap.pixels.allSatisfy { $0.w == 1 })
+        #expect(result.bitmap.pixels.allSatisfy { median($0) <= 0.5 + 1e-6 })
+    }
+}

--- a/LiveWallpaperTests/WPEMSDFTextPipelineTests.swift
+++ b/LiveWallpaperTests/WPEMSDFTextPipelineTests.swift
@@ -1,0 +1,89 @@
+import CoreGraphics
+import CoreText
+import LiveWallpaperProWPE
+import Metal
+import Testing
+@testable import LiveWallpaper
+
+/// Standalone gate for the GPU MSDF text pipeline (Milestone D) — exercises the
+/// font-material packing and CoreText→atlas layout without the live scene-render
+/// wiring, so the math is locked in before any on-device draw integration.
+@MainActor
+struct WPEMSDFTextPipelineTests {
+
+    private func makeTextObject(
+        text: String = "Hi",
+        outlineSize: Double = 0,
+        blurSize: Double = 0,
+        shadowSize: Double = 0,
+        shadowOffset: SIMD2<Double> = SIMD2<Double>(0, 0)
+    ) -> WPESceneTextObject {
+        WPESceneTextObject(
+            id: "t", name: "T", text: text,
+            fontRelativePath: nil, pointSize: 32,
+            color: SIMD3<Double>(1, 0.5, 0.25), alpha: 0.8,
+            origin: SIMD3<Double>(0, 0, 0), scale: SIMD3<Double>(1, 1, 1),
+            visible: true, horizontalAlignment: "center", verticalAlignment: "middle",
+            maxWidth: nil, parallaxDepth: 0,
+            outlineSize: outlineSize, outlineColor: SIMD3<Double>(0, 1, 0),
+            blurSize: blurSize, shadowSize: shadowSize, shadowColor: SIMD3<Double>(0, 0, 1),
+            shadowOffset: shadowOffset, letterSpacing: 1
+        )
+    }
+
+    @Test("Font material packs the authoritative RenderVar layout and derives combos")
+    func fontMaterialPacksRenderVars() {
+        let object = makeTextObject(outlineSize: 3, blurSize: 2, shadowSize: 4, shadowOffset: SIMD2<Double>(5, -6))
+        let material = WPEMSDFFontMaterial.make(object: object, parameters: WPEMSDFParameters())
+
+        #expect(material.combos["MSDF"] == 1)
+        #expect(material.combos["COLORFONT"] == 0)
+        #expect(material.combos["OUTLINE_ENABLED"] == 1)
+        #expect(material.combos["BLUR_ENABLED"] == 1)
+        #expect(material.combos["DROP_SHADOW_ENABLED"] == 1)
+
+        // g_RenderVar0 = (MSDF_RANGE, OUTLINE_WIDTH, BLUR_RADIUS, DROP_SHADOW_RADIUS)
+        #expect(material.uniforms["g_RenderVar0"]?.vectorValue == [4, 3, 2, 4])
+        // g_RenderVar1 = (OUTLINE_COLOR.rgb, DROP_SHADOW_OFFSET.x)
+        #expect(material.uniforms["g_RenderVar1"]?.vectorValue == [0, 1, 0, 5])
+        // g_RenderVar2 = (DROP_SHADOW_COLOR.rgb, DROP_SHADOW_OFFSET.y)
+        #expect(material.uniforms["g_RenderVar2"]?.vectorValue == [0, 0, 1, -6])
+        // g_RenderVar3 = (DROP_SHADOW_OPACITY, 0, 0, 0)
+        #expect(material.uniforms["g_RenderVar3"]?.vectorValue == [1, 0, 0, 0])
+        // Fill color = g_Color4 (rgb + alpha).
+        #expect(material.uniforms["g_Color4"]?.vectorValue == [1, 0.5, 0.25, 0.8])
+    }
+
+    @Test("Plain text disables every optional effect combo")
+    func fontMaterialPlainTextDisablesEffects() {
+        let material = WPEMSDFFontMaterial.make(object: makeTextObject(), parameters: WPEMSDFParameters())
+        #expect(material.combos["OUTLINE_ENABLED"] == 0)
+        #expect(material.combos["BLUR_ENABLED"] == 0)
+        #expect(material.combos["DROP_SHADOW_ENABLED"] == 0)
+        #expect(material.uniforms["g_RenderVar3"]?.vectorValue == [0, 0, 0, 0])
+    }
+
+    @Test("Layout produces one six-vertex quad per glyph grouped by atlas page")
+    func layoutProducesQuadsPerGlyph() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let atlas = WPEMSDFAtlas(device: device)
+        let generator = WPEMSDFGlyphGenerator()
+        let layout = WPEMSDFTextLayout()
+        let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
+        let object = makeTextObject(text: "Hi")
+
+        let mesh = try #require(layout.layout(
+            object: object,
+            font: font,
+            atlas: atlas,
+            generator: generator,
+            fontID: "Helvetica@32"
+        ))
+
+        #expect(!mesh.perPage.isEmpty)
+        let totalVertices = mesh.perPage.values.reduce(0) { $0 + $1.count }
+        // Two glyphs ("Hi") × 6 vertices per quad.
+        #expect(totalVertices == 12)
+        #expect(totalVertices % 6 == 0)
+    }
+}

--- a/LiveWallpaperTests/WPESceneDocumentParserTests.swift
+++ b/LiveWallpaperTests/WPESceneDocumentParserTests.swift
@@ -227,6 +227,56 @@ struct WPESceneDocumentParserTests {
         #expect(text.resolvedAlpha(at: 4) == 0)
     }
 
+    @Test("WPE 2.8 MSDF text effect keys parse into the text object with neutral defaults")
+    func textObjectParsesMSDFEffectKeys() throws {
+        let payload: [String: Any] = [
+            "camera": ["center": "0 0 0"],
+            "general": ["orthogonalprojection": ["width": 1920, "height": 1080, "auto": true]],
+            "objects": [
+                [
+                    "id": "effect-text",
+                    "name": "Effect Text",
+                    "type": "text",
+                    "text": "Glow",
+                    "outlinesize": 3,
+                    "outlinecolor": "1 0 0",
+                    "blursize": 2,
+                    "shadowsize": 4,
+                    "shadowcolor": "0 0 1",
+                    "shadowoffset": "5 -6",
+                    "letterspacing": 1.5
+                ],
+                [
+                    "id": "plain-text",
+                    "name": "Plain Text",
+                    "type": "text",
+                    "text": "Plain"
+                ]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let document = try WPESceneDocumentParser.parse(data: data)
+
+        let effect = try #require(document.textObjects.first { $0.id == "effect-text" })
+        #expect(effect.outlineSize == 3)
+        #expect(effect.outlineColor == SIMD3<Double>(1, 0, 0))
+        #expect(effect.blurSize == 2)
+        #expect(effect.shadowSize == 4)
+        #expect(effect.shadowColor == SIMD3<Double>(0, 0, 1))
+        #expect(effect.shadowOffset == SIMD2<Double>(5, -6))
+        #expect(effect.letterSpacing == 1.5)
+
+        // A 2.7-style text object without effect keys stays neutral, so the
+        // CoreText fallback and existing scenes are unaffected.
+        let plain = try #require(document.textObjects.first { $0.id == "plain-text" })
+        #expect(plain.outlineSize == 0)
+        #expect(plain.blurSize == 0)
+        #expect(plain.shadowSize == 0)
+        #expect(plain.shadowOffset == SIMD2<Double>(0, 0))
+        #expect(plain.letterSpacing == 0)
+    }
+
     @Test("Image object inherits parent transform from non-renderable group object")
     func imageObjectInheritsParentTransform() throws {
         let payload: [String: Any] = [

--- a/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
+++ b/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
@@ -105,4 +105,63 @@ struct WPESceneScriptRuntimeTests {
         let instance = try WPESceneScriptInstance(script: script, initialValue: "?")
         #expect(instance.tickString() == "value-set")
     }
+
+    // MARK: - WPE 2.8 baseclasses (Vec/Mat math + tolerant globals)
+
+    @Test("Vec3 math from the 2.8 baseclasses computes correctly")
+    func vec3MathAvailable() throws {
+        // A wrong/absent Vec3 would throw → the runtime falls back to the
+        // initial value, so a correct numeric result proves the class ran.
+        let script = """
+        export function update(value) { return String(new Vec3(0, 3, 4).length()); }
+        """
+        let instance = try WPESceneScriptInstance(script: script, initialValue: "init")
+        #expect(instance.tickString() == "5")
+    }
+
+    @Test("Mat4.identity().normalMatrix() is the identity 3×3")
+    func mat4NormalMatrixIdentity() throws {
+        // Guards the column-major Mat4 identity: a corrupt identity would make
+        // inverse/normalMatrix diverge from the identity 3×3.
+        let script = """
+        export function update(value) {
+            return Mat4.identity().normalMatrix().m.join(',');
+        }
+        """
+        let instance = try WPESceneScriptInstance(script: script, initialValue: "init")
+        #expect(instance.tickString() == "1,0,0,0,1,0,0,0,1")
+    }
+
+    @Test("Tolerant globals make scene/thisLayer/timers/model references harmless")
+    func tolerantGlobalsNeverThrow() throws {
+        // These are the exact 2.8 failure shapes from the WPE install log:
+        // `scene is not defined`, `setTimeout is not defined`, and null derefs
+        // on `.origin` / `.visible`. With the baseclasses they must not throw —
+        // a clean "tolerant" result proves no ReferenceError/TypeError fired.
+        let script = """
+        export function update(value) {
+            setTimeout(function () {}, 16);
+            var origin = thisLayer.origin;
+            origin.x;
+            thisLayer.visible = false;
+            scene.customField = 42;
+            var model = getModel('character');
+            var depth = model.bones.head.position.z;
+            return 'tolerant';
+        }
+        """
+        let instance = try WPESceneScriptInstance(script: script, initialValue: "init")
+        #expect(instance.tickString() == "tolerant")
+    }
+
+    @Test("Baseclasses do not clobber the existing engine sandbox")
+    func baseclassesPreserveExistingSandbox() throws {
+        let script = """
+        export function update(value) {
+            return (typeof engine.getTimeOfDay === 'function') ? 'kept' : 'lost';
+        }
+        """
+        let instance = try WPESceneScriptInstance(script: script, initialValue: "init")
+        #expect(instance.tickString() == "kept")
+    }
 }

--- a/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
+++ b/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
@@ -132,6 +132,27 @@ struct WPESceneScriptRuntimeTests {
         #expect(instance.tickString() == "1,0,0,0,1,0,0,0,1")
     }
 
+    @Test("Mat3.inverse() is the true inverse, not its transpose")
+    func mat3InverseIsTrueInverse() throws {
+        // Regression: inverse() used to return the cofactor matrix (the
+        // transpose of the inverse) for non-symmetric M. M·M⁻¹ must be the
+        // identity 3×3; a transposed inverse fails this. M below has det = 1.
+        let script = """
+        export function update(value) {
+            var m = new Mat3([1, 2, 3, 0, 1, 4, 5, 6, 0]);
+            var p = m.multiply(m.inverse()).m;
+            var ok = true;
+            var id = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+            for (var i = 0; i < 9; i += 1) {
+                if (Math.abs(p[i] - id[i]) > 1e-9) { ok = false; }
+            }
+            return ok ? 'identity' : p.join(',');
+        }
+        """
+        let instance = try WPESceneScriptInstance(script: script, initialValue: "init")
+        #expect(instance.tickString() == "identity")
+    }
+
     @Test("Tolerant globals make scene/thisLayer/timers/model references harmless")
     func tolerantGlobalsNeverThrow() throws {
         // These are the exact 2.8 failure shapes from the WPE install log:

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
@@ -172,6 +172,15 @@ public struct WPESceneTextObject: Equatable, Sendable, Identifiable {
     public let boxSize: SIMD2<Double>?
     /// Transparent margin (scene pixels) inside `boxSize` around the text.
     public let padding: Double
+    /// WPE 2.8 MSDF text effects (all default to disabled / neutral so 2.7
+    /// scenes and the CoreText fallback are unaffected).
+    public let outlineSize: Double
+    public let outlineColor: SIMD3<Double>
+    public let blurSize: Double
+    public let shadowSize: Double
+    public let shadowColor: SIMD3<Double>
+    public let shadowOffset: SIMD2<Double>
+    public let letterSpacing: Double
 
     public init(
         id: String,
@@ -191,7 +200,14 @@ public struct WPESceneTextObject: Equatable, Sendable, Identifiable {
         maxWidth: Double?,
         parallaxDepth: Double,
         boxSize: SIMD2<Double>? = nil,
-        padding: Double = 0
+        padding: Double = 0,
+        outlineSize: Double = 0,
+        outlineColor: SIMD3<Double> = SIMD3<Double>(0, 0, 0),
+        blurSize: Double = 0,
+        shadowSize: Double = 0,
+        shadowColor: SIMD3<Double> = SIMD3<Double>(0, 0, 0),
+        shadowOffset: SIMD2<Double> = SIMD2<Double>(0, 0),
+        letterSpacing: Double = 0
     ) {
         self.id = id
         self.name = name
@@ -211,6 +227,13 @@ public struct WPESceneTextObject: Equatable, Sendable, Identifiable {
         self.parallaxDepth = parallaxDepth
         self.boxSize = boxSize
         self.padding = padding
+        self.outlineSize = outlineSize
+        self.outlineColor = outlineColor
+        self.blurSize = blurSize
+        self.shadowSize = shadowSize
+        self.shadowColor = shadowColor
+        self.shadowOffset = shadowOffset
+        self.letterSpacing = letterSpacing
     }
 
     public func resolvedAlpha(at time: Double) -> Double {
@@ -239,7 +262,14 @@ public struct WPESceneTextObject: Equatable, Sendable, Identifiable {
             maxWidth: maxWidth,
             parallaxDepth: parallaxDepth,
             boxSize: boxSize,
-            padding: padding
+            padding: padding,
+            outlineSize: outlineSize,
+            outlineColor: outlineColor,
+            blurSize: blurSize,
+            shadowSize: shadowSize,
+            shadowColor: shadowColor,
+            shadowOffset: shadowOffset,
+            letterSpacing: letterSpacing
         )
     }
 }


### PR DESCRIPTION
Completes the WPE 2.7→2.8 asset migration: pure-Swift MSDF core (geometry/edge-coloring/glyph-gen/atlas), JS baseclasses + HDR/fragment-only hardening, text-effect schema, and GPU MSDF text wired into the live render path with an all-or-nothing CoreText fallback (never errors). `wpe_msdf_text_vertex` reuses `WPEVertexOut` for the proven `font.frag` stage-in linkage.

Build green; MSDF/text/script/compile-gate suites pass. Remaining: on-device visual validation of MSDF text + the 2.8 corpus run. Note: 3 red tests (suspended brightness / FBO previous / textureCandidates) pre-exist on main from the WebGL-removal line — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)