### PR TITLE
refactor(playback): master-gate frees memory + single-authority video play/pause

### DIFF
--- a/LiveWallpaper/Infrastructure/WPESceneDebugArtifacts.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDebugArtifacts.swift
@@ -25,6 +25,30 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
         let folderURL: URL
         let logURL: URL
         var passCounter: Int
+        var noteNames: Set<String>
+    }
+
+    private let waterWavesPathLock = NSLock()
+    private var waterWavesPathValue = "Inactive"
+    private var waterWavesPathStamp: TimeInterval = 0
+
+    /// Live indicator of which code path the waterwaves effect is currently taking
+    /// ("Builtin" / "Transpiled" / "Inactive"). Goes stale to "Inactive" ~1s after the
+    /// last waterwaves dispatch so it reflects the *current* scene. Read by Developer Tools.
+    var waterWavesPath: String {
+        waterWavesPathLock.lock()
+        defer { waterWavesPathLock.unlock() }
+        if ProcessInfo.processInfo.systemUptime - waterWavesPathStamp > 1.0 {
+            return "Inactive"
+        }
+        return waterWavesPathValue
+    }
+
+    func setWaterWavesPath(_ path: String) {
+        waterWavesPathLock.lock()
+        waterWavesPathValue = path
+        waterWavesPathStamp = ProcessInfo.processInfo.systemUptime
+        waterWavesPathLock.unlock()
     }
 
     private var session: ActiveSession?
@@ -100,7 +124,8 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
             workshopID: workshopID,
             folderURL: folder,
             logURL: logURL,
-            passCounter: 0
+            passCounter: 0,
+            noteNames: []
         )
         sessionLock.unlock()
 
@@ -372,6 +397,26 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
         sessionLock.unlock()
         guard let folderURL else { return }
         write(contents, to: folderURL.appendingPathComponent(safeFileName(name)))
+    }
+
+    /// Drop a text payload once per active debug session — for successful shader dumps
+    /// that would otherwise be rewritten every rendered frame.
+    func recordNoteOnce(name: String, contents: String) {
+        guard isEnabled else { return }
+        let safeName = safeFileName(name)
+        sessionLock.lock()
+        guard var current = session else {
+            sessionLock.unlock()
+            return
+        }
+        guard current.noteNames.insert(safeName).inserted else {
+            sessionLock.unlock()
+            return
+        }
+        let folderURL = current.folderURL
+        session = current
+        sessionLock.unlock()
+        write(contents, to: folderURL.appendingPathComponent(safeName))
     }
 
     /// P3 dump for raw `.tex` metadata: TEXI image-dimension + unkInt0 and

--- a/LiveWallpaper/Policies/WallpaperPolicyEngine.swift
+++ b/LiveWallpaper/Policies/WallpaperPolicyEngine.swift
@@ -10,9 +10,11 @@ enum WallpaperPolicyEngine {
         isWindowOccluding: Bool,
         isApplicationRuleActive: Bool,
         thermalState: ProcessInfo.ThermalState,
-        isGameModeActive: Bool
+        isGameModeActive: Bool,
+        isUserAbsent: Bool = false
     ) -> WallpaperPerformanceProfile {
-        let shouldSuspend = isGameModeActive ||
+        let shouldSuspend = isUserAbsent ||
+            isGameModeActive ||
             isApplicationRuleActive ||
             shouldPauseForPower(globalSettings: globalSettings, powerSource: powerSource) ||
             shouldSuspendForThermal(thermalState) ||

--- a/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
@@ -48,6 +48,12 @@ final class PlaybackCoordinator {
     /// Strategy for keeping `ScreenConfiguration.wpeOrigin` consistent with
     /// the active wallpaper. Injected so Lite can swap in a no-op variant.
     private let originReconciler: any OriginReconciler
+    /// Master render gate. When this returns `false`, video session
+    /// construction is skipped (configuration stays persisted by the caller)
+    /// so the player/decoder is never allocated while wallpapers are globally
+    /// disabled — mirrors the gate `ScreenManager.restoreWallpaperSession`
+    /// applies to scene/HTML sessions.
+    private let isGloballyEnabled: @MainActor () -> Bool
 
     init(
         configurationStore: WallpaperConfigurationStore,
@@ -62,7 +68,8 @@ final class PlaybackCoordinator {
         releaseRuntimeSession: @MainActor @escaping (Screen) -> Void,
         notifyWallpaperSessionChanged: @MainActor @escaping () -> Void,
         reportRuntimeError: @MainActor @escaping (CGDirectDisplayID, WallpaperRuntimeError?) -> Void = { _, _ in },
-        originReconciler: any OriginReconciler
+        originReconciler: any OriginReconciler,
+        isGloballyEnabled: @MainActor @escaping () -> Bool = { true }
     ) {
         self.configurationStore = configurationStore
         self.powerMonitor = powerMonitor
@@ -77,6 +84,7 @@ final class PlaybackCoordinator {
         self.notifyWallpaperSessionChanged = notifyWallpaperSessionChanged
         self.reportRuntimeError = reportRuntimeError
         self.originReconciler = originReconciler
+        self.isGloballyEnabled = isGloballyEnabled
     }
 
     // MARK: - Configuration setters
@@ -573,6 +581,15 @@ final class PlaybackCoordinator {
 
     func setupVideoPlayback(url: URL, screen: Screen) {
         releaseRuntimeSession(screen)
+
+        // Master gate: callers (setVideo / playlist / schedule) persist the
+        // configuration before reaching here, so when wallpapers are globally
+        // disabled we simply skip building the player — it is rebuilt from the
+        // saved configuration when the master switch is turned back on.
+        guard isGloballyEnabled() else {
+            notifyWallpaperSessionChanged()
+            return
+        }
 
         let configuration = configurationStore.get(for: screen.id, fingerprint: screen.displayFingerprint)
         let player = WallpaperVideoPlayer(

--- a/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
@@ -54,6 +54,10 @@ final class PlaybackCoordinator {
     /// disabled — mirrors the gate `ScreenManager.restoreWallpaperSession`
     /// applies to scene/HTML sessions.
     private let isGloballyEnabled: @MainActor () -> Bool
+    /// Whether the user is away (lock screen / display sleep / system sleep).
+    /// Folded into the effective performance profile so a freshly-built video
+    /// honours user-absence on its very first frame.
+    private let isUserAbsent: @MainActor () -> Bool
 
     init(
         configurationStore: WallpaperConfigurationStore,
@@ -69,7 +73,8 @@ final class PlaybackCoordinator {
         notifyWallpaperSessionChanged: @MainActor @escaping () -> Void,
         reportRuntimeError: @MainActor @escaping (CGDirectDisplayID, WallpaperRuntimeError?) -> Void = { _, _ in },
         originReconciler: any OriginReconciler,
-        isGloballyEnabled: @MainActor @escaping () -> Bool = { true }
+        isGloballyEnabled: @MainActor @escaping () -> Bool = { true },
+        isUserAbsent: @MainActor @escaping () -> Bool = { false }
     ) {
         self.configurationStore = configurationStore
         self.powerMonitor = powerMonitor
@@ -85,6 +90,7 @@ final class PlaybackCoordinator {
         self.reportRuntimeError = reportRuntimeError
         self.originReconciler = originReconciler
         self.isGloballyEnabled = isGloballyEnabled
+        self.isUserAbsent = isUserAbsent
     }
 
     // MARK: - Configuration setters
@@ -312,66 +318,6 @@ final class PlaybackCoordinator {
         }
     }
 
-    private func applyStartupPlaybackPolicy(to player: WallpaperVideoPlayer, for screen: Screen) {
-        let globalSettings = SettingsManager.shared.loadGlobalSettings()
-        let powerSource = powerMonitor.currentPowerSource
-        let isHiddenByFullScreen = fullScreenDetector.isDesktopHidden(for: screen.id)
-
-        let pauseForPower = WallpaperPolicyEngine.shouldPauseForPower(
-            globalSettings: globalSettings,
-            powerSource: powerSource
-        )
-        let pauseForFullScreen = WallpaperPolicyEngine.shouldApplyFullScreenPolicy(
-            globalSettings: globalSettings,
-            isHiddenByFullScreen: isHiddenByFullScreen
-        )
-
-        if pauseForPower {
-            powerPolicy.markPausedByPower(screen.id)
-        }
-        if pauseForFullScreen {
-            powerPolicy.markPausedByFullScreen(screen.id)
-        }
-
-        if WallpaperPolicyEngine.shouldStartVideoPaused(
-            globalSettings: globalSettings,
-            powerSource: powerSource,
-            isHiddenByFullScreen: isHiddenByFullScreen
-        ) {
-            player.pause()
-            return
-        }
-
-        schedulePolicyAwarePlaybackStart(to: player, screenID: screen.id)
-    }
-
-    private func schedulePolicyAwarePlaybackStart(to player: WallpaperVideoPlayer, screenID: CGDirectDisplayID) {
-        Task { @MainActor [weak self, weak player] in
-            do {
-                try await Task.sleep(for: .milliseconds(200))
-            } catch {
-                return
-            }
-
-            guard let self, let player else { return }
-
-            let globalSettings = SettingsManager.shared.loadGlobalSettings()
-            let shouldPause = WallpaperPolicyEngine.shouldStartVideoPaused(
-                globalSettings: globalSettings,
-                powerSource: self.powerMonitor.currentPowerSource,
-                isHiddenByFullScreen: self.fullScreenDetector.isDesktopHidden(for: screenID)
-            )
-
-            guard !shouldPause else {
-                player.pause()
-                return
-            }
-
-            player.play()
-            self.markSessionStateChanged()
-        }
-    }
-
     // MARK: - Video session lifecycle
 
     func setVideo(url: URL, bookmarkData: Data, for screen: Screen) {
@@ -518,7 +464,6 @@ final class PlaybackCoordinator {
 
         if !needsNewPlayer, let player = existingPlayer {
             let currentTime = preservingState ? player.player?.currentTime() : .zero
-            let wasPlaying = player.isPlaying
 
             player.setVideoFitMode(configuration.fitMode)
 
@@ -538,19 +483,9 @@ final class PlaybackCoordinator {
             if let currentTime {
                 player.player?.seek(to: currentTime)
             }
-
-            let globalSettings = SettingsManager.shared.loadGlobalSettings()
-            let shouldPause = WallpaperPolicyEngine.shouldStartVideoPaused(
-                globalSettings: globalSettings,
-                powerSource: powerMonitor.currentPowerSource,
-                isHiddenByFullScreen: fullScreenDetector.isDesktopHidden(for: screen.id)
-            )
-
-            if shouldPause {
-                player.pause()
-            } else if !wasPlaying {
-                schedulePolicyAwarePlaybackStart(to: player, screenID: screen.id)
-            }
+            // Play/pause is left to the trailing applyPerformancePolicy: it
+            // honours the session's existing intent + current profile, so a
+            // config re-apply never resumes a video the user paused.
         } else {
             if existingPlayer != nil {
                 releaseRuntimeSession(screen)
@@ -570,12 +505,13 @@ final class PlaybackCoordinator {
             player.setVideoColorSpace(configuration.videoColorSpace)
             player.setPlaybackSpeed(configuration.playbackSpeed)
             applyConfigurationWhenAssetReady(player: player, screen: screen, configuration: configuration)
-            applyStartupPlaybackPolicy(to: player, for: screen)
         }
 
         reportRuntimeError(screen.id, nil)
         syncVideoAudioLeadership()
         applyVideoSpanLayout()
+        // Single authority: a fresh session defaults to intent=true; the profile
+        // decides whether it actually plays now.
         applyPerformancePolicy(to: screen)
     }
 
@@ -621,7 +557,6 @@ final class PlaybackCoordinator {
 
         syncVideoAudioLeadership()
         applyVideoSpanLayout()
-        applyStartupPlaybackPolicy(to: player, for: liveScreen)
         Logger.info("Video player initialized for screen \(screen.id) — async asset load in progress", category: .screenManager)
         notifyWallpaperSessionChanged()
     }
@@ -653,7 +588,8 @@ final class PlaybackCoordinator {
             isWindowOccluding: isWindowOccluding,
             isApplicationRuleActive: ApplicationPerformanceRuleEngine.isActive(for: globalSettings),
             thermalState: ProcessInfo.processInfo.thermalState,
-            isGameModeActive: globalSettings.pauseInGameMode && GameModeDetector.isActive
+            isGameModeActive: globalSettings.pauseInGameMode && GameModeDetector.isActive,
+            isUserAbsent: isUserAbsent()
         )
         screen.runtimeSession?.applyPerformanceProfile(profile)
     }

--- a/LiveWallpaper/Runtime/WPEMetalRenderErrors+Uniforms.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderErrors+Uniforms.swift
@@ -187,6 +187,19 @@ struct WPEWaterWavesUniforms {
     /// mask region tinted red, 3 = displacement-magnitude heatmap. Driven by the Developer
     /// Tools "Waterwaves debug" picker; 0 in production.
     var debugMode: Float = 0
+    /// WPE packs texture resolution as (textureWidth, textureHeight, imageWidth, imageHeight).
+    /// The debug overlay uses this to mirror `waterwaves.vert`'s mask-UV padding correction.
+    var texture1Resolution: SIMD4<Float> = SIMD4<Float>(1, 1, 1, 1)
+}
+
+/// Developer Tools "Waterwaves uniform trace" flag — when on, the live custom (transpiler) path
+/// logs the packed waterwaves uniforms per pass and dumps the translated MSL once. Off in production.
+enum WPEWaterWavesTrace {
+    static let defaultsKey = "WPEWaterWavesTrace"
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: defaultsKey)
+    }
 }
 
 /// Developer Tools "Waterwaves debug" visualization mode — single source of truth shared by the

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -1653,6 +1653,8 @@ final class WPEMetalRenderExecutor {
             )
         }
 
+        WPESceneDebugArtifacts.shared.setWaterWavesPath("Builtin")
+        let maskResolution = WPEMetalTextureMetadataRegistry.shared.resolution(for: maskTexture)
         var uniforms = WPEWaterWavesUniforms(
             time: time,
             speed: speed,
@@ -1662,7 +1664,13 @@ final class WPEMetalRenderExecutor {
             directionX: direction.x,
             directionY: direction.y,
             hasMask: hasMask,
-            debugMode: debugMode
+            debugMode: debugMode,
+            texture1Resolution: SIMD4<Float>(
+                Float(maskResolution.textureWidth),
+                Float(maskResolution.textureHeight),
+                Float(maskResolution.imageWidth),
+                Float(maskResolution.imageHeight)
+            )
         )
         encoder.setFragmentBytes(&uniforms, length: MemoryLayout<WPEWaterWavesUniforms>.stride, index: 0)
 

--- a/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
+++ b/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
@@ -737,29 +737,23 @@ struct WPEMetalShaderDispatcher {
     ) throws {
         let result = try executor.compileCustomShader(for: pass)
         let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
-        // Diagnostic for the hair/cloth "ghost": a displacement effect whose
-        // custom .vert builds v_Direction / a resolution-scaled mask UV gets
-        // that .vert discarded when usesObjectQuad forces the builtin
-        // object-quad vertex (scene-target pass). Logs which vertex each
-        // waterwaves-class pass actually runs + whether the mask is live.
-        if pass.pass.shader.lowercased().contains("wave")
-            || pass.pass.shader.lowercased().contains("flutter") {
-            let maskLive = pass.textureBindings[1] != nil || pass.pass.textures[1] != nil
+        let isWaveLikePass = Self.isWaveLikePass(pass)
+        let isWaterWavesPass = Self.isWaterWavesPass(pass)
+        // The transpiler is fragment-only: it always uses wpe_fullscreen_vertex and
+        // synthesizes v_TexCoord / v_Direction in the fragment (it does NOT run the
+        // scene .vert). Record which path waterwaves takes live + whether the mask is bound.
+        if isWaterWavesPass {
+            WPESceneDebugArtifacts.shared.setWaterWavesPath("Transpiled")
+        }
+        if isWaveLikePass {
+            let maskLive = Self.hasExplicitTextureSlot(1, in: pass)
             WPESceneDebugArtifacts.shared.appendLog(
                 "🌊 [WPE.fx.vtx] \(pass.pass.shader) target=\(pass.pass.target) "
-                    + "vertex=\(usesObjectQuad ? "builtin_object_quad(drops v_Direction/.zw)" : "custom_vert") "
+                    + "vertex=\(usesObjectQuad ? "builtin_object_quad" : "fullscreen+synthesized-varyings") "
                     + "maskSlot1=\(maskLive) MASK=\(pass.comboValues["MASK"] ?? 0)",
                 level: .warning
             )
         }
-        let pipelineState = try executor.translatedPipelineState(
-            for: result,
-            vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : nil,
-            blendMode: pass.pass.blending,
-            colorPixelFormat: destination.texture.pixelFormat,
-            depthPixelFormat: depthPixelFormat
-        )
-        encoder.setRenderPipelineState(pipelineState)
 
         var primary: MTLTexture? = nil
         var resolvedTexturesBySlot: [Int: MTLTexture] = [:]
@@ -817,13 +811,62 @@ struct WPEMetalShaderDispatcher {
             }
         }
 
+        var packedUniformSlots: [SIMD4<Float>] = []
         if !result.uniformLayout.isEmpty {
-            var slots = executor.packTranslatedUniforms(
+            packedUniformSlots = executor.packTranslatedUniforms(
                 for: pass,
                 layout: result.uniformLayout,
                 texturesBySlot: resolvedTexturesBySlot,
                 destinationTexture: usesObjectQuad ? (primary ?? destination.texture) : destination.texture
             )
+        }
+
+        // Phase A: log the GPU-bound uniforms for waterwaves passes so the live values
+        // (g_Time/g_Speed/g_Scale/g_Direction/g_Strength/g_Texture1Resolution) can be
+        // inspected on-device, plus dump the translated MSL once.
+        if isWaterWavesPass && WPEWaterWavesTrace.isEnabled {
+            Self.traceWaterWavesPass(
+                pass: pass,
+                result: result,
+                layout: result.uniformLayout,
+                slots: packedUniformSlots,
+                texturesBySlot: resolvedTexturesBySlot
+            )
+        }
+
+        // Phase B: when the Developer Tools "Waterwaves debug" picker is on, visualize the
+        // effect on the REAL (transpiled) path by drawing the builtin debug fragment with the
+        // packed uniforms, instead of the transpiled shader. Off in production.
+        let waterWavesDebugMode = isWaterWavesPass ? WPEWaterWavesDebugMode.current : .off
+        if waterWavesDebugMode != .off {
+            try dispatchWaterWavesDebugOverlay(
+                pass: pass,
+                destination: destination,
+                sourceTexture: resolvedTexturesBySlot[0] ?? primary,
+                maskTexture: Self.hasExplicitTextureSlot(1, in: pass)
+                    ? resolvedTexturesBySlot[1]
+                    : (resolvedTexturesBySlot[0] ?? primary),
+                hasMask: Self.hasExplicitTextureSlot(1, in: pass),
+                layout: result.uniformLayout,
+                slots: packedUniformSlots,
+                debugMode: waterWavesDebugMode,
+                encoder: encoder,
+                depthPixelFormat: depthPixelFormat
+            )
+            return
+        }
+
+        let pipelineState = try executor.translatedPipelineState(
+            for: result,
+            vertexName: usesObjectQuad ? "wpe_object_quad_vertex" : nil,
+            blendMode: pass.pass.blending,
+            colorPixelFormat: destination.texture.pixelFormat,
+            depthPixelFormat: depthPixelFormat
+        )
+        encoder.setRenderPipelineState(pipelineState)
+
+        if !packedUniformSlots.isEmpty {
+            var slots = packedUniformSlots
             let byteCount = MemoryLayout<SIMD4<Float>>.stride * slots.count
             encoder.setFragmentBytes(&slots, length: byteCount, index: 0)
         }
@@ -840,6 +883,160 @@ struct WPEMetalShaderDispatcher {
                 index: 1
             )
         }
+    }
+
+    /// Phase B helper: render the builtin waterwaves debug fragment (mask/overlay/displacement/
+    /// solid visualizations) onto the live transpiler-path target, using the uniforms packed for
+    /// the real shader. Lets the Developer Tools debug picker affect the actual on-screen path.
+    private func dispatchWaterWavesDebugOverlay(
+        pass: WPEPreparedRenderPass,
+        destination: (id: WPEMetalTargetID, texture: MTLTexture),
+        sourceTexture: MTLTexture?,
+        maskTexture: MTLTexture?,
+        hasMask: Bool,
+        layout: [WPEUniformSlot],
+        slots: [SIMD4<Float>],
+        debugMode: WPEWaterWavesDebugMode,
+        encoder: MTLRenderCommandEncoder,
+        depthPixelFormat: MTLPixelFormat
+    ) throws {
+        guard let sourceTexture else {
+            throw WPEMetalRenderExecutorError.missingTexture(pass.pass.source)
+        }
+        let resolvedMaskTexture = maskTexture ?? sourceTexture
+        encoder.setRenderPipelineState(try executor.renderPipeline(
+            vertexName: "wpe_fullscreen_vertex",
+            fragmentName: "wpe_effect_waterwaves_fragment",
+            blendMode: pass.pass.blending,
+            colorPixelFormat: destination.texture.pixelFormat,
+            depthPixelFormat: depthPixelFormat
+        ))
+        encoder.setFragmentTexture(sourceTexture, index: 0)
+        encoder.setFragmentTexture(resolvedMaskTexture, index: 1)
+
+        let angle = Self.packedScalar(named: "g_Direction", in: layout, slots: slots) ?? 0
+        let direction = SIMD2<Float>(-sin(angle), cos(angle))
+        var uniforms = WPEWaterWavesUniforms(
+            time: Self.packedScalar(named: "g_Time", in: layout, slots: slots) ?? 0,
+            speed: Self.packedScalar(named: "g_Speed", in: layout, slots: slots) ?? 5,
+            scale: Self.packedScalar(named: "g_Scale", in: layout, slots: slots) ?? 200,
+            strength: Self.packedScalar(named: "g_Strength", in: layout, slots: slots) ?? 0.1,
+            exponent: Self.packedScalar(named: "g_Exponent", in: layout, slots: slots) ?? 1,
+            directionX: direction.x,
+            directionY: direction.y,
+            hasMask: hasMask ? 1 : 0,
+            debugMode: debugMode.rawValue,
+            texture1Resolution: Self.packedVector(named: "g_Texture1Resolution", in: layout, slots: slots)
+                ?? Self.textureResolutionVector(for: resolvedMaskTexture)
+        )
+        encoder.setFragmentBytes(
+            &uniforms,
+            length: MemoryLayout<WPEWaterWavesUniforms>.stride,
+            index: 0
+        )
+        // The caller (WPEMetalRenderExecutor.encode) issues the fullscreen draw after dispatch returns.
+    }
+
+    private static func traceWaterWavesPass(
+        pass: WPEPreparedRenderPass,
+        result: WPEShaderCompileResult,
+        layout: [WPEUniformSlot],
+        slots: [SIMD4<Float>],
+        texturesBySlot: [Int: MTLTexture]
+    ) {
+        WPESceneDebugArtifacts.shared.recordNoteOnce(
+            name: "msl-\(pass.pass.id)-\(pass.pass.shader).metal",
+            contents: result.mslSource
+        )
+
+        let angle = packedScalar(named: "g_Direction", in: layout, slots: slots)
+        let direction = angle.map { SIMD2<Float>(-sin($0), cos($0)) }
+        let strength = packedScalar(named: "g_Strength", in: layout, slots: slots)
+        let maxUV = strength.map { $0 * $0 }
+        WPESceneDebugArtifacts.shared.appendLog(
+            "[waterwaves.trace] pass=\(pass.pass.id)"
+                + " combos=\(pass.comboValues)"
+                + " samplers=\(result.samplerNames)"
+                + " tex0=\(textureSizeDescription(texturesBySlot[0]))"
+                + " tex1=\(textureSizeDescription(texturesBySlot[1]))"
+                + " g_Time=\(scalarDescription(packedScalar(named: "g_Time", in: layout, slots: slots)))"
+                + " g_Direction=\(scalarDescription(angle))"
+                + " dir=\(vector2Description(direction))"
+                + " g_Speed=\(scalarDescription(packedScalar(named: "g_Speed", in: layout, slots: slots)))"
+                + " g_Scale=\(scalarDescription(packedScalar(named: "g_Scale", in: layout, slots: slots)))"
+                + " g_Strength=\(scalarDescription(strength))"
+                + " g_Exponent=\(scalarDescription(packedScalar(named: "g_Exponent", in: layout, slots: slots)))"
+                + " g_Texture1Resolution=\(vector4Description(packedVector(named: "g_Texture1Resolution", in: layout, slots: slots)))"
+                + " maxUV=\(scalarDescription(maxUV))",
+            level: .warning
+        )
+    }
+
+    private static func isWaterWavesPass(_ pass: WPEPreparedRenderPass) -> Bool {
+        WPEMetalShaderInputs.normalizedBuiltinShaderName(pass.pass.shader) == "effect_waterwaves"
+    }
+
+    private static func isWaveLikePass(_ pass: WPEPreparedRenderPass) -> Bool {
+        if isWaterWavesPass(pass) { return true }
+        let shader = pass.pass.shader.lowercased()
+        return shader.contains("wave") || shader.contains("flutter")
+    }
+
+    private static func hasExplicitTextureSlot(_ slot: Int, in pass: WPEPreparedRenderPass) -> Bool {
+        pass.textureBindings[slot] != nil
+            || pass.pass.textures[slot] != nil
+            || pass.pass.binds[slot] != nil
+    }
+
+    private static func packedScalar(
+        named name: String,
+        in layout: [WPEUniformSlot],
+        slots: [SIMD4<Float>]
+    ) -> Float? {
+        packedVector(named: name, in: layout, slots: slots)?.x
+    }
+
+    private static func packedVector(
+        named name: String,
+        in layout: [WPEUniformSlot],
+        slots: [SIMD4<Float>]
+    ) -> SIMD4<Float>? {
+        guard let uniform = layout.first(where: { $0.name == name }),
+              slots.indices.contains(uniform.slot) else {
+            return nil
+        }
+        return slots[uniform.slot]
+    }
+
+    private static func textureResolutionVector(for texture: MTLTexture?) -> SIMD4<Float> {
+        guard let texture else { return SIMD4<Float>(1, 1, 1, 1) }
+        let resolution = WPEMetalTextureMetadataRegistry.shared.resolution(for: texture)
+        return SIMD4<Float>(
+            Float(resolution.textureWidth),
+            Float(resolution.textureHeight),
+            Float(resolution.imageWidth),
+            Float(resolution.imageHeight)
+        )
+    }
+
+    private static func textureSizeDescription(_ texture: MTLTexture?) -> String {
+        guard let texture else { return "nil" }
+        return "\(texture.width)x\(texture.height)"
+    }
+
+    private static func scalarDescription(_ value: Float?) -> String {
+        guard let value else { return "nil" }
+        return String(format: "%.6f", value)
+    }
+
+    private static func vector2Description(_ value: SIMD2<Float>?) -> String {
+        guard let value else { return "nil" }
+        return String(format: "(%.6f,%.6f)", value.x, value.y)
+    }
+
+    private static func vector4Description(_ value: SIMD4<Float>?) -> String {
+        guard let value else { return "nil" }
+        return String(format: "(%.3f,%.3f,%.3f,%.3f)", value.x, value.y, value.z, value.w)
     }
 
     private func isSceneCaptureUtilityLayer(_ layer: WPERenderLayer) -> Bool {

--- a/LiveWallpaper/Runtime/WPEShaderTranspiler.swift
+++ b/LiveWallpaper/Runtime/WPEShaderTranspiler.swift
@@ -131,8 +131,21 @@ struct WPEShaderTranspiler {
         let mainBody = String(body[mainRange])
         let postMain = String(body[mainRange.upperBound...])
 
-        let translatedHelpers = applySubstitutions(preMain + "\n" + postMain)
-        let translatedMain = translateMain(mainBody)
+        let varyingTypesByName = Dictionary(
+            varyings.map { ($0.name, $0.metalType) },
+            uniquingKeysWith: { _, last in last }
+        )
+        let preserveTexCoordZW = shouldPreserveTexCoordZW(shaderName: shaderName)
+        let translatedHelpers = applySubstitutions(
+            preMain + "\n" + postMain,
+            varyingTypesByName: varyingTypesByName,
+            preserveTexCoordZW: preserveTexCoordZW
+        )
+        let translatedMain = translateMain(
+            mainBody,
+            varyingTypesByName: varyingTypesByName,
+            preserveTexCoordZW: preserveTexCoordZW
+        )
         let helperResources = rewriteHelperResourceAccess(
             helpers: translatedHelpers,
             mainBody: translatedMain,
@@ -610,11 +623,20 @@ struct WPEShaderTranspiler {
     }
 
     /// Strip the `void main() { ... }` wrapper and rebuild it as Metal-friendly statements.
-    private static func translateMain(_ source: String) -> String {
+    private static func translateMain(
+        _ source: String,
+        varyingTypesByName: [String: String] = [:],
+        preserveTexCoordZW: Bool = false
+    ) -> String {
         guard let openBrace = source.range(of: "{") else { return "" }
         guard let closeBrace = source.range(of: "}", options: .backwards) else { return "" }
         var inner = String(source[openBrace.upperBound..<closeBrace.lowerBound])
-        inner = applySubstitutions(inner, rewriteProgramScopeConsts: false)
+        inner = applySubstitutions(
+            inner,
+            rewriteProgramScopeConsts: false,
+            varyingTypesByName: varyingTypesByName,
+            preserveTexCoordZW: preserveTexCoordZW
+        )
 
         let usesGLOut = inner.contains("gl_FragColor")
         let usesWPEOut = inner.contains("wpe_fragColor")
@@ -641,7 +663,12 @@ struct WPEShaderTranspiler {
     // MARK: - Type / intrinsic substitutions
 
     /// Apply token-level substitutions for the GLSL→MSL gap.
-    private static func applySubstitutions(_ source: String, rewriteProgramScopeConsts: Bool = true) -> String {
+    private static func applySubstitutions(
+        _ source: String,
+        rewriteProgramScopeConsts: Bool = true,
+        varyingTypesByName: [String: String] = [:],
+        preserveTexCoordZW: Bool = false
+    ) -> String {
         var s = source
 
         for (glsl, msl) in [
@@ -678,7 +705,11 @@ struct WPEShaderTranspiler {
         s = rewriteTextureResolutionVector2Assignments(s)
         s = rewriteVectorConstructorNarrowing(s)
         s = rewriteTexCoordVector2Arithmetic(s)
-        s = rewriteTexCoordMaskUVFallback(s)
+        s = rewriteTexCoordMaskUVFallback(
+            s,
+            varyingTypesByName: varyingTypesByName,
+            preserveTexCoordZW: preserveTexCoordZW
+        )
         s = rewriteGLSLArrayConstructors(s)
 
         s = rewriteReferenceParameters(s)
@@ -1034,11 +1065,34 @@ struct WPEShaderTranspiler {
         )
     }
 
-    /// Some WPE effects compute secondary mask UVs into `v_TexCoord.zw` in the
-    /// vertex shader, but this fullscreen Metal path only exposes base UVs.
-    /// Falling back to `.xy` preserves compilation and the common mask behavior.
-    private static func rewriteTexCoordMaskUVFallback(_ source: String) -> String {
-        source.replacingOccurrences(of: "v_TexCoord.zw", with: "v_TexCoord.xy")
+    /// waterwaves computes a resolution-scaled mask UV into `v_TexCoord.zw`, which the
+    /// fragment-only path faithfully synthesizes (`wpe_texcoord_with_resolution`). For that
+    /// shader we keep the `.zw` sample so the mask padding correction survives. For every
+    /// other shader the synthesized `.zw` is NOT guaranteed to match the source `.vert`
+    /// (e.g. blur step, clipping-mask transforms), so we keep the historical `.xy` fallback
+    /// to avoid changing their flags-off output.
+    private static func rewriteTexCoordMaskUVFallback(
+        _ source: String,
+        varyingTypesByName: [String: String],
+        preserveTexCoordZW: Bool
+    ) -> String {
+        guard preserveTexCoordZW, varyingTypesByName["v_TexCoord"] == "float4" else {
+            return source.replacingOccurrences(of: "v_TexCoord.zw", with: "v_TexCoord.xy")
+        }
+        return source
+    }
+
+    /// Only `effects/waterwaves` has a transpiler-synthesized `v_TexCoord.zw` that matches its
+    /// source `.vert` (the mask-UV resolution scaling). Restrict `.zw` preservation to it so
+    /// other float4-`v_TexCoord` effects keep their historical behavior.
+    private static func shouldPreserveTexCoordZW(shaderName: String) -> Bool {
+        let normalized = shaderName
+            .lowercased()
+            .replacingOccurrences(of: ".frag", with: "")
+            .replacingOccurrences(of: ".vert", with: "")
+        return normalized == "effect_waterwaves"
+            || normalized == "effects/waterwaves"
+            || normalized.hasSuffix("/effects/waterwaves")
     }
 
     /// Metal accepts aggregate array initializers, not GLSL constructor syntax

--- a/LiveWallpaper/Runtime/WallpaperRuntimeSession.swift
+++ b/LiveWallpaper/Runtime/WallpaperRuntimeSession.swift
@@ -88,6 +88,11 @@ protocol HTMLWallpaperConfigApplying: AnyObject {
 @MainActor
 protocol WallpaperPlaybackControllable: WallpaperRuntimeSession {
     var isPlaying: Bool { get }
+    /// The user's transient intent to play, independent of whether a
+    /// performance policy is currently suppressing playback. Manual controls
+    /// read this (not `isPlaying`) so a policy-suspended video still toggles
+    /// from the user's point of view.
+    var userIntendsToPlay: Bool { get }
 
     func play()
     func pause()
@@ -96,7 +101,16 @@ protocol WallpaperPlaybackControllable: WallpaperRuntimeSession {
 @MainActor
 final class VideoWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackControllable {
     private var player: WallpaperVideoPlayer?
-    private var wasPlayingBeforeSuspend: Bool?
+    /// Durable-for-the-session user intent. Set by manual play/pause; never
+    /// touched by a performance-policy suspend. Combined with the current
+    /// profile, this is the single authority for whether the video plays:
+    /// `play = userIntendsToPlay && currentProfile == .quality`.
+    private(set) var userIntendsToPlay = true
+    /// Last profile applied by the policy layer. Remembered so a manual
+    /// play/pause can re-derive the effective state without re-querying the
+    /// policy — e.g. tapping play while on battery records intent but stays
+    /// paused until the profile returns to `.quality`.
+    private var currentProfile: WallpaperPerformanceProfile = .quality
     /// Mirrors `player.setWindowVisible(_:)`. When `false` the wallpaper
     /// window is `orderOut`-ed (master switch off), so the desktop shows
     /// nothing behind it — distinct from `.paused`, where the last frame
@@ -157,11 +171,13 @@ final class VideoWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
     }
 
     func play() {
-        player?.play()
+        userIntendsToPlay = true
+        applyPerformanceProfile(currentProfile)
     }
 
     func pause() {
-        player?.pause()
+        userIntendsToPlay = false
+        applyPerformanceProfile(currentProfile)
     }
 
     func show() {
@@ -175,33 +191,25 @@ final class VideoWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
     }
 
     func applyPerformanceProfile(_ profile: WallpaperPerformanceProfile) {
+        currentProfile = profile
         switch profile {
         case .quality:
-            if let wasPlayingBeforeSuspend {
-                self.wasPlayingBeforeSuspend = nil
-                if wasPlayingBeforeSuspend {
-                    player?.play()
-                }
+            if userIntendsToPlay {
+                player?.play()
+            } else {
+                player?.pause()
             }
         case .suspended:
-            if wasPlayingBeforeSuspend == nil {
-                wasPlayingBeforeSuspend = player?.isPlaying ?? false
-            }
             player?.pause()
         }
     }
 
     func suspend() {
-        guard wasPlayingBeforeSuspend == nil else { return }
-        wasPlayingBeforeSuspend = player?.isPlaying ?? false
-        player?.suspend()
+        applyPerformanceProfile(.suspended)
     }
 
     func resume() {
-        guard let wasPlayingBeforeSuspend else { return }
-        self.wasPlayingBeforeSuspend = nil
-        guard wasPlayingBeforeSuspend else { return }
-        player?.resume()
+        applyPerformanceProfile(.quality)
     }
 
     func retry() async {
@@ -212,7 +220,11 @@ final class VideoWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
         let volume = oldPlayer.audioVolume
         let speed = Double(oldPlayer.player?.defaultRate ?? 1)
         let frameRateLimit = oldPlayer.requestedFrameRateLimit
-        let shouldAutoplay = oldPlayer.isPlaying || oldPlayer.shouldAutoplayWhenReady
+        // Carry the user's intent + current policy profile across the rebuild
+        // rather than reading the old player's autoplay flag, which a policy
+        // suspend may have cleared.
+        let intent = userIntendsToPlay
+        let profile = currentProfile
 
         oldPlayer.cleanup()
 
@@ -224,11 +236,10 @@ final class VideoWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
         if frameRateLimit > 0 {
             replacement.setFrameRateLimit(frameRateLimit)
         }
-        if !shouldAutoplay {
-            replacement.pause()
-        }
         player = replacement
         runtimeError = replacement.runtimeError
+        userIntendsToPlay = intent
+        applyPerformanceProfile(profile)
     }
 
     func cleanup() {

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -127,6 +127,17 @@ final class ScreenManager {
     @ObservationIgnored private var transientRuntimeErrors: [CGDirectDisplayID: WallpaperRuntimeError] = [:]
     @ObservationIgnored private let exclusiveRenderingCoordinator = ExclusiveRenderingCoordinator()
     @ObservationIgnored private var exclusiveRenderingObservation: NSObjectProtocol?
+    private enum UserAbsenceReason: Hashable {
+        case screenLocked
+        case displaySleep
+        case systemSleep
+    }
+    /// Reasons the user is not watching the desktop. Folded into the effective
+    /// performance profile (`isUserAbsent`) so lock / display-sleep / system
+    /// sleep suspend through the single policy path instead of a parallel
+    /// pause/resume overlay.
+    @ObservationIgnored private var userAbsenceReasons: Set<UserAbsenceReason> = []
+    private var isUserAbsent: Bool { !userAbsenceReasons.isEmpty }
     /// Coordinates per-screen playback configuration mutations + transition
     /// tokens. Lazy because it captures `self` for the effect-application and
     /// refresh-rate-lookup callbacks; the stored properties used by those
@@ -162,6 +173,9 @@ final class ScreenManager {
         originReconciler: originReconciler,
         isGloballyEnabled: { [weak self] in
             self?.wallpapersGloballyEnabled ?? true
+        },
+        isUserAbsent: { [weak self] in
+            self?.isUserAbsent ?? false
         }
     )
     /// Lazy because the `saveConfiguration` / `restoreWallpaperSession`
@@ -451,51 +465,34 @@ final class ScreenManager {
 
     private func handleScreenLocked() {
         Logger.info("Screen locked — suspending wallpaper sessions", category: .lifecycle)
-        suspendAllForUserAbsence()
+        setUserAbsence(.screenLocked, present: true)
     }
 
     private func handleDisplaySleep() {
         Logger.info("Display asleep — suspending wallpaper sessions", category: .lifecycle)
-        suspendAllForUserAbsence()
-    }
-
-    /// Lock screen 和 display sleep 都属于「用户不在看屏幕」语义，复用 PowerPolicy
-    /// 的 lockScreen 集合：渲染都停下，等下一次恢复信号（unlock / wake）再放回。
-    private func suspendAllForUserAbsence() {
-        for screen in screens {
-            if let playback = screen.playbackController, playback.isPlaying {
-                playback.pause()
-                powerPolicy.markPausedByLockScreen(screen.id)
-            }
-            if let session = screen.runtimeSession, screen.playbackController == nil {
-                session.applyPerformanceProfile(.suspended)
-                powerPolicy.markPausedByLockScreen(screen.id)
-            }
-        }
-        markWallpaperSessionStateChanged()
+        setUserAbsence(.displaySleep, present: true)
     }
 
     private func handleDisplayWake() {
         Logger.info("Display awake — restoring wallpaper sessions", category: .lifecycle)
-        resumeAllAfterUserAbsence()
+        setUserAbsence(.displaySleep, present: false)
     }
 
     private func handleScreenUnlocked() {
         Logger.info("Screen unlocked — restoring wallpaper sessions", category: .lifecycle)
-        resumeAllAfterUserAbsence()
+        setUserAbsence(.screenLocked, present: false)
     }
 
-    private func resumeAllAfterUserAbsence() {
-        for screen in screens where powerPolicy.wasPausedByLockScreen(screen.id) {
-            powerPolicy.markResumedFromLockScreen(screen.id)
-            if let playback = screen.playbackController {
-                playback.play()
-            } else if let session = screen.runtimeSession {
-                session.applyPerformanceProfile(.quality)
-            }
-        }
-        // Re-apply power + full-screen policies — state may have changed during absence.
-        handlePowerStateChange(powerMonitor.currentPowerSource)
+    /// Lock screen and display sleep both mean "user is not watching". They
+    /// fold into the effective performance profile via `isUserAbsent`, so a
+    /// single policy refresh suspends or restores every session (respecting
+    /// each video's `userIntendsToPlay`) — no separate pause/resume overlay.
+    private func setUserAbsence(_ reason: UserAbsenceReason, present: Bool) {
+        let changed = present
+            ? userAbsenceReasons.insert(reason).inserted
+            : (userAbsenceReasons.remove(reason) != nil)
+        guard changed else { return }
+        refreshPerformancePolicyForAllScreens()
         markWallpaperSessionStateChanged()
     }
 
@@ -615,57 +612,12 @@ final class ScreenManager {
         }
     }
 
+    /// Full-screen / window-occlusion changes fold into the effective profile
+    /// like every other condition; a single policy refresh applies the unified
+    /// play/pause decision. The `hiddenScreens` snapshot is now informational —
+    /// the policy reads the detector live.
     private func handleFullScreenChange(_ hiddenScreens: [CGDirectDisplayID: Bool]) {
-        let globalSettings = SettingsManager.shared.loadGlobalSettings()
-        let powerSource = powerMonitor.currentPowerSource
-        let thermalState = ProcessInfo.processInfo.thermalState
-        let isGameModeActive = globalSettings.pauseInGameMode && GameModeDetector.isActive
-        let isApplicationRuleActive = currentApplicationRuleActive(globalSettings)
-
-        for screen in screens {
-            let isHidden = hiddenScreens[screen.id] ?? false
-            let shouldApplyFullScreenPolicy = WallpaperPolicyEngine.shouldApplyFullScreenPolicy(
-                globalSettings: globalSettings,
-                isHiddenByFullScreen: isHidden
-            )
-            let shouldApplyOcclusionPolicy = WallpaperPolicyEngine.shouldApplyWindowOcclusionPolicy(
-                globalSettings: globalSettings,
-                isWindowOccluding: fullScreenDetector.isDesktopOccluded(for: screen.id)
-            )
-            // Either window-coverage rule pauses video the same way (and reuses
-            // the same paused-by-full-screen bookkeeping for resume).
-            let shouldPauseForWindows = shouldApplyFullScreenPolicy || shouldApplyOcclusionPolicy
-
-            if shouldPauseForWindows {
-                if let playback = screen.playbackController, playback.isPlaying {
-                    playback.pause()
-                    powerPolicy.markPausedByFullScreen(screen.id)
-                }
-            } else {
-                if let playback = screen.playbackController,
-                   powerPolicy.wasPausedByFullScreen(screen.id) {
-                    if WallpaperPolicyEngine.shouldResumeFromFullScreen(
-                        globalSettings: globalSettings,
-                        powerSource: powerSource,
-                        wasPausedByFullScreen: true
-                    ) {
-                        playback.play()
-                    }
-                    powerPolicy.markResumedFromFullScreen(screen.id)
-                }
-            }
-
-            applyPerformancePolicy(
-                to: screen,
-                globalSettings: globalSettings,
-                powerSource: powerSource,
-                isHiddenByFullScreen: shouldApplyFullScreenPolicy,
-                isWindowOccluding: shouldApplyOcclusionPolicy,
-                isApplicationRuleActive: isApplicationRuleActive,
-                thermalState: thermalState,
-                isGameModeActive: isGameModeActive
-            )
-        }
+        refreshPerformancePolicyForAllScreens()
         updatePlaybackState()
     }
 
@@ -1060,15 +1012,16 @@ final class ScreenManager {
     func togglePlayback() {
         guard hasControllableWallpaperSessions else { return }
 
-        let isAnyPlaying = screens.contains { $0.playbackController?.isPlaying ?? false }
+        // Decide from user INTENT, not actual playback: a policy-suspended
+        // video reads `isPlaying == false` but the user still "intends" to
+        // play, so toggling must flip intent, not chase the suppressed state.
+        let anyIntendsToPlay = screens.contains { $0.playbackController?.userIntendsToPlay ?? false }
 
-        Logger.info("Toggling global playback: \(isAnyPlaying ? "pausing" : "playing") all videos", category: .videoPlayer)
+        Logger.info("Toggling global playback: \(anyIntendsToPlay ? "pausing" : "playing") all videos", category: .videoPlayer)
 
         for screen in screens {
             guard let playback = screen.playbackController else { continue }
-
-            if isAnyPlaying {
-                powerPolicy.markResumedFromPower(screen.id)
+            if anyIntendsToPlay {
                 playback.pause()
             } else {
                 playback.play()
@@ -1134,78 +1087,13 @@ final class ScreenManager {
     }
     
     // MARK: - Power Management
+    /// Power changes no longer carry their own play/pause logic — they fold
+    /// into the effective performance profile like every other condition, so a
+    /// single refresh applies the unified decision (`userIntendsToPlay` for
+    /// video, profile for ambient) across all screens.
     private func handlePowerStateChange(_ powerSource: PowerMonitor.PowerSource) {
-        let globalSettings = SettingsManager.shared.loadGlobalSettings()
-        let thermalState = ProcessInfo.processInfo.thermalState
-        let isGameModeActive = globalSettings.pauseInGameMode && GameModeDetector.isActive
-        let isApplicationRuleActive = currentApplicationRuleActive(globalSettings)
-
-        var updatedScreens = false
-
-        for screen in screens {
-            let isHiddenByFullScreen = globalSettings.pauseOnFullScreen &&
-                fullScreenDetector.isDesktopHidden(for: screen.id)
-            let isWindowOccluding = globalSettings.pauseOnWindowOcclusion &&
-                fullScreenDetector.isDesktopOccluded(for: screen.id)
-
-            let profile = applyPerformancePolicy(
-                to: screen,
-                globalSettings: globalSettings,
-                powerSource: powerSource,
-                isHiddenByFullScreen: isHiddenByFullScreen,
-                isWindowOccluding: isWindowOccluding,
-                isApplicationRuleActive: isApplicationRuleActive,
-                thermalState: thermalState,
-                isGameModeActive: isGameModeActive
-            )
-
-            let shouldPauseForPower = WallpaperPolicyEngine.shouldPauseForPower(
-                globalSettings: globalSettings,
-                powerSource: powerSource
-            )
-            let shouldResumeForPower = WallpaperPolicyEngine.shouldResumeFromPower(
-                powerSource: powerSource,
-                wasPausedByPower: powerPolicy.wasPausedByPower(screen.id)
-            )
-
-            if let playback = screen.playbackController {
-                if shouldPauseForPower && playback.isPlaying {
-                    Logger.debug("Pausing screen \(screen.id) due to power policy", category: .powerMonitor)
-                    playback.pause()
-                    powerPolicy.markPausedByPower(screen.id)
-                    updatedScreens = true
-                } else if shouldResumeForPower, !playback.isPlaying, profile != .suspended {
-                    // Resume is only safe if the wider policy lets the
-                    // wallpaper run. Game Mode, critical thermal, or a
-                    // fullscreen takeover all keep `profile == .suspended`,
-                    // and racing the resume in those windows would undo the
-                    // performance policy decision we just applied.
-                    Logger.debug("Resuming screen \(screen.id) due to external power (was paused by power management)", category: .powerMonitor)
-                    playback.play()
-                    powerPolicy.markResumedFromPower(screen.id)
-                    updatedScreens = true
-                }
-            } else if let runtimeSession = screen.runtimeSession {
-                if shouldPauseForPower, !powerPolicy.wasPausedByPower(screen.id) {
-                    Logger.debug("Suspending ambient session for screen \(screen.id) due to power policy", category: .powerMonitor)
-                    runtimeSession.applyPerformanceProfile(.suspended)
-                    powerPolicy.markPausedByPower(screen.id)
-                } else if shouldResumeForPower, profile != .suspended {
-                    Logger.debug("Resuming ambient session for screen \(screen.id) due to external power", category: .powerMonitor)
-                    runtimeSession.applyPerformanceProfile(profile)
-                    powerPolicy.markResumedFromPower(screen.id)
-                }
-            }
-        }
-
-        if !powerSource.isOnBattery {
-            let currentScreenIDs = Set(screens.map(\.id))
-            powerPolicy.cleanUpStaleEntries(currentScreenIDs: currentScreenIDs)
-        }
-
-        if updatedScreens {
-            updatePlaybackState()
-        }
+        refreshPerformancePolicyForAllScreens()
+        updatePlaybackState()
     }
 
     @discardableResult
@@ -1226,7 +1114,8 @@ final class ScreenManager {
             isWindowOccluding: isWindowOccluding,
             isApplicationRuleActive: isApplicationRuleActive,
             thermalState: thermalState,
-            isGameModeActive: isGameModeActive
+            isGameModeActive: isGameModeActive,
+            isUserAbsent: isUserAbsent
         )
         screen.runtimeSession?.applyPerformanceProfile(profile)
         return profile
@@ -1284,35 +1173,34 @@ final class ScreenManager {
         Logger.warning("Low memory condition detected, optimizing resource usage", category: .memory)
 
         for screen in screens {
-            if let player = screen.videoPlayer, player.isPlaying {
-                let isActive = NSScreen.screens.contains { $0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID == screen.id }
+            guard let playback = screen.playbackController, playback.isPlaying else { continue }
+            let isActive = NSScreen.screens.contains { $0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID == screen.id }
 
-                if !isActive {
-                    Logger.debug("Pausing background video on screen \(screen.id) to conserve memory", category: .memory)
-                    player.pause()
-                }
+            if !isActive {
+                // Route through the session so intent is cleared: low-memory
+                // pause is deliberate and must not auto-resume on the next
+                // policy refresh (matches the prior direct-pause behavior).
+                Logger.debug("Pausing background video on screen \(screen.id) to conserve memory", category: .memory)
+                playback.pause()
             }
         }
-
     }
     
     // MARK: - System Events
     private func handleSystemSleep() {
         Logger.info("System sleep detected", category: .lifecycle)
-        for screen in screens {
-            screen.runtimeSession?.suspend()
-        }
+        userAbsenceReasons.insert(.systemSleep)
+        refreshPerformancePolicyForAllScreens()
         markWallpaperSessionStateChanged()
     }
 
     private func handleSystemWake() {
         Logger.info("System wake detected", category: .lifecycle)
-        for screen in screens {
-            screen.runtimeSession?.resume()
-        }
         refreshScreens()
         powerMonitor.refreshPowerStatus()
-        handlePowerStateChange(powerMonitor.currentPowerSource)
+        userAbsenceReasons.remove(.systemSleep)
+        refreshPerformancePolicyForAllScreens()
+        markWallpaperSessionStateChanged()
     }
 
     private func captureDesktopSnapshotsForLockIfNeeded() {

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -159,7 +159,10 @@ final class ScreenManager {
         reportRuntimeError: { [weak self] screenID, error in
             self?.setTransientRuntimeError(error, for: screenID)
         },
-        originReconciler: originReconciler
+        originReconciler: originReconciler,
+        isGloballyEnabled: { [weak self] in
+            self?.wallpapersGloballyEnabled ?? true
+        }
     )
     /// Lazy because the `saveConfiguration` / `restoreWallpaperSession`
     /// callbacks capture `self` (matches `playbackCoordinator`'s pattern).
@@ -714,9 +717,10 @@ final class ScreenManager {
         updatePlaybackState()
         updateFullScreenFallbackPolling()
 
-        // Enforce a persisted "off" master gate on freshly-restored sessions.
-        // Only when disabled — when enabled we leave visibility to the normal
-        // power / full-screen policies rather than force-showing here.
+        // Enforce a persisted "off" master gate. With the build gate in
+        // `restoreWallpaperSession`, disabled screens never build a session
+        // above; this is the safety net that also tears down any session
+        // adopted/preserved across a screen refresh so nothing stays resident.
         if !wallpapersGloballyEnabled {
             applyGlobalRenderGate()
         }
@@ -829,6 +833,22 @@ final class ScreenManager {
         configuration: ScreenConfiguration,
         preservingState: Bool
     ) {
+        // Master gate: when wallpapers are globally disabled we keep the
+        // configuration persisted but do NOT build a live session. This avoids
+        // allocating the renderer / scene runtime / decoded assets only to
+        // suspend them — the session is (re)built by `applyGlobalRenderGate()`
+        // when the master switch is turned back on.
+        guard wallpapersGloballyEnabled else {
+            if screen.runtimeSession != nil { releaseRuntimeSession(screen) }
+            // No live session is built, but the caller has just persisted this
+            // configuration. Refresh the derived session state so a wallpaper
+            // assigned while the gate is off is reflected as configured-but-
+            // `.off` (keeping the master switch enabled) — mirrors the video
+            // path's refresh in `PlaybackCoordinator.setupVideoPlayback`.
+            notifyWallpaperSessionChanged()
+            return
+        }
+
         guard let definition = WallpaperSessionDefinition(configuration: configuration) else {
             Logger.warning("Skipping malformed wallpaper configuration for screen \(screen.id)", category: .screenManager)
             releaseRuntimeSession(screen)
@@ -894,7 +914,38 @@ final class ScreenManager {
     }
 
     func wallpaperSummary(for screen: Screen) -> WallpaperSessionSummary {
-        wallpaperSessionSummaryCache.summary(for: screen.id, fallback: screen.wallpaperSessionSummary)
+        wallpaperSessionSummaryCache.summary(for: screen.id, fallback: effectiveSummary(for: screen))
+    }
+
+    /// Per-screen summary that accounts for the master render gate. With a live
+    /// session we use its own summary. Without one we still report
+    /// configured-but-`.off` when the master switch is off and a wallpaper is
+    /// persisted — so the overview stays `.off` (and the menu-bar master switch
+    /// stays enabled to turn rendering back on) instead of collapsing to
+    /// `.notConfigured` now that the gate tears sessions down to free memory.
+    private func effectiveSummary(for screen: Screen) -> WallpaperSessionSummary {
+        if screen.runtimeSession != nil {
+            return screen.wallpaperSessionSummary
+        }
+        if !wallpapersGloballyEnabled, let type = persistedWallpaperType(for: screen) {
+            return WallpaperSessionSummary(
+                wallpaperType: type,
+                activity: .off,
+                supportsPlaybackControl: false,
+                subtitle: nil
+            )
+        }
+        return screen.wallpaperSessionSummary
+    }
+
+    /// The wallpaper type a screen would render from its persisted
+    /// configuration, or `nil` when nothing valid is assigned. Uses the same
+    /// validity gate as `restoreWallpaperSession` so an empty/malformed config
+    /// reads as "not configured".
+    private func persistedWallpaperType(for screen: Screen) -> WallpaperType? {
+        guard let config = configurationStore.get(for: screen.id, fingerprint: screen.displayFingerprint),
+              WallpaperSessionDefinition(configuration: config) != nil else { return nil }
+        return config.activeWallpaper.wallpaperType
     }
 
     /// Currently surfaced error for a screen's runtime session (or `nil`).
@@ -971,7 +1022,7 @@ final class ScreenManager {
     private func commitWallpaperSessionState(includePollingRefresh: Bool = false) {
         var next = wallpaperSessionState
         next.summaryCache = WallpaperSessionSummaryCache(
-            entries: screens.map { ($0.id, $0.wallpaperSessionSummary) }
+            entries: screens.map { ($0.id, effectiveSummary(for: $0)) }
         )
         next.isAnyPlaying = screens.contains { $0.playbackController?.isPlaying ?? false }
 
@@ -1027,11 +1078,14 @@ final class ScreenManager {
         updatePlaybackState()
     }
 
-    /// Master render gate. Toggles whether wallpaper pipelines render at all by
-    /// showing/suspending every session — deliberately WITHOUT touching
-    /// per-screen playback (`play()`/`pause()`), so flipping this neither reads
-    /// nor mutates whether an individual screen is paused. The flag is persisted
-    /// and is the single source of truth for the menu-bar master switch.
+    /// Master render gate. Toggles whether wallpaper pipelines exist at all:
+    /// disabling tears every session down to free its memory, enabling rebuilds
+    /// them from persisted configuration (see `applyGlobalRenderGate`). The flag
+    /// is persisted and is the single source of truth for the menu-bar master
+    /// switch. Note: because sessions are destroyed rather than suspended,
+    /// transient per-screen playback state (a manual pause is not persisted
+    /// anywhere) is not carried across an off→on cycle — rebuilt screens follow
+    /// the normal startup playback policy, exactly as on app relaunch.
     func setWallpapersEnabled(_ enabled: Bool) {
         wallpapersGloballyEnabled = enabled
         UserDefaults.standard.set(enabled, forKey: Self.globallyEnabledDefaultsKey)
@@ -1041,18 +1095,25 @@ final class ScreenManager {
         markWallpaperSessionStateChanged()
     }
 
-    /// Apply the master gate to every live session (show+resume when enabled,
-    /// suspend+hide when disabled). Idempotent; safe to call after sessions are
-    /// (re)built so the gate also holds across launches and new wallpapers.
+    /// Apply the master gate to every screen. When enabled, builds any session
+    /// that is missing (from its persisted configuration) and shows/resumes the
+    /// ones already live. When disabled, fully tears each session down so its
+    /// GPU textures, scene runtime, and decoded assets are released — rather
+    /// than leaving a suspended-but-resident renderer holding memory. Idempotent
+    /// and safe to call across launches and after new wallpapers are assigned.
     func applyGlobalRenderGate() {
         for screen in screens {
-            guard let session = screen.runtimeSession else { continue }
             if wallpapersGloballyEnabled {
-                session.show()
-                session.resume()
-            } else {
-                session.suspend()
-                session.hide()
+                if screen.runtimeSession == nil {
+                    // Rendering is permitted again — rebuild from the persisted
+                    // configuration. No-op for screens without a saved wallpaper.
+                    loadConfigurationForScreen(screen)
+                } else {
+                    screen.runtimeSession?.show()
+                    screen.runtimeSession?.resume()
+                }
+            } else if screen.runtimeSession != nil {
+                releaseRuntimeSession(screen)
             }
         }
     }

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -1096,25 +1096,40 @@ final class ScreenManager {
     }
 
     /// Apply the master gate to every screen. When enabled, builds any session
-    /// that is missing (from its persisted configuration) and shows/resumes the
-    /// ones already live. When disabled, fully tears each session down so its
-    /// GPU textures, scene runtime, and decoded assets are released — rather
-    /// than leaving a suspended-but-resident renderer holding memory. Idempotent
-    /// and safe to call across launches and after new wallpapers are assigned.
+    /// that is missing (from its persisted configuration) and makes any
+    /// already-live one visible, then re-runs the performance policy so the
+    /// gate never decides quality/suspended itself. When disabled, fully tears
+    /// each session down so its GPU textures, scene runtime, and decoded assets
+    /// are released — rather than leaving a suspended-but-resident renderer
+    /// holding memory. Idempotent and safe to call across launches and after
+    /// new wallpapers are assigned.
     func applyGlobalRenderGate() {
         for screen in screens {
             if wallpapersGloballyEnabled {
                 if screen.runtimeSession == nil {
                     // Rendering is permitted again — rebuild from the persisted
                     // configuration. No-op for screens without a saved wallpaper.
+                    // The build path applies the current performance policy itself.
                     loadConfigurationForScreen(screen)
                 } else {
+                    // Already-live session (idempotent re-enable): only ensure
+                    // the window is visible. Whether it runs or stays suspended
+                    // is decided by the performance policy below — never a blind
+                    // resume() that would override power / thermal / full-screen
+                    // / app-rule state.
                     screen.runtimeSession?.show()
-                    screen.runtimeSession?.resume()
                 }
             } else if screen.runtimeSession != nil {
                 releaseRuntimeSession(screen)
             }
+        }
+
+        // Single source of truth for "how hard a live session works". Re-running
+        // the policy after enabling keeps the master gate (a lifecycle axis)
+        // from bypassing the performance-profile axis. Skipped while disabled —
+        // there are no live sessions to target.
+        if wallpapersGloballyEnabled {
+            refreshPerformancePolicyForAllScreens()
         }
     }
     

--- a/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
+++ b/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
@@ -698,7 +698,8 @@ struct WPEWaterWavesUniforms {
     float directionX;
     float directionY;
     float hasMask;
-    float debugMode; // 0 normal; 1 mask grayscale; 2 source+red mask overlay; 3 displacement heatmap
+    float debugMode; // 0 normal; 1 mask grayscale; 2 source+red mask overlay; 3 displacement heatmap; 4 solid magenta
+    float4 texture1Resolution; // (textureWidth, textureHeight, imageWidth, imageHeight)
 };
 
 // Port of WPE's effects/waterwaves.frag: a sine wave travels along `direction` at
@@ -712,8 +713,18 @@ fragment half4 wpe_effect_waterwaves_fragment(
 ) {
     constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
     float2 direction = float2(uniforms.directionX, uniforms.directionY);
+    // Mirror waterwaves.vert's mask-UV padding correction (v_TexCoord.zw *= res.zw/res.xy)
+    // for the debug overlay so the mask visualization lands where the real effect samples.
+    float2 maskUV = in.uv;
+    if (uniforms.debugMode > 0.5) {
+        float2 maskScale = float2(
+            abs(uniforms.texture1Resolution.x) > 0.000001 ? uniforms.texture1Resolution.z / uniforms.texture1Resolution.x : 1.0,
+            abs(uniforms.texture1Resolution.y) > 0.000001 ? uniforms.texture1Resolution.w / uniforms.texture1Resolution.y : 1.0
+        );
+        maskUV *= maskScale;
+    }
     float mask = (uniforms.hasMask > 0.5)
-        ? float(texture1.sample(linearSampler, in.uv).r)
+        ? float(texture1.sample(linearSampler, maskUV).r)
         : 1.0;
 
     float distance = uniforms.time * uniforms.speed + dot(in.uv, direction) * uniforms.scale;

--- a/LiveWallpaper/Views/MenuBarContent.swift
+++ b/LiveWallpaper/Views/MenuBarContent.swift
@@ -513,7 +513,10 @@ private enum DisplayVisualState: Equatable {
 @MainActor
 enum PlaybackToggle {
     static func toggle(_ playback: any WallpaperPlaybackControllable) {
-        if playback.isPlaying {
+        // Toggle the user's intent, not the actual playing state: a
+        // policy-suspended video reads `isPlaying == false` even though the
+        // user still intends to play it.
+        if playback.userIntendsToPlay {
             playback.pause()
         } else {
             playback.play()

--- a/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
+++ b/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
@@ -23,6 +23,7 @@ struct DeveloperToolsView: View {
     @State private var flagRefresh = 0
     @State private var waterWavesDebug = WPEWaterWavesDebugMode.current
     @State private var selectedTab: DevToolsTab = .corpusTest
+    @State private var activeWaterWavesPath = WPESceneDebugArtifacts.shared.waterWavesPath
 
     private enum DevToolsTab: String, CaseIterable, Identifiable {
         case corpusTest
@@ -270,6 +271,30 @@ struct DeveloperToolsView: View {
                     Text(verbatim: "Visualize where the waterwaves effect triggers: Mask / Overlay show the masked region on the character, Displacement shows the wave field. Applies on the next rendered frame.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                    HStack(spacing: 4) {
+                        Text(verbatim: "Active waterwaves path:")
+                            .font(.caption)
+                        Text(verbatim: activeWaterWavesPath)
+                            .font(.caption.bold())
+                            .foregroundStyle(waterWavesPathColor)
+                    }
+                    .accessibilityElement(children: .combine)
+
+                    if waterWavesDebug != .off && activeWaterWavesPath == "Inactive" {
+                        Text(verbatim: "⚠️ Waterwaves debug is on but no waterwaves effect is rendering in the current scene.")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Toggle(isOn: boolBinding("WPEWaterWavesTrace")) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(verbatim: "Waterwaves uniform trace")
+                        Text(verbatim: "Log packed waterwaves uniforms per pass + dump the translated MSL to scene-debug. Needs scene debug artifacts on.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 Divider()
@@ -291,6 +316,12 @@ struct DeveloperToolsView: View {
             }
             .padding(.vertical, 4)
             .id(flagRefresh)
+            .task {
+                while !Task.isCancelled {
+                    activeWaterWavesPath = WPESceneDebugArtifacts.shared.waterWavesPath
+                    try? await Task.sleep(nanoseconds: 700_000_000)
+                }
+            }
         }
     }
 
@@ -313,6 +344,14 @@ struct DeveloperToolsView: View {
         }
     }
 
+    private var waterWavesPathColor: Color {
+        switch activeWaterWavesPath {
+        case "Builtin": return .green
+        case "Transpiled": return .orange
+        default: return .secondary
+        }
+    }
+
     private func resetDiagnosticFlags() {
         for flag in Self.diagnosticBoolFlags {
             UserDefaults.standard.removeObject(forKey: flag.key)
@@ -320,6 +359,7 @@ struct DeveloperToolsView: View {
         for key in Self.diagnosticStringKeys {
             UserDefaults.standard.removeObject(forKey: key)
         }
+        UserDefaults.standard.removeObject(forKey: WPEWaterWavesTrace.defaultsKey)
         waterWavesDebug = .off
         flagRefresh += 1
     }

--- a/LiveWallpaperTests/MasterRenderGateTests.swift
+++ b/LiveWallpaperTests/MasterRenderGateTests.swift
@@ -1,0 +1,146 @@
+import AppKit
+import Foundation
+import Testing
+@testable import LiveWallpaper
+import LiveWallpaperCore
+
+/// Regression coverage for the master render gate (the menu-bar global on/off
+/// switch). The gate must NOT build a live session while disabled — it keeps
+/// the configuration persisted and rebuilds on enable — so a screen with a
+/// saved wallpaper stays reported as configured-but-`.off` (keeping the switch
+/// enabled) rather than collapsing to `.notConfigured`, which would soft-lock
+/// the user out of ever turning wallpapers back on.
+@Suite("Master render gate")
+@MainActor
+struct MasterRenderGateTests {
+
+    /// Mirrors `ScreenManager.globallyEnabledDefaultsKey` (private). Setting it
+    /// before constructing the manager makes the gate load in a known state
+    /// without building anything.
+    private static let gateDefaultsKey = "loomscreen.wallpapers.globallyEnabled.v1"
+
+    private static func withGate(_ enabled: Bool, _ body: () throws -> Void) rethrows {
+        let original = UserDefaults.standard.object(forKey: gateDefaultsKey)
+        UserDefaults.standard.set(enabled, forKey: gateDefaultsKey)
+        defer {
+            if let original {
+                UserDefaults.standard.set(original, forKey: gateDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: gateDefaultsKey)
+            }
+        }
+        try body()
+    }
+
+    private static func makeManager(screen: Screen) -> ScreenManager {
+        ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: true,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: FakePlayableVideoLoader(),
+            displayRegistry: FakeDisplayRegistry(screens: [screen])
+        ))
+    }
+
+    @Test("Gate off does not build a session yet reports the screen as configured-but-off")
+    func gateOffSkipsBuildButReportsOff() throws {
+        guard let screen = NSScreen.screens.first.map(Screen.init(nsScreen:)) else {
+            Issue.record("No NSScreen available")
+            return
+        }
+        let originalConfigurations = SettingsManager.shared.loadConfigurations()
+        defer { SettingsManager.shared.replaceAllConfigurations(originalConfigurations) }
+
+        SettingsManager.shared.replaceAllConfigurations([
+            ScreenConfiguration(screenID: screen.id, wallpaper: .metalShader(.waves))
+        ])
+
+        try Self.withGate(false) {
+            let manager = Self.makeManager(screen: screen)
+            defer { screen.resetRuntimeSession() }
+
+            #expect(manager.wallpapersGloballyEnabled == false)
+
+            guard let liveScreen = manager.screens.first(where: { $0.id == screen.id }) else {
+                Issue.record("Injected display registry did not produce a screen")
+                return
+            }
+
+            // Core fix: rendering never started, so no session/renderer memory.
+            #expect(liveScreen.runtimeSession == nil, "Gate off must not build a live session")
+
+            // Soft-lock guard: the configured screen is reported as `.off`, so
+            // the overview is `.off` (switch enabled), NOT `.notConfigured`.
+            let summary = manager.wallpaperSummary(for: liveScreen)
+            #expect(summary.activity == .off)
+            #expect(summary.isConfigured)
+            #expect(manager.wallpaperOverviewStatus == .off)
+            #expect(manager.wallpaperOverviewStatus != .notConfigured)
+        }
+    }
+
+    @Test("Gate off with no saved wallpaper still reports not-configured")
+    func gateOffWithoutConfigReportsNotConfigured() throws {
+        guard let screen = NSScreen.screens.first.map(Screen.init(nsScreen:)) else {
+            Issue.record("No NSScreen available")
+            return
+        }
+        let originalConfigurations = SettingsManager.shared.loadConfigurations()
+        defer { SettingsManager.shared.replaceAllConfigurations(originalConfigurations) }
+
+        SettingsManager.shared.replaceAllConfigurations([])
+
+        try Self.withGate(false) {
+            let manager = Self.makeManager(screen: screen)
+            defer { screen.resetRuntimeSession() }
+
+            guard let liveScreen = manager.screens.first(where: { $0.id == screen.id }) else {
+                Issue.record("Injected display registry did not produce a screen")
+                return
+            }
+
+            #expect(liveScreen.runtimeSession == nil)
+            // No wallpaper assigned: must NOT masquerade as `.off`; the switch
+            // is correctly disabled when there is nothing to enable.
+            #expect(manager.wallpaperSummary(for: liveScreen).activity == .inactive)
+            #expect(manager.wallpaperOverviewStatus == .notConfigured)
+        }
+    }
+
+    @Test("Assigning a wallpaper while the gate is off flips the overview to .off (no stale cache)")
+    func assigningWallpaperWhileOffRefreshesOverview() throws {
+        guard let screen = NSScreen.screens.first.map(Screen.init(nsScreen:)) else {
+            Issue.record("No NSScreen available")
+            return
+        }
+        let originalConfigurations = SettingsManager.shared.loadConfigurations()
+        defer { SettingsManager.shared.replaceAllConfigurations(originalConfigurations) }
+
+        // Start with nothing configured anywhere.
+        SettingsManager.shared.replaceAllConfigurations([])
+
+        try Self.withGate(false) {
+            let manager = Self.makeManager(screen: screen)
+            defer { screen.resetRuntimeSession() }
+
+            guard let liveScreen = manager.screens.first(where: { $0.id == screen.id }) else {
+                Issue.record("Injected display registry did not produce a screen")
+                return
+            }
+
+            // Precondition: nothing configured, switch would be disabled.
+            #expect(manager.wallpaperOverviewStatus == .notConfigured)
+
+            // Assign a shader wallpaper while the gate is off: it must persist
+            // without building a session, and the derived overview must refresh
+            // to `.off` so the menu-bar switch becomes usable again — otherwise
+            // a stale `.notConfigured` cache would soft-lock the switch.
+            manager.setShaderWallpaper(source: .waves, for: liveScreen)
+
+            #expect(liveScreen.runtimeSession == nil, "Gate off must not build a session")
+            #expect(manager.wallpaperSummary(for: liveScreen).activity == .off)
+            #expect(manager.wallpaperOverviewStatus == .off)
+        }
+    }
+}

--- a/LiveWallpaperTests/MasterRenderGateTests.swift
+++ b/LiveWallpaperTests/MasterRenderGateTests.swift
@@ -143,4 +143,83 @@ struct MasterRenderGateTests {
             #expect(manager.wallpaperOverviewStatus == .off)
         }
     }
+
+    @Test("Enabling the gate rebuilds the session from persisted config and makes it live")
+    func enablingGateRebuildsAndRunsPolicy() throws {
+        guard let screen = NSScreen.screens.first.map(Screen.init(nsScreen:)) else {
+            Issue.record("No NSScreen available")
+            return
+        }
+        let originalConfigurations = SettingsManager.shared.loadConfigurations()
+        defer { SettingsManager.shared.replaceAllConfigurations(originalConfigurations) }
+
+        SettingsManager.shared.replaceAllConfigurations([
+            ScreenConfiguration(screenID: screen.id, wallpaper: .metalShader(.waves))
+        ])
+
+        try Self.withGate(false) {
+            let manager = Self.makeManager(screen: screen)
+            defer { screen.resetRuntimeSession() }
+
+            guard let liveScreen = manager.screens.first(where: { $0.id == screen.id }) else {
+                Issue.record("Injected display registry did not produce a screen")
+                return
+            }
+
+            #expect(liveScreen.runtimeSession == nil, "Gate off must not build a session")
+
+            // Enable: the lifecycle axis rebuilds the missing session from
+            // persisted config; the performance policy (not a blind resume)
+            // then drives it live, so the overview leaves the `.off` state.
+            manager.setWallpapersEnabled(true)
+
+            #expect(manager.wallpapersGloballyEnabled)
+            #expect(liveScreen.runtimeSession != nil, "Enabling must rebuild the session")
+            #expect(manager.wallpaperOverviewStatus != .off)
+            #expect(manager.wallpaperOverviewStatus != .notConfigured)
+
+            // Round-trip back off must tear the rebuilt session down again.
+            manager.setWallpapersEnabled(false)
+            #expect(liveScreen.runtimeSession == nil, "Disabling must release the rebuilt session")
+        }
+    }
+
+    @Test("Re-applying the gate while already enabled keeps the same live session (show-only branch)")
+    func reapplyingGateKeepsLiveSession() throws {
+        guard let screen = NSScreen.screens.first.map(Screen.init(nsScreen:)) else {
+            Issue.record("No NSScreen available")
+            return
+        }
+        let originalConfigurations = SettingsManager.shared.loadConfigurations()
+        defer { SettingsManager.shared.replaceAllConfigurations(originalConfigurations) }
+
+        SettingsManager.shared.replaceAllConfigurations([
+            ScreenConfiguration(screenID: screen.id, wallpaper: .metalShader(.waves))
+        ])
+
+        try Self.withGate(true) {
+            let manager = Self.makeManager(screen: screen)
+            defer { screen.resetRuntimeSession() }
+
+            guard let liveScreen = manager.screens.first(where: { $0.id == screen.id }) else {
+                Issue.record("Injected display registry did not produce a screen")
+                return
+            }
+
+            // Gate on + restore-on-refresh builds the session at launch.
+            #expect(liveScreen.runtimeSession != nil, "Gate on must build the session")
+            let builtIdentity = liveScreen.runtimeSession.map { ObjectIdentifier($0 as AnyObject) }
+
+            // Idempotent re-apply exercises the already-live `show()`-only
+            // branch: the session must be preserved (not rebuilt, not resumed
+            // blindly) and the performance policy left in charge.
+            manager.applyGlobalRenderGate()
+
+            #expect(liveScreen.runtimeSession != nil, "Re-enabling must not tear a live session down")
+            #expect(liveScreen.runtimeSession.map { ObjectIdentifier($0 as AnyObject) } == builtIdentity,
+                    "An already-live session must be reused, not rebuilt")
+            #expect(manager.wallpaperOverviewStatus != .off)
+            #expect(manager.wallpaperOverviewStatus != .notConfigured)
+        }
+    }
 }

--- a/LiveWallpaperTests/VideoSessionLifecycleTests.swift
+++ b/LiveWallpaperTests/VideoSessionLifecycleTests.swift
@@ -194,4 +194,44 @@ struct VideoSessionLifecycleTests {
 
         #expect(powerMonitor.currentPowerSourceReadCount >= baselineReadCount)
     }
+
+    // MARK: - VideoWallpaperSession intent state machine (single authority)
+
+    /// Asserts the core safety invariant: a performance-policy profile NEVER
+    /// mutates `userIntendsToPlay`; only manual play/pause do. Uses a player
+    /// built with `loadImmediately: false` so no AVPlayer/window is created —
+    /// the intent flag is synchronous and independent of real playback.
+    @Test("Policy profiles never mutate intent; manual play/pause own it")
+    func videoIntentStateMachine() {
+        let player = WallpaperVideoPlayer(
+            url: URL(fileURLWithPath: "/tmp/master-gate-intent-\(UUID().uuidString).mov"),
+            frame: CGRect(x: 0, y: 0, width: 100, height: 100),
+            loadImmediately: false
+        )
+        let session = VideoWallpaperSession(player: player)
+        defer { session.cleanup() }
+
+        // Fresh session intends to play.
+        #expect(session.userIntendsToPlay)
+
+        // Policy suspend/restore must not touch intent.
+        session.applyPerformanceProfile(.suspended)
+        #expect(session.userIntendsToPlay)
+        session.applyPerformanceProfile(.quality)
+        #expect(session.userIntendsToPlay)
+
+        // Manual pause clears intent.
+        session.pause()
+        #expect(!session.userIntendsToPlay)
+
+        // A policy `.quality` must NOT resume a manually-paused video.
+        session.applyPerformanceProfile(.suspended)
+        #expect(!session.userIntendsToPlay)
+        session.applyPerformanceProfile(.quality)
+        #expect(!session.userIntendsToPlay)
+
+        // Manual play restores intent.
+        session.play()
+        #expect(session.userIntendsToPlay)
+    }
 }

--- a/LiveWallpaperTests/WallpaperArchitectureTests.swift
+++ b/LiveWallpaperTests/WallpaperArchitectureTests.swift
@@ -266,6 +266,20 @@ struct MenuBarPlaybackControlTests {
         #expect(playback.playCount == 1)
         #expect(playback.pauseCount == 0)
     }
+
+    @Test("Toggle reads intent, not playback: a policy-suspended (intends-to-play) wallpaper pauses")
+    func toggleReadsIntentNotPlaybackState() {
+        // Suppressed by a performance policy: not actually playing, but the
+        // user still intends to play. Toggling must pause (flip intent off),
+        // not "resume" by chasing the suppressed isPlaying state.
+        let playback = FakePlaybackController(isPlaying: false, userIntendsToPlay: true)
+
+        PlaybackToggle.toggle(playback)
+
+        #expect(!playback.userIntendsToPlay)
+        #expect(playback.pauseCount == 1)
+        #expect(playback.playCount == 0)
+    }
 }
 
 @Suite("PlaylistEntry identity")
@@ -711,11 +725,13 @@ struct WallpaperRuntimeReadinessTests {
 @MainActor
 private final class FakePlaybackController: WallpaperPlaybackControllable {
     var isPlaying: Bool
+    private(set) var userIntendsToPlay: Bool
     var playCount = 0
     var pauseCount = 0
 
-    init(isPlaying: Bool) {
+    init(isPlaying: Bool, userIntendsToPlay: Bool? = nil) {
         self.isPlaying = isPlaying
+        self.userIntendsToPlay = userIntendsToPlay ?? isPlaying
     }
 
     var wallpaperType: WallpaperType { .video }
@@ -731,11 +747,13 @@ private final class FakePlaybackController: WallpaperPlaybackControllable {
 
     func play() {
         playCount += 1
+        userIntendsToPlay = true
         isPlaying = true
     }
 
     func pause() {
         pauseCount += 1
+        userIntendsToPlay = false
         isPlaying = false
     }
 }
@@ -808,6 +826,76 @@ struct WallpaperPolicyEngineTests {
             globalSettings: settings,
             isHiddenByFullScreen: true
         ))
+    }
+
+    @Test("User absence (lock / display-sleep / system-sleep) maps to suspended profile")
+    func userAbsentSuspendedProfile() {
+        let settings = GlobalSettings()
+
+        let active = WallpaperPolicyEngine.performanceProfile(
+            globalSettings: settings,
+            powerSource: .external,
+            isHiddenByFullScreen: false,
+            isWindowOccluding: false,
+            isApplicationRuleActive: false,
+            thermalState: .nominal,
+            isGameModeActive: false,
+            isUserAbsent: false
+        )
+        let absent = WallpaperPolicyEngine.performanceProfile(
+            globalSettings: settings,
+            powerSource: .external,
+            isHiddenByFullScreen: false,
+            isWindowOccluding: false,
+            isApplicationRuleActive: false,
+            thermalState: .nominal,
+            isGameModeActive: false,
+            isUserAbsent: true
+        )
+
+        #expect(active == .quality)
+        #expect(absent == .suspended)
+    }
+
+    @Test("Every suspend condition independently maps to suspended; all-benign stays quality")
+    func unifiedSuspendConditionMatrix() {
+        // Each row toggles exactly one condition true on an otherwise-benign
+        // baseline (external power, nominal thermal, nothing hidden).
+        func profile(
+            hidden: Bool = false,
+            occluding: Bool = false,
+            appRule: Bool = false,
+            game: Bool = false,
+            thermal: ProcessInfo.ThermalState = .nominal,
+            powerSource: PowerMonitor.PowerSource = .external,
+            userAbsent: Bool = false
+        ) -> WallpaperPerformanceProfile {
+            WallpaperPolicyEngine.performanceProfile(
+                globalSettings: GlobalSettings(
+                    globalPauseOnBattery: true,
+                    pauseOnFullScreen: true,
+                    pauseInGameMode: true,
+                    pauseOnWindowOcclusion: true
+                ),
+                powerSource: powerSource,
+                isHiddenByFullScreen: hidden,
+                isWindowOccluding: occluding,
+                isApplicationRuleActive: appRule,
+                thermalState: thermal,
+                isGameModeActive: game,
+                isUserAbsent: userAbsent
+            )
+        }
+
+        #expect(profile() == .quality)
+        #expect(profile(hidden: true) == .suspended)
+        #expect(profile(occluding: true) == .suspended)
+        #expect(profile(appRule: true) == .suspended)
+        #expect(profile(game: true) == .suspended)
+        #expect(profile(thermal: .serious) == .suspended)
+        #expect(profile(thermal: .critical) == .suspended)
+        #expect(profile(powerSource: .battery(level: 50)) == .suspended)
+        #expect(profile(userAbsent: true) == .suspended)
     }
 
     @Test("Global pause on battery pauses video playback")


### PR DESCRIPTION
Two related wallpaper render-control changes:

- **Master switch** now skips/tears down rendering when off (frees GPU/scene/decoder memory) instead of fully rendering then suspending; rebuilds from persisted config on enable, and a configured-but-off screen still reports `.off` so the menu switch stays usable.
- **Video play/pause** unified to a single authority: `userIntendsToPlay && effectiveProfile == .quality`, recomputed on every policy event (power/thermal/fullscreen/occlusion/game/app-rule/lock/sleep). This collapses the prior dual pause/play decision + narrow startup gate, and fixes videos that autoplayed at startup under thermal/game/app-rule/occlusion and then never resumed after the condition cleared.

`PowerPolicyController` removal is staged as a phase-2 follow-up (after on-device smoke). Note: the branch also carries a pre-existing WPE MSDF/waterwaves commit (`da3c24e`) unrelated to the above.

Pro + Lite build green; ~95 targeted tests pass (policy matrix incl. user-absence, video intent state machine, master-gate rebuild/soft-lock). Multi-model reviewed (PASS, no blockers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)