### PR TITLE
fix(wpe-2.8): MSDF stability — audit follow-ups (whitespace/blend/skip/retry/bounds)

### DIFF
--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
@@ -176,10 +176,14 @@ final class WPEMSDFAtlas {
     private var pages: [Page] = []
     private var entries: [WPEMSDFGlyphKey: WPEMSDFAtlasEntry] = [:]
     private var pending: Set<WPEMSDFGlyphKey> = []
-    /// Glyphs with no outline (whitespace) or that permanently failed to
-    /// generate/store. Returned as `.skip` so they are never re-scheduled (fixes
+    /// Glyphs with no outline (whitespace / unsupported) or that exhausted their
+    /// store retries. Returned as `.skip` so they are never re-scheduled (fixes
     /// per-frame background-task churn) and never drawn as a bogus 0.5 quad.
     private var skipped: Set<WPEMSDFGlyphKey> = []
+    /// Transient store-failure (e.g. texture allocation) retry counts; a glyph is
+    /// only moved to `skipped` after exhausting these, so a temporary failure can
+    /// recover instead of being permanently dropped.
+    private var storeFailures: [WPEMSDFGlyphKey: Int] = [:]
     private var clock: UInt64 = 0
 
     init(device: MTLDevice, pageSize: Int = 1024, maxPages: Int = 4) {
@@ -250,11 +254,24 @@ final class WPEMSDFAtlas {
     private func completeGeneration(_ generated: GeneratedGlyph?, for key: WPEMSDFGlyphKey) {
         defer { pending.remove(key) }
         guard entries[key] == nil else { return }
-        // No outline (whitespace) or generation failed → mark permanently skipped
-        // so it is never re-scheduled every frame and never drawn as a 0.5 box.
-        guard let generated, store(generated: generated, for: key) != nil else {
+        // No outline (whitespace / unsupported glyph) is a PERMANENT skip — never
+        // re-schedule it and never draw it as a 0.5 box.
+        guard let generated else {
             skipped.insert(key)
             return
+        }
+        if store(generated: generated, for: key) != nil {
+            storeFailures[key] = nil
+            return
+        }
+        // Store failed (transient, e.g. texture allocation under pressure): retry
+        // a bounded number of times, then give up so we don't regenerate forever.
+        let failures = (storeFailures[key] ?? 0) + 1
+        if failures >= 3 {
+            storeFailures[key] = nil
+            skipped.insert(key)
+        } else {
+            storeFailures[key] = failures
         }
     }
 

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFAtlas.swift
@@ -53,9 +53,12 @@ final class WPEMSDFAtlas {
         }
 
         func reset() {
+            // Keep the MTLTexture across eviction: only the packing state is
+            // reset. New glyphs overwrite their own sub-rects; stale pixels are
+            // never sampled (their entries are removed and glyphs carry padding).
+            // Avoids reallocating + re-registering a 1024² texture under LRU churn.
             skyline = [SkylineNode(x: 0, y: 0, width: size)]
             keys.removeAll(keepingCapacity: true)
-            texture = nil
             lastUsed = 0
         }
 
@@ -156,12 +159,27 @@ final class WPEMSDFAtlas {
         let maxCellSide: Int
     }
 
+    /// Outcome of a non-blocking glyph request.
+    enum GlyphRequest {
+        /// Glyph is ready in the atlas — draw a quad.
+        case ready(WPEMSDFAtlasEntry)
+        /// Generation is in flight — caller should fall back this frame and retry.
+        case pending
+        /// Glyph has no drawable outline (whitespace) or permanently failed —
+        /// advance past it but draw nothing, and never schedule it again.
+        case skip
+    }
+
     private let device: MTLDevice
     private let pageSize: Int
     private let maxPages: Int
     private var pages: [Page] = []
     private var entries: [WPEMSDFGlyphKey: WPEMSDFAtlasEntry] = [:]
     private var pending: Set<WPEMSDFGlyphKey> = []
+    /// Glyphs with no outline (whitespace) or that permanently failed to
+    /// generate/store. Returned as `.skip` so they are never re-scheduled (fixes
+    /// per-frame background-task churn) and never drawn as a bogus 0.5 quad.
+    private var skipped: Set<WPEMSDFGlyphKey> = []
     private var clock: UInt64 = 0
 
     init(device: MTLDevice, pageSize: Int = 1024, maxPages: Int = 4) {
@@ -194,18 +212,21 @@ final class WPEMSDFAtlas {
         return nil
     }
 
-    /// Non-blocking entry: returns the cached entry if present, otherwise kicks
-    /// off background glyph generation (deduplicated) and returns nil so the
-    /// caller falls back (CoreText) for this frame. A later frame finds it cached.
+    /// Non-blocking request: returns `.ready` if cached, `.skip` for known
+    /// no-outline/failed glyphs, otherwise schedules deduplicated background
+    /// generation and returns `.pending` so the caller falls back this frame.
     func requestEntry(
         for key: WPEMSDFGlyphKey,
         generator: WPEMSDFGlyphGenerator,
         font: CTFont
-    ) -> WPEMSDFAtlasEntry? {
+    ) -> GlyphRequest {
         if let cached = cachedEntry(for: key) {
-            return cached
+            return .ready(cached)
         }
-        guard !pending.contains(key) else { return nil }
+        if skipped.contains(key) {
+            return .skip
+        }
+        guard !pending.contains(key) else { return .pending }
         pending.insert(key)
         let request = GlyphGenerationRequest(
             key: key,
@@ -223,13 +244,18 @@ final class WPEMSDFAtlas {
                 self?.completeGeneration(generated, for: request.key)
             }
         }
-        return nil
+        return .pending
     }
 
     private func completeGeneration(_ generated: GeneratedGlyph?, for key: WPEMSDFGlyphKey) {
         defer { pending.remove(key) }
-        guard entries[key] == nil, let generated else { return }
-        _ = store(generated: generated, for: key)
+        guard entries[key] == nil else { return }
+        // No outline (whitespace) or generation failed → mark permanently skipped
+        // so it is never re-scheduled every frame and never drawn as a 0.5 box.
+        guard let generated, store(generated: generated, for: key) != nil else {
+            skipped.insert(key)
+            return
+        }
     }
 
     @discardableResult

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFGlyphGenerator.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFGlyphGenerator.swift
@@ -23,24 +23,21 @@ final class WPEMSDFGlyphGenerator: @unchecked Sendable {
         let advance = advanceForGlyph(glyph, font: font)
         let pathUnitsToEm = pathUnitsToEmUnits(font: font)
 
-        guard let path = CTFontCreatePathForGlyph(font, glyph, nil) else {
-            return neutralResult(
-                cellSide: cellSide,
-                padding: padding,
-                advance: advance * pathUnitsToEm,
-                emUnitsPerPixel: pathUnitsToEm
-            )
+        // No outline (whitespace / control / unsupported color glyph) → nil, so
+        // the atlas marks it `.skip` (advance past it, draw nothing) instead of
+        // emitting a 0.5-filled quad that the MSDF shader renders as a gray box.
+        guard let path = CTFontCreatePathForGlyph(font, glyph, nil), !path.isEmpty else {
+            return nil
         }
 
         var shape = buildShape(from: path)
-        let sourceBounds = shape.bounds()
-        guard !shape.contours.isEmpty, !sourceBounds.isNull else {
-            return neutralResult(
-                cellSide: cellSide,
-                padding: padding,
-                advance: advance * pathUnitsToEm,
-                emUnitsPerPixel: pathUnitsToEm
-            )
+        // Tight bounds from the actual curve (boundingBoxOfPath), not the Bézier
+        // control points, so off-curve handles can't inflate the cell mapping
+        // and shrink/misplace the glyph.
+        let sourceBounds = path.boundingBoxOfPath
+        guard !shape.contours.isEmpty, !sourceBounds.isNull,
+              sourceBounds.width > 0 || sourceBounds.height > 0 else {
+            return nil
         }
 
         let sourceWidth = Double(sourceBounds.width)
@@ -50,12 +47,7 @@ final class WPEMSDFGlyphGenerator: @unchecked Sendable {
         let heightScale = sourceHeight > WPEMSDFGeometryMath.epsilon ? available / sourceHeight : Double.greatestFiniteMagnitude
         let scale = min(widthScale, heightScale)
         guard scale.isFinite, scale > WPEMSDFGeometryMath.epsilon else {
-            return neutralResult(
-                cellSide: cellSide,
-                padding: padding,
-                advance: advance * pathUnitsToEm,
-                emUnitsPerPixel: pathUnitsToEm
-            )
+            return nil
         }
 
         let contentWidth = sourceWidth * scale
@@ -116,25 +108,6 @@ final class WPEMSDFGlyphGenerator: @unchecked Sendable {
         return (padding, cellSide)
     }
 
-    private func neutralResult(
-        cellSide: Int,
-        padding: Int,
-        advance: WPEMSDFPoint,
-        emUnitsPerPixel: Double
-    ) -> (bitmap: WPEMSDFBitmap, metrics: WPEMSDFGlyphMetrics) {
-        let metrics = WPEMSDFGlyphMetrics(
-            cellSize: CGSize(width: cellSide, height: cellSide),
-            bearing: WPEMSDFPoint(0, 0),
-            advance: advance,
-            scale: 1,
-            translate: WPEMSDFPoint(Double(padding), Double(padding)),
-            emUnitsPerPixel: emUnitsPerPixel
-        )
-        return (
-            bitmap: WPEMSDFBitmap(width: cellSide, height: cellSide, fill: Self.neutralFill),
-            metrics: metrics
-        )
-    }
 
     private func buildShape(from path: CGPath) -> WPEMSDFShape {
         var contours: [WPEMSDFContour] = []

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
@@ -21,8 +21,7 @@ struct WPEMSDFTextLayout {
         object: WPESceneTextObject,
         font: CTFont,
         atlas: WPEMSDFAtlas,
-        generator: WPEMSDFGlyphGenerator,
-        fontID: String
+        generator: WPEMSDFGlyphGenerator
     ) -> WPEMSDFTextMesh? {
         guard !object.text.isEmpty else { return nil }
         // The MSDF path lays out a SINGLE line. Hard line breaks or text that
@@ -63,8 +62,7 @@ struct WPEMSDFTextLayout {
             naturalHeight: naturalHeight,
             innerHeight: innerHeight
         )
-        let pathUnitsToEm = Self.pathUnitsToEmUnits(font: font)
-        let pixelSize = max(Int(ceil(CTFontGetSize(font))), 1)
+        let utf16 = Array(object.text.utf16)
         let runs = CTLineGetGlyphRuns(line) as! [CTRun]
         var perPage: [Int: [WPEMSDFTextVertex]] = [:]
         var isComplete = true
@@ -75,24 +73,38 @@ struct WPEMSDFTextLayout {
             let range = CFRange(location: 0, length: glyphCount)
             var glyphs = [CGGlyph](repeating: 0, count: glyphCount)
             var positions = [CGPoint](repeating: .zero, count: glyphCount)
+            var stringIndices = [CFIndex](repeating: 0, count: glyphCount)
             CTRunGetGlyphs(run, range, &glyphs)
             CTRunGetPositions(run, range, &positions)
+            CTRunGetStringIndices(run, range, &stringIndices)
+
+            // Use the run's ACTUAL font: CoreText substitutes a fallback font for
+            // glyphs the scene font lacks, and glyph IDs are relative to that font.
+            let runFont = Self.runFont(run) ?? font
+            let runFontID = Self.fontIdentifier(runFont)
+            let runPixelSize = max(Int(ceil(CTFontGetSize(runFont))), 1)
+            let runPathUnitsToEm = Self.pathUnitsToEmUnits(font: runFont)
 
             for index in 0..<glyphCount {
                 let glyph = glyphs[index]
-                let key = WPEMSDFGlyphKey(fontID: fontID, glyph: glyph, pixelSize: pixelSize)
+                let key = WPEMSDFGlyphKey(fontID: runFontID, glyph: glyph, pixelSize: runPixelSize)
                 let entry: WPEMSDFAtlasEntry
-                switch atlas.requestEntry(for: key, generator: generator, font: font) {
+                switch atlas.requestEntry(for: key, generator: generator, font: runFont) {
                 case .ready(let ready):
                     entry = ready
-                case .skip:
-                    continue // whitespace / no-outline glyph: advance, draw nothing
                 case .pending:
                     isComplete = false
                     continue
+                case .skip:
+                    // Whitespace has no outline by design → advance, draw nothing.
+                    // A NON-whitespace glyph with no MSDF outline (emoji / color /
+                    // unsupported) must NOT be silently dropped — fall the whole
+                    // object back to CoreText so it renders correctly.
+                    if Self.isWhitespace(stringIndices[index], in: utf16) { continue }
+                    return nil
                 }
                 let position = positions[index]
-                let bearing = entry.metrics.bearing / pathUnitsToEm
+                let bearing = entry.metrics.bearing / runPathUnitsToEm
                 let glyphWidth = Double(entry.metrics.cellSize.width) / entry.metrics.scale
                 let glyphHeight = Double(entry.metrics.cellSize.height) / entry.metrics.scale
                 let x = Double(xOffset) + Double(position.x) + bearing.x
@@ -174,6 +186,27 @@ struct WPEMSDFTextLayout {
         let unitsPerEm = max(Double(CTFontGetUnitsPerEm(font)), 1)
         let fontSize = max(Double(CTFontGetSize(font)), 1.0e-6)
         return unitsPerEm / fontSize
+    }
+
+    /// The font CoreText actually used for this run (may be a substituted
+    /// fallback font when the scene font lacks a glyph).
+    private static func runFont(_ run: CTRun) -> CTFont? {
+        let attributes = CTRunGetAttributes(run) as NSDictionary
+        guard let value = attributes[kCTFontAttributeName as String] else { return nil }
+        return (value as! CTFont)
+    }
+
+    private static func fontIdentifier(_ font: CTFont) -> String {
+        let name = CTFontCopyPostScriptName(font) as String
+        return "\(name)@\(Int(ceil(CTFontGetSize(font))))"
+    }
+
+    /// Whether the source character at `utf16Index` is whitespace (so a missing
+    /// outline is expected and the glyph can be safely advanced past).
+    private static func isWhitespace(_ utf16Index: CFIndex, in utf16: [UInt16]) -> Bool {
+        guard utf16Index >= 0, utf16Index < utf16.count,
+              let scalar = Unicode.Scalar(UInt32(utf16[utf16Index])) else { return false }
+        return scalar.properties.isWhitespace
     }
 }
 #endif

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
@@ -25,6 +25,11 @@ struct WPEMSDFTextLayout {
         fontID: String
     ) -> WPEMSDFTextMesh? {
         guard !object.text.isEmpty else { return nil }
+        // The MSDF path lays out a SINGLE line. Hard line breaks or text that
+        // would wrap under maxWidth are laid out differently by the CoreText
+        // framesetter fallback, so defer those whole objects to CoreText instead
+        // of compressing/mispositioning them (correctness over coverage).
+        if object.text.contains(where: \.isNewline) { return nil }
         let attributed = attributedString(for: object, font: font)
         let line = CTLineCreateWithAttributedString(attributed)
         var ascent: CGFloat = 0
@@ -33,18 +38,19 @@ struct WPEMSDFTextLayout {
         let rawLineWidth = CGFloat(CTLineGetTypographicBounds(line, &ascent, &descent, &leading))
         let naturalHeight = max(ascent + descent + leading, 1)
         let padding = CGFloat(max(object.padding, 0))
-        let maxWidth = object.maxWidth.map { CGFloat(max($0, 1)) }
-        let fittedLineWidth = maxWidth.map { min(max(rawLineWidth, 1), $0) } ?? max(rawLineWidth, 1)
-        let xScale = rawLineWidth > 0 ? Double(fittedLineWidth / rawLineWidth) : 1
+        if let maxWidth = object.maxWidth.map({ CGFloat(max($0, 1)) }), rawLineWidth > maxWidth + 0.5 {
+            return nil // would wrap → CoreText framesetter handles it
+        }
+        let lineWidth = max(rawLineWidth, 1)
         let boxSize = object.boxSize.map {
             CGSize(width: max($0.x, 1), height: max($0.y, 1))
         } ?? CGSize(
-            width: fittedLineWidth + padding * 2,
+            width: lineWidth + padding * 2,
             height: naturalHeight + padding * 2
         )
         let innerWidth = max(boxSize.width - padding * 2, 1)
         let innerHeight = max(boxSize.height - padding * 2, 1)
-        let alignedLineWidth = min(fittedLineWidth, innerWidth)
+        let alignedLineWidth = min(lineWidth, innerWidth)
         let xOffset = padding + horizontalOffset(
             alignment: object.horizontalAlignment,
             lineWidth: alignedLineWidth,
@@ -69,15 +75,19 @@ struct WPEMSDFTextLayout {
             let range = CFRange(location: 0, length: glyphCount)
             var glyphs = [CGGlyph](repeating: 0, count: glyphCount)
             var positions = [CGPoint](repeating: .zero, count: glyphCount)
-            var advances = [CGSize](repeating: .zero, count: glyphCount)
             CTRunGetGlyphs(run, range, &glyphs)
             CTRunGetPositions(run, range, &positions)
-            CTRunGetAdvances(run, range, &advances)
 
             for index in 0..<glyphCount {
                 let glyph = glyphs[index]
                 let key = WPEMSDFGlyphKey(fontID: fontID, glyph: glyph, pixelSize: pixelSize)
-                guard let entry = atlas.requestEntry(for: key, generator: generator, font: font) else {
+                let entry: WPEMSDFAtlasEntry
+                switch atlas.requestEntry(for: key, generator: generator, font: font) {
+                case .ready(let ready):
+                    entry = ready
+                case .skip:
+                    continue // whitespace / no-outline glyph: advance, draw nothing
+                case .pending:
                     isComplete = false
                     continue
                 }
@@ -85,15 +95,14 @@ struct WPEMSDFTextLayout {
                 let bearing = entry.metrics.bearing / pathUnitsToEm
                 let glyphWidth = Double(entry.metrics.cellSize.width) / entry.metrics.scale
                 let glyphHeight = Double(entry.metrics.cellSize.height) / entry.metrics.scale
-                let x = Double(xOffset) + Double(position.x) * xScale + bearing.x * xScale
+                let x = Double(xOffset) + Double(position.x) + bearing.x
                 let y = Double(baseline) - Double(position.y) - (bearing.y + glyphHeight)
                 appendQuad(
                     page: entry.page,
-                    rect: CGRect(x: x, y: y, width: glyphWidth * xScale, height: glyphHeight),
+                    rect: CGRect(x: x, y: y, width: glyphWidth, height: glyphHeight),
                     uvRect: entry.uvRect,
                     perPage: &perPage
                 )
-                _ = advances[index]
             }
         }
 

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFTextRenderer.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFTextRenderer.swift
@@ -53,13 +53,11 @@ final class WPEMSDFTextRenderer {
         let font = resolveFont(for: object)
         let material = WPEMSDFFontMaterial.make(object: object, parameters: parameters)
         guard let request = try? shaderRequest(comboValues: material.combos) else { return nil }
-        let fontID = fontIdentifier(font)
         guard let mesh = layout.layout(
             object: object,
             font: font,
             atlas: atlas,
-            generator: generator,
-            fontID: fontID
+            generator: generator
         ) else { return nil }
 
         let transformed = transform(mesh: mesh, object: object, parallaxOffset: parallaxOffset)
@@ -180,11 +178,6 @@ final class WPEMSDFTextRenderer {
         let fit = min(innerW / width, innerH / height)
         guard fit.isFinite, fit > 0 else { return base }
         return base * fit
-    }
-
-    private func fontIdentifier(_ font: CTFont) -> String {
-        let name = CTFontCopyPostScriptName(font) as String
-        return "\(name)@\(Int(ceil(CTFontGetSize(font))))"
     }
 
     private static func readInclude(path: String, resolver: WPEMultiRootResourceResolver) -> String? {

--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFTextRenderer.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFTextRenderer.swift
@@ -137,7 +137,13 @@ final class WPEMSDFTextRenderer {
     }
 
     private func resolveFont(for object: WPESceneTextObject) -> CTFont {
-        let size = effectiveFontSize(for: object)
+        font(for: object, size: effectiveFontSize(for: object))
+    }
+
+    /// The scene's font (custom file or HelveticaNeue fallback) at an explicit
+    /// size. Used both for the final glyph font and for box measurement, so
+    /// box-fit is computed with the SAME typeface that will be rendered.
+    private func font(for object: WPESceneTextObject, size: CGFloat) -> CTFont {
         if let path = object.fontRelativePath {
             registerFontIfNeeded(path)
             if let url = try? resolver.resolveExistingFileURL(relativePath: path),
@@ -161,7 +167,7 @@ final class WPEMSDFTextRenderer {
     private func effectiveFontSize(for object: WPESceneTextObject) -> CGFloat {
         let base = CGFloat(max(object.pointSize, 1))
         guard let box = object.boxSize, box.x > 0, box.y > 0 else { return base }
-        let font = CTFontCreateWithName("HelveticaNeue" as CFString, base, nil)
+        let font = font(for: object, size: base)
         let attributed = CFAttributedStringCreate(nil, object.text as CFString, [kCTFontAttributeName: font] as CFDictionary)!
         let line = CTLineCreateWithAttributedString(attributed)
         var ascent: CGFloat = 0

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -527,7 +527,10 @@ final class WPEMetalRenderExecutor {
         attachment.isBlendingEnabled = true
         attachment.rgbBlendOperation = .add
         attachment.alphaBlendOperation = .add
-        attachment.sourceRGBBlendFactor = .one
+        // font.frag returns STRAIGHT (non-premultiplied) alpha — vec4(rgb, a) —
+        // so source RGB must be scaled by sourceAlpha. Using .one (premultiplied)
+        // over-contributed RGB and haloed semi-transparent text / AA edges.
+        attachment.sourceRGBBlendFactor = .sourceAlpha
         attachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
         attachment.sourceAlphaBlendFactor = .one
         attachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha

--- a/LiveWallpaperTests/WPEMSDFGlyphGeneratorTests.swift
+++ b/LiveWallpaperTests/WPEMSDFGlyphGeneratorTests.swift
@@ -58,13 +58,27 @@ struct WPEMSDFGlyphGeneratorTests {
         #expect(first.bitmap.pixels == second.bitmap.pixels)
     }
 
-    @Test("Whitespace glyph produces a valid neutral bitmap without crashing")
-    func whitespaceGlyphIsNeutral() throws {
+    @Test("Whitespace glyph has no outline → generator returns nil (atlas marks it skip)")
+    func whitespaceGlyphReturnsNil() throws {
+        // A space has no drawable outline. Returning nil lets the atlas mark it
+        // `.skip` (advance, draw nothing) instead of emitting a 0.5-filled quad
+        // that the MSDF shader would render as a gray box.
         let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
         let generator = WPEMSDFGlyphGenerator()
-        let result = try #require(generator.generate(glyph: glyph(" ", font: font), font: font))
-        // No contours → neutral 0.5 fill: opaque, everywhere outside.
-        #expect(result.bitmap.pixels.allSatisfy { $0.w == 1 })
-        #expect(result.bitmap.pixels.allSatisfy { median($0) <= 0.5 + 1e-6 })
+        #expect(generator.generate(glyph: glyph(" ", font: font), font: font) == nil)
+    }
+
+    @Test("Counter glyph (O) is filled on the ring and empty in the hole")
+    func counterGlyphHoleIsOutside() throws {
+        // Guards the winding/orientation handling for glyphs with holes: the
+        // enclosed counter must read as OUTSIDE (median < 0.5) while the ring
+        // reads INSIDE (median > 0.5) — i.e. the hole isn't filled / inverted.
+        let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
+        let generator = WPEMSDFGlyphGenerator()
+        let result = try #require(generator.generate(glyph: glyph("O", font: font), font: font))
+        let bitmap = result.bitmap
+        let center = bitmap[bitmap.width / 2, bitmap.height / 2]
+        #expect(median(center) < 0.5)                       // hole = outside
+        #expect(bitmap.pixels.contains { median($0) > 0.5 }) // ring = inside
     }
 }

--- a/LiveWallpaperTests/WPEMSDFTextPipelineTests.swift
+++ b/LiveWallpaperTests/WPEMSDFTextPipelineTests.swift
@@ -80,8 +80,7 @@ struct WPEMSDFTextPipelineTests {
                 object: object,
                 font: font,
                 atlas: atlas,
-                generator: generator,
-                fontID: "Helvetica@32"
+                generator: generator
             )
             if mesh == nil { try await Task.sleep(nanoseconds: 10_000_000) }
         }


### PR DESCRIPTION
Follow-up fixes from two codex stability audits of the merged MSDF text feature (still gated behind WPEEnableMSDFText, default off).

- Whitespace/no-outline glyphs no longer draw 0.5 gray boxes (generator returns nil → atlas `.skip`); non-whitespace unsupported glyphs (emoji/color/substituted-font) fall the whole object back to CoreText instead of being dropped.
- Per-CTRun font used for atlas key + generation (fixes wrong glyphs in CoreText-substituted runs).
- Straight-alpha blend for font.frag; curve-tight glyph bounds (boundingBoxOfPath); page eviction keeps its texture; generate/store failures no longer re-scheduled every frame (bounded retry).
- Multi-line/wrapping text deferred to the CoreText framesetter (no positioning divergence).

codex final review: all prior High issues resolved (84/100). Remaining gate before default-on is on-device visual validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)