### PR TITLE
fix(wpe-scene): SceneScript property defaults exposed (clock 'undefined' separator)

### DIFF
--- a/LiveWallpaper/Runtime/WPESceneScriptRuntime.swift
+++ b/LiveWallpaper/Runtime/WPESceneScriptRuntime.swift
@@ -128,10 +128,23 @@ final class WPESceneScriptInstance {
 
         let createScriptProperties: @convention(block) () -> JSValue = {
             let proxy = JSValue(newObjectIn: context)!
-            let chainable: @convention(block) (JSValue) -> JSValue = { _ in proxy }
+            // Each `add*({ name, value, ... })` registers a script property; expose
+            // its default `value` on the returned object so `scriptProperties.<name>`
+            // resolves (e.g. a clock's `delimiter` → ":" instead of `undefined`,
+            // which otherwise stringifies into the rendered text). Returns the proxy
+            // so the builder calls chain; `finish()` (no args) just returns it.
+            let register: @convention(block) (JSValue) -> JSValue = { config in
+                if config.isObject,
+                   let nameValue = config.objectForKeyedSubscript("name"),
+                   nameValue.isString, let name = nameValue.toString(), !name.isEmpty,
+                   let value = config.objectForKeyedSubscript("value"), !value.isUndefined {
+                    proxy.setObject(value, forKeyedSubscript: name as NSString)
+                }
+                return proxy
+            }
             for name in ["addCheckbox", "addText", "addSlider", "addColor",
                          "addCombo", "addFile", "addUserShortcut", "addGroup", "finish"] {
-                proxy.setObject(chainable, forKeyedSubscript: name as NSString)
+                proxy.setObject(register, forKeyedSubscript: name as NSString)
             }
             return proxy
         }

--- a/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
+++ b/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
@@ -65,7 +65,7 @@ struct WPESceneScriptRuntimeTests {
         #expect(instance.tickString() == "static")
     }
 
-    @Test("createScriptProperties chain doesn't crash")
+    @Test("createScriptProperties exposes each property's default value")
     func createScriptPropertiesChain() throws {
         let script = """
         export var scriptProperties = createScriptProperties()
@@ -77,8 +77,25 @@ struct WPESceneScriptRuntimeTests {
         }
         """
         let instance = try WPESceneScriptInstance(script: script, initialValue: "init")
-        let result = instance.tickString()
-        #expect(result.hasSuffix("OK"))
+        // The registered default (':') must be readable, not undefined.
+        #expect(instance.tickString() == ":OK")
+    }
+
+    @Test("Clock-style script reads property defaults, not 'undefined'")
+    func clockScriptPropertyDefaults() throws {
+        // Reproduces the VHS clock bug: a missing `delimiter`/`use24hFormat`
+        // default stringified to "undefined" between the hours and minutes.
+        let script = """
+        export var scriptProperties = createScriptProperties()
+            .addCheckbox({name: 'use24hFormat', value: true})
+            .addText({name: 'delimiter', value: ':'})
+            .finish();
+        export function update(value) {
+            return '03' + scriptProperties.delimiter + '30' + '/' + scriptProperties.use24hFormat;
+        }
+        """
+        let instance = try WPESceneScriptInstance(script: script, initialValue: "init")
+        #expect(instance.tickString() == "03:30/true")
     }
 
     @Test("engine.getTimeOfDay returns 0..1")


### PR DESCRIPTION
SceneScript's createScriptProperties() returned a chainable no-op proxy but never stored each property's default `value`, so `scriptProperties.<name>` was undefined. In the VHS clock that made `hours + scriptProperties.delimiter + minutes` render as `03undefined30`, and `use24hFormat` (undefined) wrongly took the 12h branch.

add*({name, value, ...}) now records `value` on the returned object so defaults resolve. Tests: chain exposes ':'; clock script yields "03:30/true".

🤖 Generated with [Claude Code](https://claude.com/claude-code)