### PR TITLE
WPE scenes read in place (zero-cache) + SteamCMD downloads reveal button

### DIFF
--- a/LiveWallpaper/Infrastructure/WPESceneDebugArtifacts.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDebugArtifacts.swift
@@ -215,6 +215,39 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
         }
         recordNote(name: "pass-list.txt", contents: lines.joined(separator: "\n"))
         appendLog("[pass-list] wrote \(pipeline.layers.reduce(0) { $0 + $1.passes.count }) pass entries")
+        recordLayerPlacements(pipeline)
+    }
+
+    /// One-shot per-scene dump of every layer's resolved placement plus each puppet's MDAT anchors,
+    /// so a body-split rig's parent/child mis-placement can be diagnosed numerically (read-only).
+    func recordLayerPlacements(_ pipeline: WPEPreparedRenderPipeline) {
+        guard isEnabled else { return }
+        func fmt(_ v: SIMD3<Double>) -> String { String(format: "(%.1f,%.1f,%.1f)", v.x, v.y, v.z) }
+        func fmt2(_ v: SIMD2<Double>) -> String { String(format: "(%.1f,%.1f)", v.x, v.y) }
+        var lines: [String] = []
+        for layer in pipeline.layers {
+            let g = layer.graphLayer.geometry
+            let sizeStr = g.size.map { String(format: "%.0fx%.0f", $0.width, $0.height) } ?? "nil"
+            lines.append(
+                "id=\(layer.graphLayer.objectID) name=\(layer.graphLayer.objectName) "
+                + "puppet=\(layer.puppetModel != nil ? 1 : 0) "
+                + "parent=\(layer.graphLayer.parentObjectID ?? "-") attach=\(layer.graphLayer.attachment ?? "-") "
+                + "origin=\(fmt(g.origin)) size=\(sizeStr) meshCenter=\(fmt2(g.puppetMeshCenter)) "
+                + "scale=\(fmt(g.scale)) angles=\(fmt(g.angles)) align=\(g.alignment)"
+            )
+            if let model = layer.puppetModel, !model.attachments.isEmpty {
+                for a in model.attachments {
+                    let bind = a.bindMatrix
+                    let bt = bind.count >= 16 ? String(format: "MDAT_T=(%.1f,%.1f)", bind[12], bind[13]) : "MDAT_T=?"
+                    let bone = model.bones.first { $0.index == a.boneIndex }
+                    let bw = bone.flatMap { $0.rawMatrix.count >= 16 ? $0.rawMatrix : nil }
+                    let bwt = bw.map { String(format: "boneWorld_T=(%.1f,%.1f)", $0[12], $0[13]) } ?? "boneWorld_T=?"
+                    lines.append("    anchor \(a.name) -> bone \(a.boneIndex)  \(bt)  \(bwt)")
+                }
+            }
+        }
+        recordNote(name: "layer-placements.txt", contents: lines.joined(separator: "\n"))
+        appendLog("[placements] wrote \(pipeline.layers.count) layer placements")
     }
 
     func recordFirstFrameStats(_ stats: WPEMetalTextureVisualStats) {

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -424,7 +424,7 @@ final class WallpaperEngineImportService {
         // so nothing is kept in wpe-cache. Remove any stale prior extraction for
         // this id — frees its disk and ensures the source `.pkg` is never treated
         // as a redundant, reclaimable copy (no completion manifest survives).
-        try? await cache.purge(workshopID: project.workshopID)
+        await purgeStaleCache(workshopID: project.workshopID)
 
         let dependencyMounts = WPEDependencyMountResolver().mounts(
             dependencyWorkshopIDs: project.dependencyWorkshopIDs,
@@ -486,7 +486,7 @@ final class WallpaperEngineImportService {
 
         // Zero-cache: assets and project.json are read in place from the folder.
         // Remove any stale prior mirror/extraction for this id.
-        try? await cache.purge(workshopID: project.workshopID)
+        await purgeStaleCache(workshopID: project.workshopID)
 
         let dependencyMounts = WPEDependencyMountResolver().mounts(
             dependencyWorkshopIDs: project.dependencyWorkshopIDs,
@@ -525,6 +525,20 @@ final class WallpaperEngineImportService {
             return .unsupported(origin: origin)
         }
         return .ready(.scene(descriptor), origin: origin)
+    }
+
+    /// Removes any stale extraction/mirror for an in-place import. Best-effort:
+    /// a failure leaves the (now-unreferenced) old cache on disk but the runtime
+    /// still reads from source — logged so a lingering cache is diagnosable.
+    private func purgeStaleCache(workshopID: String) async {
+        do {
+            try await cache.purge(workshopID: workshopID)
+        } catch {
+            Logger.warning(
+                "WPE in-place import: stale cache purge failed for \(workshopID): \(describe(error))",
+                category: .screenManager
+            )
+        }
     }
 
     private func ensureExtracted(project: WallpaperEngineProject, pkgURL: URL) async -> Result<URL, ExtractionFailure> {
@@ -731,10 +745,10 @@ struct WPECachedContentResolver {
         let entryURLCandidate = resourceURL(root: cacheURL, relativePath: entryFile)
         let entryExistsInCache = entryURLCandidate.map { fileManager.fileExists(atPath: $0.path) } ?? false
 
-        // Package-backed scene: scene.json lives in the source `scene.pkg`, not
-        // the metadata-only cache. Rebuild the in-place descriptor from source.
+        // Source-backed scene: scene.json lives in the source folder or source
+        // `scene.pkg`, not in the now-empty cache. Rebuild the in-place descriptor.
         if origin.originalType == .scene, !entryExistsInCache {
-            return packageBackedSceneContent(
+            return sourceBackedSceneContent(
                 for: origin,
                 cacheRelativePath: cacheRelativePath,
                 entryFile: entryFile
@@ -809,10 +823,10 @@ struct WPECachedContentResolver {
         }
     }
 
-    /// Rebuilds a package-backed scene descriptor from its source `scene.pkg`
-    /// (favorites/history reconstruction for in-place scenes whose cache holds
-    /// only `project.json`). Returns `nil` if the source can't be opened.
-    private func packageBackedSceneContent(
+    /// Rebuilds an in-place scene descriptor from its source folder or source
+    /// `scene.pkg` (favorites/history reconstruction for zero-cache scenes whose
+    /// cache is empty). Returns `nil` if the source can't be opened.
+    private func sourceBackedSceneContent(
         for origin: WPEOrigin,
         cacheRelativePath: String,
         entryFile: String
@@ -827,11 +841,27 @@ struct WPECachedContentResolver {
         let didStart = folderURL.startAccessingSecurityScopedResource()
         defer { if didStart { folderURL.stopAccessingSecurityScopedResource() } }
 
+        let provider: any WPESceneAssetProvider
+        let assetStorage: SceneAssetStorage
+        let sceneData: Data
+
         let packageURL = folderURL.appendingPathComponent("scene.pkg", isDirectory: false)
-        guard fileManager.fileExists(atPath: packageURL.path),
-              let provider = try? WPEPackageSceneAssetProvider(packageURL: packageURL),
-              let sceneData = try? provider.data(atRelativePath: entryFile),
-              let document = try? WPESceneDocumentParser.parse(data: sceneData) else {
+        if fileManager.fileExists(atPath: packageURL.path),
+           let packageProvider = try? WPEPackageSceneAssetProvider(packageURL: packageURL),
+           let packageSceneData = try? packageProvider.data(atRelativePath: entryFile) {
+            provider = packageProvider
+            assetStorage = .packageSource(fileName: packageURL.lastPathComponent)
+            sceneData = packageSceneData
+        } else {
+            let directoryProvider = WPEDirectorySceneAssetProvider(rootURL: folderURL)
+            guard let directorySceneData = try? directoryProvider.data(atRelativePath: entryFile) else {
+                return nil
+            }
+            provider = directoryProvider
+            assetStorage = .sourceDirectory
+            sceneData = directorySceneData
+        }
+        guard let document = try? WPESceneDocumentParser.parse(data: sceneData) else {
             return nil
         }
 
@@ -866,7 +896,7 @@ struct WPECachedContentResolver {
             cacheRelativePath: cacheRelativePath,
             entryFile: entryFile,
             capabilityTier: tier,
-            assetStorage: .packageSource(fileName: packageURL.lastPathComponent),
+            assetStorage: assetStorage,
             dependencyWorkshopIDs: origin.dependencyWorkshopIDs,
             preflightTier: preflight.tier,
             preflightFeatureFlags: sortedPreflightFeatureFlags(preflight.featureFlags)

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -304,6 +304,17 @@ final class WallpaperEngineImportService {
             ))
         }
 
+        // Default: read the unpacked folder scene in place from the source — no
+        // mirror copy in wpe-cache. Falls back to mirroring only if in-place
+        // reading fails (e.g. the entry can't be read/parsed).
+        if let directoryResult = await finishSceneSourceDirectoryImport(
+            project: project,
+            folderURL: folderURL,
+            sourceBookmark: sourceBookmark
+        ) {
+            return directoryResult
+        }
+
         let cacheResult = await ensureMirrored(project: project, folderURL: folderURL)
         guard case .success(let cacheURL) = cacheResult else {
             if case .failure(let failure) = cacheResult { return .rejected(reason: failure.reason) }
@@ -437,6 +448,68 @@ final class WallpaperEngineImportService {
             entryFile: project.entryFile,
             capabilityTier: tier,
             assetStorage: .packageSource(fileName: pkgURL.lastPathComponent),
+            dependencyWorkshopIDs: project.dependencyWorkshopIDs,
+            preflightTier: preflight.tier,
+            preflightFeatureFlags: sortedPreflightFeatureFlags(preflight.featureFlags)
+        )
+        let origin = makeOrigin(
+            project: project,
+            sourceBookmark: sourceBookmark,
+            cacheRelativePath: cacheRelativePath(for: project),
+            resourceLocation: .cache
+        )
+
+        if tier == .unsupported {
+            return .unsupported(origin: origin)
+        }
+        return .ready(.scene(descriptor), origin: origin)
+    }
+
+    /// Imports an unpacked folder scene to read in place from its source folder
+    /// (no mirror copy). Returns `nil` when the entry can't be read/parsed, so
+    /// the caller falls back to mirroring into the cache.
+    private func finishSceneSourceDirectoryImport(
+        project: WallpaperEngineProject,
+        folderURL: URL,
+        sourceBookmark: Data
+    ) async -> ImportResult? {
+        let provider = WPEDirectorySceneAssetProvider(rootURL: folderURL)
+        guard let sceneData = try? provider.data(atRelativePath: project.entryFile) else {
+            return nil
+        }
+        let document: WPESceneDocument
+        do {
+            document = try WPESceneDocumentParser.parse(data: sceneData)
+        } catch {
+            return nil
+        }
+
+        // Zero-cache: assets and project.json are read in place from the folder.
+        // Remove any stale prior mirror/extraction for this id.
+        try? await cache.purge(workshopID: project.workshopID)
+
+        let dependencyMounts = WPEDependencyMountResolver().mounts(
+            dependencyWorkshopIDs: project.dependencyWorkshopIDs,
+            origin: nil
+        )
+        let engineRoot = WPEEngineAssetsLibrary.shared.resolveAuthorizedRoot()
+        let tier = WPESceneCapabilityClassifier().capabilityTier(
+            for: document,
+            primaryProvider: provider,
+            dependencyMounts: dependencyMounts,
+            engineAssetsRootURL: engineRoot
+        )
+        let preflight = WPEScenePreflight.classify(
+            document: document,
+            project: project,
+            scenePackageEntries: provider.entryNames
+        )
+        let descriptor = SceneDescriptor(
+            workshopID: project.workshopID,
+            cacheRelativePath: cacheRelativePath(for: project),
+            entryFile: project.entryFile,
+            capabilityTier: tier,
+            assetStorage: .sourceDirectory,
             dependencyWorkshopIDs: project.dependencyWorkshopIDs,
             preflightTier: preflight.tier,
             preflightFeatureFlags: sortedPreflightFeatureFlags(preflight.featureFlags)

--- a/LiveWallpaper/Views/Settings/WorkshopDoctorView.swift
+++ b/LiveWallpaper/Views/Settings/WorkshopDoctorView.swift
@@ -135,6 +135,8 @@ struct WorkshopDoctorView: View {
                         catch { setupError = error.localizedDescription }
                     }
                 )
+                Divider()
+                downloadsRow
                 if let setupError {
                     Label(setupError, systemImage: "exclamationmark.triangle.fill")
                         .foregroundStyle(.red)
@@ -145,6 +147,42 @@ struct WorkshopDoctorView: View {
                 }
             }
         }
+    }
+
+    /// Reveals the real on-disk location where SteamCMD saves Workshop items —
+    /// the sandbox-redirected container Steam tree, which is otherwise buried in
+    /// `~/Library/Containers/…` and hard to reach by hand.
+    private var downloadsRow: some View {
+        HStack(alignment: .top, spacing: DesignTokens.Spacing.sm) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.xxs) {
+                Text("Downloads")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Where SteamCMD saves Workshop items inside this app's container.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+            Button("Show in Finder") { revealDownloadsFolder() }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Opens the SteamCMD download folder in Finder, falling back to its deepest
+    /// existing ancestor when nothing has been downloaded yet (the
+    /// `content/431960` folder only appears after the first download).
+    private func revealDownloadsFolder() {
+        let fileManager = FileManager.default
+        guard let contentRoot = WPEDownloadArchiveReclaimer.containerSteamContentRoot(fileManager: fileManager) else {
+            return
+        }
+        var target = contentRoot
+        while !fileManager.fileExists(atPath: target.path) {
+            let parent = target.deletingLastPathComponent()
+            if parent.path == target.path { return }
+            target = parent
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([target])
     }
 
     private var diagnosticsSection: some View {

--- a/LiveWallpaper/Views/Settings/WorkshopSettingsView.swift
+++ b/LiveWallpaper/Views/Settings/WorkshopSettingsView.swift
@@ -138,15 +138,6 @@ struct WorkshopSettingsView: View {
 
             Section {
                 LabeledContent {
-                    Button("Show in Finder") { revealLibraryFolder() }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                        .help("Open the folder where imported Workshop projects are stored")
-                } label: {
-                    Label("Workshop library folder", systemImage: "folder")
-                }
-
-                LabeledContent {
                     Button("Manage") { showingCacheManagement = true }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
@@ -157,7 +148,7 @@ struct WorkshopSettingsView: View {
             } header: {
                 Text("Cache")
             } footer: {
-                Text("Imported projects live in the library folder. The browse cache holds QueryFiles JSON responses (5-minute TTL, 100 MB hard cap).")
+                Text("The browse cache holds QueryFiles JSON responses (5-minute TTL, 100 MB hard cap). Scene assets are read in place from their source — they're no longer copied into a cache.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -292,10 +283,5 @@ struct WorkshopSettingsView: View {
         }
     }
 
-    private func revealLibraryFolder() {
-        let url = WallpaperEngineCache.defaultRootURL
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        NSWorkspace.shared.open(url)
-    }
 }
 #endif

--- a/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
+++ b/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
@@ -253,7 +253,7 @@ struct WallpaperEngineImportServiceTests {
         #expect(!FileManager.default.fileExists(atPath: sceneCache.path))
     }
 
-    @Test("Unpacked scene folder with valid scene.json + image asset returns ready cache-backed scene content")
+    @Test("Unpacked scene folder with valid scene.json + image asset imports in place (.sourceDirectory)")
     func unpackedSceneFolderWithAssetReturnsReady() async throws {
         let pngBytes = try makeFixturePNG(width: 4, height: 4)
         let sceneJSON = """
@@ -291,17 +291,16 @@ struct WallpaperEngineImportServiceTests {
             Issue.record("Expected .scene content, got \(content)")
             return
         }
-        let cachedScene = fixture.cacheURL
-            .appendingPathComponent(fixture.workshopID, isDirectory: true)
-            .appendingPathComponent("scene.json")
-
         #expect(descriptor.workshopID == fixture.workshopID)
         #expect(descriptor.cacheRelativePath == "wpe-cache/\(fixture.workshopID)")
         #expect(descriptor.entryFile == "scene.json")
         #expect(descriptor.capabilityTier == .imageOnly)
+        #expect(descriptor.assetStorage == .sourceDirectory)
         #expect(origin.cacheRelativePath == "wpe-cache/\(fixture.workshopID)")
         #expect(origin.resourceLocation == .cache)
-        #expect(FileManager.default.fileExists(atPath: cachedScene.path))
+        // Zero-cache: the folder is read in place, so nothing is mirrored into wpe-cache.
+        let sceneCache = fixture.cacheURL.appendingPathComponent(fixture.workshopID, isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: sceneCache.path))
     }
 
     @Test("Scene with image layers AND unsupported objects is classified degraded")


### PR DESCRIPTION
All WPE **scene** imports (packaged `scene.pkg` and unpacked folder) now read assets in place from their source — nothing is copied into `wpe-cache`, eliminating the unbounded extraction cache. Removes the misleading "Workshop library folder" cache row (it opened `wpe-cache` and claimed projects live there; wpe-cache management still lives in General Settings) and adds a "Show in Finder" button for the real SteamCMD download folder.

Builds on the merged in-place provider work (#112). `wpe-cache` code remains only for packaged video/web (AVFoundation/WKWebView need on-disk files). codex-reviewed; favorites/history reconstruction handles both `.packageSource` and `.sourceDirectory`. Note: also carries one unrelated debug-diagnostic commit (`8dcfaa0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)