### PR TITLE
test(wpe-2.8): MSDF idiomatic whitespace + emoji/whitespace tests (missed by #108)

### DIFF
--- a/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
+++ b/LiveWallpaper/Runtime/MSDF/WPEMSDFTextLayout.swift
@@ -62,7 +62,17 @@ struct WPEMSDFTextLayout {
             naturalHeight: naturalHeight,
             innerHeight: innerHeight
         )
-        let utf16 = Array(object.text.utf16)
+        // Per-UTF16-unit whitespace flags using grapheme-level Character.isWhitespace
+        // (expanded across each character's UTF-16 units) so a glyph's source can
+        // be classified in O(1) by its CTRun string index.
+        var whitespaceByUTF16: [Bool] = []
+        whitespaceByUTF16.reserveCapacity(object.text.utf16.count)
+        for character in object.text {
+            let isWhitespace = character.isWhitespace
+            for _ in 0..<String(character).utf16.count {
+                whitespaceByUTF16.append(isWhitespace)
+            }
+        }
         let runs = CTLineGetGlyphRuns(line) as! [CTRun]
         var perPage: [Int: [WPEMSDFTextVertex]] = [:]
         var isComplete = true
@@ -100,7 +110,7 @@ struct WPEMSDFTextLayout {
                     // A NON-whitespace glyph with no MSDF outline (emoji / color /
                     // unsupported) must NOT be silently dropped — fall the whole
                     // object back to CoreText so it renders correctly.
-                    if Self.isWhitespace(stringIndices[index], in: utf16) { continue }
+                    if Self.isWhitespace(stringIndices[index], flags: whitespaceByUTF16) { continue }
                     return nil
                 }
                 let position = positions[index]
@@ -201,12 +211,11 @@ struct WPEMSDFTextLayout {
         return "\(name)@\(Int(ceil(CTFontGetSize(font))))"
     }
 
-    /// Whether the source character at `utf16Index` is whitespace (so a missing
-    /// outline is expected and the glyph can be safely advanced past).
-    private static func isWhitespace(_ utf16Index: CFIndex, in utf16: [UInt16]) -> Bool {
-        guard utf16Index >= 0, utf16Index < utf16.count,
-              let scalar = Unicode.Scalar(UInt32(utf16[utf16Index])) else { return false }
-        return scalar.properties.isWhitespace
+    /// Whether the source character at the glyph's UTF-16 offset is whitespace
+    /// (so a missing outline is expected and the glyph can be safely advanced
+    /// past). Backed by grapheme-level `Character.isWhitespace`.
+    private static func isWhitespace(_ utf16Offset: CFIndex, flags: [Bool]) -> Bool {
+        utf16Offset >= 0 && utf16Offset < flags.count && flags[utf16Offset]
     }
 }
 #endif

--- a/LiveWallpaperTests/WPEMSDFTextPipelineTests.swift
+++ b/LiveWallpaperTests/WPEMSDFTextPipelineTests.swift
@@ -92,4 +92,52 @@ struct WPEMSDFTextPipelineTests {
         #expect(totalVertices == 12)
         #expect(totalVertices % 6 == 0)
     }
+
+    /// Polls the async layout until it produces a mesh (or a bounded timeout).
+    private func awaitMesh(
+        _ object: WPESceneTextObject,
+        font: CTFont,
+        atlas: WPEMSDFAtlas,
+        generator: WPEMSDFGlyphGenerator,
+        layout: WPEMSDFTextLayout,
+        attempts: Int = 200
+    ) async -> WPEMSDFTextMesh? {
+        for _ in 0..<attempts {
+            if let mesh = layout.layout(object: object, font: font, atlas: atlas, generator: generator) {
+                return mesh
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return nil
+    }
+
+    @Test("Whitespace is advanced past, not drawn (A B → two quads, space skipped)")
+    func whitespaceIsSkippedNotDrawn() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let atlas = WPEMSDFAtlas(device: device)
+        let generator = WPEMSDFGlyphGenerator()
+        let layout = WPEMSDFTextLayout()
+        let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
+
+        let mesh = await awaitMesh(makeTextObject(text: "A B"), font: font, atlas: atlas, generator: generator, layout: layout)
+        let resolved = try #require(mesh)
+        let totalVertices = resolved.perPage.values.reduce(0) { $0 + $1.count }
+        // "A" + "B" drawn (2 quads × 6), the space contributes no quad.
+        #expect(totalVertices == 12)
+    }
+
+    @Test("Emoji (no MSDF outline) makes the whole object fall back to CoreText")
+    func emojiObjectFallsBackToCoreText() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let atlas = WPEMSDFAtlas(device: device)
+        let generator = WPEMSDFGlyphGenerator()
+        let layout = WPEMSDFTextLayout()
+        let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
+
+        // A color emoji has no monochrome outline → generation yields nil → the
+        // glyph is .skip and, being non-whitespace, the layout must keep returning
+        // nil (object renders via CoreText) rather than dropping the emoji.
+        let mesh = await awaitMesh(makeTextObject(text: "😀"), font: font, atlas: atlas, generator: generator, layout: layout, attempts: 40)
+        #expect(mesh == nil)
+    }
 }


### PR DESCRIPTION
Recovers commit 46c31d2 — it was pushed to feat/wpe-2.8-msdf-stability *after* PR #108 had already been merged, so it never reached main. The functional behavior in main is correct (the existing whitespace check is fail-safe); this adds the cleaner implementation + the two tests I'd intended to ship with #108.

- isWhitespace uses grapheme-level Character.isWhitespace via a precomputed per-UTF16 flag array (O(1), correct for combining marks/surrogates).
- Tests: 'A B' draws two quads with the space skipped; '😀' keeps layout nil so the object falls back to CoreText.

🤖 Generated with [Claude Code](https://claude.com/claude-code)