### PR TITLE
feat(wpe-2.8): align MSDF text with WPE — pseudo-distance quality + async generation

### DIFF
--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
@@ -141,11 +141,27 @@ final class WPEMSDFAtlas {
         }
     }
 
+    private struct GeneratedGlyph: @unchecked Sendable {
+        let bitmap: WPEMSDFBitmap
+        let metrics: WPEMSDFGlyphMetrics
+    }
+
+    /// Wraps the (non-Sendable) CTFont + generator so the background generation
+    /// task can capture them across the @Sendable boundary safely (the inputs
+    /// are only read, and the generator is immutable).
+    private struct GlyphGenerationRequest: @unchecked Sendable {
+        let key: WPEMSDFGlyphKey
+        let generator: WPEMSDFGlyphGenerator
+        let font: CTFont
+        let maxCellSide: Int
+    }
+
     private let device: MTLDevice
     private let pageSize: Int
     private let maxPages: Int
     private var pages: [Page] = []
     private var entries: [WPEMSDFGlyphKey: WPEMSDFAtlasEntry] = [:]
+    private var pending: Set<WPEMSDFGlyphKey> = []
     private var clock: UInt64 = 0
 
     init(device: MTLDevice, pageSize: Int = 1024, maxPages: Int = 4) {
@@ -159,12 +175,65 @@ final class WPEMSDFAtlas {
         generator: WPEMSDFGlyphGenerator,
         font: CTFont
     ) -> WPEMSDFAtlasEntry? {
+        if let cached = cachedEntry(for: key) {
+            return cached
+        }
+        guard let generated = generator.generate(glyph: key.glyph, font: font, maxCellSide: pageSize) else { return nil }
+        return store(
+            generated: GeneratedGlyph(bitmap: generated.bitmap, metrics: generated.metrics),
+            for: key
+        )
+    }
+
+    /// Cache-only lookup (no generation). Cheap; safe to call every frame.
+    func cachedEntry(for key: WPEMSDFGlyphKey) -> WPEMSDFAtlasEntry? {
         if let cached = entries[key], let page = page(for: cached.page) {
             touch(page)
             return cached
         }
+        return nil
+    }
 
-        guard let generated = generator.generate(glyph: key.glyph, font: font, maxCellSide: pageSize) else { return nil }
+    /// Non-blocking entry: returns the cached entry if present, otherwise kicks
+    /// off background glyph generation (deduplicated) and returns nil so the
+    /// caller falls back (CoreText) for this frame. A later frame finds it cached.
+    func requestEntry(
+        for key: WPEMSDFGlyphKey,
+        generator: WPEMSDFGlyphGenerator,
+        font: CTFont
+    ) -> WPEMSDFAtlasEntry? {
+        if let cached = cachedEntry(for: key) {
+            return cached
+        }
+        guard !pending.contains(key) else { return nil }
+        pending.insert(key)
+        let request = GlyphGenerationRequest(
+            key: key,
+            generator: generator,
+            font: font,
+            maxCellSide: pageSize
+        )
+        Task.detached(priority: .utility) { [request, weak self] in
+            let generated = request.generator.generate(
+                glyph: request.key.glyph,
+                font: request.font,
+                maxCellSide: request.maxCellSide
+            ).map { GeneratedGlyph(bitmap: $0.bitmap, metrics: $0.metrics) }
+            await MainActor.run { [weak self] in
+                self?.completeGeneration(generated, for: request.key)
+            }
+        }
+        return nil
+    }
+
+    private func completeGeneration(_ generated: GeneratedGlyph?, for key: WPEMSDFGlyphKey) {
+        defer { pending.remove(key) }
+        guard entries[key] == nil, let generated else { return }
+        _ = store(generated: generated, for: key)
+    }
+
+    @discardableResult
+    private func store(generated: GeneratedGlyph, for key: WPEMSDFGlyphKey) -> WPEMSDFAtlasEntry? {
         let bitmap = generated.bitmap
         guard bitmap.width <= pageSize, bitmap.height <= pageSize else { return nil }
         guard let allocation = allocate(width: bitmap.width, height: bitmap.height) else { return nil }

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFEdgeColoring.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFEdgeColoring.swift
@@ -5,7 +5,7 @@ enum WPEMSDFEdgeColoring {
     private static let palette: [WPEMSDFEdgeColor] = [.yellow, .cyan, .magenta]
 
     static func colorShape(_ shape: inout WPEMSDFShape, angleThreshold: Double) {
-        let threshold = max(angleThreshold, 0)
+        let threshold = WPEMSDFGeometryMath.clamp(angleThreshold, 0, Double.pi)
         for contourIndex in shape.contours.indices {
             colorContour(&shape.contours[contourIndex], angleThreshold: threshold)
         }
@@ -50,25 +50,26 @@ enum WPEMSDFEdgeColoring {
         let count = contour.segments.count
         guard count > 0 else { return [] }
         var indices: [Int] = []
+        let crossThreshold = sin(angleThreshold)
         for index in 0..<count {
             let previous = contour.segments[(index + count - 1) % count]
             let current = contour.segments[index]
-            if cornerAngle(previous: previous, current: current) > angleThreshold {
+            if isCorner(previous: previous, current: current, crossThreshold: crossThreshold) {
                 indices.append(index)
             }
         }
         return indices
     }
 
-    private static func cornerAngle(previous: WPEMSDFSegment, current: WPEMSDFSegment) -> Double {
+    private static func isCorner(previous: WPEMSDFSegment, current: WPEMSDFSegment, crossThreshold: Double) -> Bool {
         let a = previous.direction(at: 1)
         let b = current.direction(at: 0)
         guard WPEMSDFGeometryMath.length(a) > WPEMSDFGeometryMath.epsilon,
               WPEMSDFGeometryMath.length(b) > WPEMSDFGeometryMath.epsilon else {
-            return 0
+            return false
         }
         let dot = WPEMSDFGeometryMath.clamp(WPEMSDFGeometryMath.dot(a, b), -1, 1)
-        return acos(dot)
+        return dot <= 0 || abs(WPEMSDFGeometryMath.cross(a, b)) > crossThreshold
     }
 
     private static func splitIntoThirds(_ segment: WPEMSDFSegment) -> [WPEMSDFSegment] {
@@ -89,11 +90,38 @@ enum WPEMSDFEdgeColoring {
 
     private static func colorsForCornerCount(_ count: Int) -> [WPEMSDFEdgeColor] {
         guard count > 0 else { return [] }
-        var colors = (0..<count).map { palette[$0 % palette.count] }
+        var colors: [WPEMSDFEdgeColor] = []
+        colors.reserveCapacity(count)
+        var color = palette[0]
+        for _ in 0..<count {
+            colors.append(color)
+            color = nextColor(after: color)
+        }
         if count > 1, colors.last == colors.first {
-            colors[colors.count - 1] = .cyan
+            colors[colors.count - 1] = nextColor(after: colors[colors.count - 2], banning: colors[0])
         }
         return colors
+    }
+
+    /// msdfgen-style color switch: pick a color sharing exactly one channel with
+    /// the previous edge so the two edges meeting at each corner differ in one
+    /// channel (which is what makes the median reconstruct a sharp corner).
+    private static func nextColor(
+        after color: WPEMSDFEdgeColor,
+        banning banned: WPEMSDFEdgeColor? = nil
+    ) -> WPEMSDFEdgeColor {
+        let candidates: [WPEMSDFEdgeColor]
+        switch color {
+        case .yellow:
+            candidates = [.cyan, .magenta]
+        case .cyan:
+            candidates = [.magenta, .yellow]
+        case .magenta:
+            candidates = [.yellow, .cyan]
+        default:
+            candidates = palette
+        }
+        return candidates.first { $0 != banned } ?? candidates[0]
     }
 
     private static func assignSpan(

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFGeometry.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFGeometry.swift
@@ -28,10 +28,20 @@ enum WPEMSDFGeometryMath {
         min(max(value, lower), upper)
     }
 
+    static func nonZeroSign(_ value: Double) -> Double {
+        value > 0 ? 1.0 : -1.0
+    }
+
+    static func median(_ a: Double, _ b: Double, _ c: Double) -> Double {
+        max(min(a, b), min(max(a, b), c))
+    }
+
     static func lerp(_ a: WPEMSDFPoint, _ b: WPEMSDFPoint, _ t: Double) -> WPEMSDFPoint {
         a + (b - a) * t
     }
 }
+
+typealias WPEMSDFSignedDistance = (distance: Double, dot: Double)
 
 enum WPEMSDFSegment {
     case linear(p0: WPEMSDFPoint, p1: WPEMSDFPoint, color: WPEMSDFEdgeColor)
@@ -110,21 +120,53 @@ enum WPEMSDFSegment {
         return WPEMSDFGeometryMath.normalized(endPoint - startPoint)
     }
 
-    func signedDistance(to p: WPEMSDFPoint) -> (distance: Double, orthogonality: Double) {
-        let t: Double
+    func signedDistance(to p: WPEMSDFPoint) -> (distance: WPEMSDFSignedDistance, t: Double) {
+        let distanceT: Double
+        let pseudoT: Double
         switch self {
         case let .linear(p0, p1, _):
             let edge = p1 - p0
             let denom = WPEMSDFGeometryMath.dot(edge, edge)
-            t = denom > WPEMSDFGeometryMath.epsilon
-                ? WPEMSDFGeometryMath.clamp(WPEMSDFGeometryMath.dot(p - p0, edge) / denom, 0, 1)
+            let t = denom > WPEMSDFGeometryMath.epsilon
+                ? WPEMSDFGeometryMath.dot(p - p0, edge) / denom
                 : 0
+            distanceT = WPEMSDFGeometryMath.clamp(t, 0, 1)
+            pseudoT = t
         case .quadratic:
-            t = nearestParameter(to: p, samples: 16, refinementSteps: 4)
+            let t = nearestParameter(to: p, samples: 16, refinementSteps: 4)
+            distanceT = t
+            pseudoT = pseudoDistanceParameter(nearest: t, origin: p)
         case .cubic:
-            t = nearestParameter(to: p, samples: 24, refinementSteps: 6)
+            let t = nearestParameter(to: p, samples: 24, refinementSteps: 6)
+            distanceT = t
+            pseudoT = pseudoDistanceParameter(nearest: t, origin: p)
         }
-        return distance(at: t, to: p)
+        return (signedDistance(at: distanceT, to: p), pseudoT)
+    }
+
+    func distanceToPseudoDistance(_ sd: WPEMSDFSignedDistance, origin p: WPEMSDFPoint, t: Double) -> Double {
+        let endpoint: WPEMSDFPoint
+        let tangent: WPEMSDFPoint
+        let isBeyondEndpoint: (Double) -> Bool
+
+        if t < 0 {
+            endpoint = point(at: 0)
+            tangent = direction(at: 0)
+            isBeyondEndpoint = { $0 < 0 }
+        } else if t > 1 {
+            endpoint = point(at: 1)
+            tangent = direction(at: 1)
+            isBeyondEndpoint = { $0 > 0 }
+        } else {
+            return sd.distance
+        }
+
+        let delta = p - endpoint
+        let projection = WPEMSDFGeometryMath.dot(delta, tangent)
+        guard isBeyondEndpoint(projection) else { return sd.distance }
+
+        let pseudoDistance = WPEMSDFGeometryMath.cross(tangent, delta)
+        return abs(pseudoDistance) <= abs(sd.distance) ? pseudoDistance : sd.distance
     }
 
     func split(at t: Double) -> (WPEMSDFSegment, WPEMSDFSegment) {
@@ -222,16 +264,27 @@ enum WPEMSDFSegment {
         return t
     }
 
-    private func distance(at t: Double, to p: WPEMSDFPoint) -> (distance: Double, orthogonality: Double) {
+    private func pseudoDistanceParameter(nearest t: Double, origin p: WPEMSDFPoint) -> Double {
+        if t <= WPEMSDFGeometryMath.epsilon {
+            let projection = WPEMSDFGeometryMath.dot(p - point(at: 0), direction(at: 0))
+            if projection < 0 { return -1 }
+        } else if t >= 1 - WPEMSDFGeometryMath.epsilon {
+            let projection = WPEMSDFGeometryMath.dot(p - point(at: 1), direction(at: 1))
+            if projection > 0 { return 2 }
+        }
+        return t
+    }
+
+    private func signedDistance(at t: Double, to p: WPEMSDFPoint) -> WPEMSDFSignedDistance {
         let q = point(at: t)
         let delta = p - q
         let magnitude = WPEMSDFGeometryMath.length(delta)
         let tangent = direction(at: t)
-        let sign = WPEMSDFGeometryMath.cross(tangent, delta) >= 0 ? 1.0 : -1.0
-        let orthogonality = magnitude > WPEMSDFGeometryMath.epsilon
+        let sign = WPEMSDFGeometryMath.nonZeroSign(WPEMSDFGeometryMath.cross(tangent, delta))
+        let dot = magnitude > WPEMSDFGeometryMath.epsilon
             ? abs(WPEMSDFGeometryMath.dot(delta / magnitude, tangent))
             : 0
-        return (distance: sign * magnitude, orthogonality: orthogonality)
+        return (distance: sign * magnitude, dot: dot)
     }
 }
 
@@ -241,6 +294,11 @@ struct WPEMSDFContour {
 
 struct WPEMSDFShape {
     var contours: [WPEMSDFContour]
+
+    private struct EdgeDistance {
+        let signedDistance: WPEMSDFSignedDistance
+        let pseudoDistance: Double
+    }
 
     func bounds() -> CGRect {
         var hasPoint = false
@@ -282,47 +340,75 @@ struct WPEMSDFShape {
     }
 
     func signedDistance(at point: WPEMSDFPoint, channel: WPEMSDFEdgeColor) -> Double {
-        let closest = closestDistance(at: point, channel: channel) ?? closestDistance(at: point, channel: nil)
-        guard let closest else { return 0 }
-        let sign = windingNumber(at: point) == 0 ? -1.0 : 1.0
-        return sign * abs(closest.distance)
-    }
-
-    /// Per-channel signed distances for one pixel, computing the inside/outside
-    /// sign (the expensive winding test) ONCE and sharing it across R/G/B —
-    /// identical output to three `signedDistance(at:channel:)` calls but ~⅓ the
-    /// winding cost. Used by the glyph generator's hot per-pixel loop.
-    func signedDistances(at point: WPEMSDFPoint) -> (r: Double, g: Double, b: Double) {
-        let sign = windingNumber(at: point) == 0 ? -1.0 : 1.0
-        func magnitude(_ channel: WPEMSDFEdgeColor) -> Double {
-            let closest = closestDistance(at: point, channel: channel) ?? closestDistance(at: point, channel: nil)
-            return sign * abs(closest?.distance ?? 0)
+        let distances = signedDistances(at: point)
+        switch channel {
+        case .red:
+            return distances.r
+        case .green:
+            return distances.g
+        case .blue:
+            return distances.b
+        default:
+            return WPEMSDFGeometryMath.median(distances.r, distances.g, distances.b)
         }
-        return (magnitude(.red), magnitude(.green), magnitude(.blue))
     }
 
-    private func closestDistance(
-        at point: WPEMSDFPoint,
-        channel: WPEMSDFEdgeColor?
-    ) -> (distance: Double, orthogonality: Double)? {
-        var best: (distance: Double, orthogonality: Double)?
-        for contour in contours {
-            for segment in contour.segments {
-                if let channel, !segment.color.contains(channel) {
-                    continue
-                }
-                let candidate = segment.signedDistance(to: point)
-                if isBetter(candidate, than: best) {
-                    best = candidate
-                }
+    /// Per-channel signed pseudo-distances for one pixel (msdfgen semantics):
+    /// pick each channel's nearest same-color edge, take that edge's signed
+    /// pseudo-distance, then correct the overall sign against the winding number
+    /// so glyph fill can never invert regardless of contour orientation.
+    func signedDistances(at point: WPEMSDFPoint) -> (r: Double, g: Double, b: Double) {
+        let distances = closestDistances(at: point)
+        func value(_ candidate: EdgeDistance?) -> Double {
+            (candidate ?? distances.any)?.pseudoDistance ?? 0
+        }
+
+        var r = value(distances.red)
+        var g = value(distances.green)
+        var b = value(distances.blue)
+        let insideSign = windingNumber(at: point) == 0 ? -1.0 : 1.0
+        let median = WPEMSDFGeometryMath.median(r, g, b)
+        if WPEMSDFGeometryMath.nonZeroSign(median) != insideSign {
+            r = -r
+            g = -g
+            b = -b
+        }
+        return (r, g, b)
+    }
+
+    private func closestDistances(
+        at point: WPEMSDFPoint
+    ) -> (red: EdgeDistance?, green: EdgeDistance?, blue: EdgeDistance?, any: EdgeDistance?) {
+        var red: EdgeDistance?
+        var green: EdgeDistance?
+        var blue: EdgeDistance?
+        var any: EdgeDistance?
+
+        func update(_ current: inout EdgeDistance?, with candidate: EdgeDistance) {
+            if isBetter(candidate.signedDistance, than: current?.signedDistance) {
+                current = candidate
             }
         }
-        return best
+
+        for contour in contours {
+            for segment in contour.segments {
+                let distance = segment.signedDistance(to: point)
+                let candidate = EdgeDistance(
+                    signedDistance: distance.distance,
+                    pseudoDistance: segment.distanceToPseudoDistance(distance.distance, origin: point, t: distance.t)
+                )
+                update(&any, with: candidate)
+                if segment.color.contains(.red) { update(&red, with: candidate) }
+                if segment.color.contains(.green) { update(&green, with: candidate) }
+                if segment.color.contains(.blue) { update(&blue, with: candidate) }
+            }
+        }
+        return (red, green, blue, any)
     }
 
     private func isBetter(
-        _ candidate: (distance: Double, orthogonality: Double),
-        than current: (distance: Double, orthogonality: Double)?
+        _ candidate: WPEMSDFSignedDistance,
+        than current: WPEMSDFSignedDistance?
     ) -> Bool {
         guard let current else { return true }
         let candidateDistance = abs(candidate.distance)
@@ -330,7 +416,7 @@ struct WPEMSDFShape {
         if abs(candidateDistance - currentDistance) > 1.0e-7 {
             return candidateDistance < currentDistance
         }
-        return candidate.orthogonality < current.orthogonality
+        return candidate.dot < current.dot
     }
 
     private func windingNumber(at point: WPEMSDFPoint) -> Int {

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFGlyphGenerator.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFGlyphGenerator.swift
@@ -4,7 +4,7 @@ import CoreText
 import Foundation
 import simd
 
-final class WPEMSDFGlyphGenerator {
+final class WPEMSDFGlyphGenerator: @unchecked Sendable {
     private let parameters: WPEMSDFParameters
     private static let neutralFill = SIMD4<Float>(0.5, 0.5, 0.5, 1)
 

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
@@ -61,6 +61,7 @@ struct WPEMSDFTextLayout {
         let pixelSize = max(Int(ceil(CTFontGetSize(font))), 1)
         let runs = CTLineGetGlyphRuns(line) as! [CTRun]
         var perPage: [Int: [WPEMSDFTextVertex]] = [:]
+        var isComplete = true
 
         for run in runs {
             let glyphCount = CTRunGetGlyphCount(run)
@@ -76,7 +77,10 @@ struct WPEMSDFTextLayout {
             for index in 0..<glyphCount {
                 let glyph = glyphs[index]
                 let key = WPEMSDFGlyphKey(fontID: fontID, glyph: glyph, pixelSize: pixelSize)
-                guard let entry = atlas.entry(for: key, generator: generator, font: font) else { return nil }
+                guard let entry = atlas.requestEntry(for: key, generator: generator, font: font) else {
+                    isComplete = false
+                    continue
+                }
                 let position = positions[index]
                 let bearing = entry.metrics.bearing / pathUnitsToEm
                 let glyphWidth = Double(entry.metrics.cellSize.width) / entry.metrics.scale
@@ -93,7 +97,7 @@ struct WPEMSDFTextLayout {
             }
         }
 
-        guard !perPage.isEmpty else { return nil }
+        guard isComplete, !perPage.isEmpty else { return nil }
         return WPEMSDFTextMesh(perPage: perPage, size: boxSize)
     }
 

--- a/LiveWallpaperTests/WPEMSDFTextPipelineTests.swift
+++ b/LiveWallpaperTests/WPEMSDFTextPipelineTests.swift
@@ -64,7 +64,7 @@ struct WPEMSDFTextPipelineTests {
     }
 
     @Test("Layout produces one six-vertex quad per glyph grouped by atlas page")
-    func layoutProducesQuadsPerGlyph() throws {
+    func layoutProducesQuadsPerGlyph() async throws {
         let device = try #require(MTLCreateSystemDefaultDevice())
         let atlas = WPEMSDFAtlas(device: device)
         let generator = WPEMSDFGlyphGenerator()
@@ -72,16 +72,23 @@ struct WPEMSDFTextPipelineTests {
         let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
         let object = makeTextObject(text: "Hi")
 
-        let mesh = try #require(layout.layout(
-            object: object,
-            font: font,
-            atlas: atlas,
-            generator: generator,
-            fontID: "Helvetica@32"
-        ))
+        // Glyph generation is now async (off-main): the first layout returns nil
+        // while glyphs are scheduled; poll until the background fill completes.
+        var mesh: WPEMSDFTextMesh?
+        for _ in 0..<200 where mesh == nil {
+            mesh = layout.layout(
+                object: object,
+                font: font,
+                atlas: atlas,
+                generator: generator,
+                fontID: "Helvetica@32"
+            )
+            if mesh == nil { try await Task.sleep(nanoseconds: 10_000_000) }
+        }
+        let resolved = try #require(mesh)
 
-        #expect(!mesh.perPage.isEmpty)
-        let totalVertices = mesh.perPage.values.reduce(0) { $0 + $1.count }
+        #expect(!resolved.perPage.isEmpty)
+        let totalVertices = resolved.perPage.values.reduce(0) { $0 + $1.count }
         // Two glyphs ("Hi") × 6 vertices per quad.
         #expect(totalVertices == 12)
         #expect(totalVertices % 6 == 0)


### PR DESCRIPTION
Closes the two remaining gaps vs Wallpaper Engine's MSDF text. Gap A: msdfgen-grade generation — per-edge signed pseudo-distance + standard edge coloring for sharp corners/thin strokes, with winding-based orientation correction so glyphs can't invert. Gap B: glyph generation runs off the main thread (background Task → @MainActor pack/upload); layout returns nil until cached so text falls back to CoreText for a frame and the render thread never stalls.

Build green; MSDF glyph/atlas/text-pipeline suites pass (incl. async layout). Still gated behind WPEEnableMSDFText (default off) pending on-device visual confirmation; once validated, flipping the default is a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)