### PR TITLE
WPE cache: auto-reclaim legacy cache + in-place hardening + framework cleanup

### DIFF
--- a/LiveWallpaper/Infrastructure/SceneResourceResolver.swift
+++ b/LiveWallpaper/Infrastructure/SceneResourceResolver.swift
@@ -261,7 +261,7 @@ struct SceneResourceResolver: Sendable {
     /// file itself; package-backed materializes a staged temporary.
     func resolveExistingFileURL(relativePath: String) throws -> URL {
         do {
-            return try provider.stagedURL(atRelativePath: relativePath, purpose: .fileConsumer).url
+            return try provider.stagedURL(atRelativePath: relativePath)
         } catch WPESceneAssetProviderError.invalidRelativePath {
             throw ResolveError.pathEscape
         } catch {

--- a/LiveWallpaper/Infrastructure/WPEDirectorySceneAssetProvider.swift
+++ b/LiveWallpaper/Infrastructure/WPEDirectorySceneAssetProvider.swift
@@ -29,13 +29,13 @@ struct WPEDirectorySceneAssetProvider: WPESceneAssetProvider {
         }
     }
 
-    func stagedURL(atRelativePath relativePath: String, purpose: WPESceneAssetURLPurpose) throws -> WPEStagedAssetURL {
+    func stagedURL(atRelativePath relativePath: String) throws -> URL {
         let url = try strictURL(for: relativePath)
         guard isRegularFile(url) else {
             throw WPESceneAssetProviderError.fileMissing(relativePath)
         }
-        // The project file itself satisfies the consumer — no copy, no release.
-        return WPEStagedAssetURL(url: url)
+        // The project file itself satisfies the consumer — no copy.
+        return url
     }
 
     func exists(atRelativePath relativePath: String) -> Bool {

--- a/LiveWallpaper/Infrastructure/WPEPackageSceneAssetProvider.swift
+++ b/LiveWallpaper/Infrastructure/WPEPackageSceneAssetProvider.swift
@@ -23,7 +23,6 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
     private static let mmapThreshold: UInt64 = 64 * 1024 * 1024
     private static let copyChunkSize = 1 << 20
 
-    private let packageURL: URL
     private let package: WallpaperEnginePackage
     private let handle: FileHandle
     private let lock = NSLock()
@@ -32,7 +31,6 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
     private var stagedPaths: [String: URL] = [:]
 
     init(packageURL: URL) throws {
-        self.packageURL = packageURL
         self.stagingRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("LiveWallpaper-WPEPkgStage-\(UUID().uuidString)", isDirectory: true)
         let handle = try FileHandle(forReadingFrom: packageURL)
@@ -70,11 +68,11 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
         }
     }
 
-    func stagedURL(atRelativePath relativePath: String, purpose: WPESceneAssetURLPurpose) throws -> WPEStagedAssetURL {
+    func stagedURL(atRelativePath relativePath: String) throws -> URL {
         let entry = try packageEntry(for: relativePath)
         lock.lock()
         defer { lock.unlock() }
-        return WPEStagedAssetURL(url: try stageEntryLocked(entry, relativePath: relativePath))
+        return try stageEntryLocked(entry, relativePath: relativePath)
     }
 
     func exists(atRelativePath relativePath: String) -> Bool {

--- a/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
@@ -1,6 +1,7 @@
 #if !LITE_BUILD
 import CoreGraphics
 import Foundation
+import simd
 
 struct WPERenderGraphBuilder: Sendable {
     private let resolver: WPEMultiRootResourceResolver
@@ -82,7 +83,75 @@ struct WPERenderGraphBuilder: Sendable {
                     preserveFinalCompositeForScene: layerIDsRequiredAsComposite.contains(object.id)
                 )
             }
-        return WPERenderGraph(layers: layers)
+        return WPERenderGraph(layers: applyAttachmentAnchorOffsets(to: layers))
+    }
+
+    /// Body-split rigs attach face/hair/clothing child layers to a parent puppet's named MDAT anchor
+    /// (头部/胸部/脖颈). Parse-time parent composition (`SceneObjectTransform.combining`) places those
+    /// children relative to the parent's ORIGIN, ignoring the anchor bone — so the children tear away
+    /// from the parent mesh. This second pass adds the missing static anchor-bind offset (in scene
+    /// space) to each attached child's origin. Layers without a resolvable attachment are untouched,
+    /// so non-attached layers and other scenes are unaffected. The executor's animated attachment
+    /// follow adds only the per-frame `currentAnchor - bindAnchor` delta on top of this static bind.
+    private func applyAttachmentAnchorOffsets(to layers: [WPERenderLayer]) -> [WPERenderLayer] {
+        guard layers.contains(where: { $0.attachment != nil && $0.parentObjectID != nil }) else {
+            return layers
+        }
+        let layersByID = Dictionary(layers.map { ($0.objectID, $0) }, uniquingKeysWith: { first, _ in first })
+        var modelCache: [String: WPEPuppetModel?] = [:]
+        func parentModel(forPuppetPath path: String) -> WPEPuppetModel? {
+            if let cached = modelCache[path] { return cached }
+            let model = (try? resolver.data(relativePath: path)).flatMap { try? WPEMdlParser.parse(data: $0) }
+            modelCache[path] = model
+            return model
+        }
+        return layers.map { layer in
+            guard let attachmentName = layer.attachment,
+                  let parentID = layer.parentObjectID,
+                  let parent = layersByID[parentID],
+                  let puppetPath = parent.puppetPath,
+                  let model = parentModel(forPuppetPath: puppetPath),
+                  let offset = Self.staticAttachmentOffset(
+                      attachmentName: attachmentName,
+                      parentGeometry: parent.geometry,
+                      parentModel: model
+                  ) else {
+                return layer
+            }
+            return layer.replacingGeometryOrigin(addingSceneOffset: offset)
+        }
+    }
+
+    /// Scene-space offset that moves an attached child from "relative to parent origin" to "relative
+    /// to the parent's anchor bone bind point". `anchorModel = rawMatrix[bone] · MDAT` is the anchor
+    /// in parent model space; it maps to scene by the parent's mesh-center, scale (model→scene), and
+    /// rotation. Returns nil (no offset) when the anchor/bone/matrix cannot be resolved.
+    private static func staticAttachmentOffset(
+        attachmentName: String,
+        parentGeometry: WPERenderLayerGeometry,
+        parentModel: WPEPuppetModel
+    ) -> SIMD3<Double>? {
+        guard let attachment = parentModel.attachments.first(where: { $0.name == attachmentName }),
+              let bone = parentModel.bones.first(where: { $0.index == attachment.boneIndex }),
+              let boneBind = WPEMdlParser.matrix(fromColumnMajorFloats: bone.rawMatrix) else {
+            return nil
+        }
+        let anchorBind = boneBind * attachment.matrix
+        let anchorModel = SIMD2<Double>(Double(anchorBind.columns.3.x), Double(anchorBind.columns.3.y))
+        // Model y is down; scene origin y is up — hence the y sign flip. Subtract the parent's mesh
+        // center so the offset is expressed in the same composite frame the puppet vertex shader uses.
+        let local = SIMD2<Double>(
+            abs(parentGeometry.scale.x) * (anchorModel.x - parentGeometry.puppetMeshCenter.x),
+            -abs(parentGeometry.scale.y) * (anchorModel.y - parentGeometry.puppetMeshCenter.y)
+        )
+        let cosine = cos(parentGeometry.angles.z)
+        let sine = sin(parentGeometry.angles.z)
+        guard local.x.isFinite, local.y.isFinite else { return nil }
+        return SIMD3<Double>(
+            cosine * local.x - sine * local.y,
+            sine * local.x + cosine * local.y,
+            0
+        )
     }
 
     private static func compositesToScene(_ object: WPESceneImageObject, liveVisibilityIDs: Set<String>) -> Bool {
@@ -850,6 +919,42 @@ private struct WPEPuppetBounds {
 
         self.min = SIMD2<Double>(minX, minY)
         self.max = SIMD2<Double>(maxX, maxY)
+    }
+}
+
+private extension WPERenderLayer {
+    func replacingGeometryOrigin(addingSceneOffset offset: SIMD3<Double>) -> WPERenderLayer {
+        let g = geometry
+        let newGeometry = WPERenderLayerGeometry(
+            origin: SIMD3<Double>(g.origin.x + offset.x, g.origin.y + offset.y, g.origin.z + offset.z),
+            scale: g.scale,
+            angles: g.angles,
+            alignment: g.alignment,
+            size: g.size,
+            puppetMeshCenter: g.puppetMeshCenter,
+            alpha: g.alpha,
+            alphaAnimation: g.alphaAnimation,
+            color: g.color,
+            brightness: g.brightness
+        )
+        return WPERenderLayer(
+            objectID: objectID,
+            objectName: objectName,
+            visible: visible,
+            imagePath: imagePath,
+            materialPath: materialPath,
+            puppetPath: puppetPath,
+            parentObjectID: parentObjectID,
+            attachment: attachment,
+            animationLayers: animationLayers,
+            geometry: newGeometry,
+            localGeometry: localGeometry,
+            compositeA: compositeA,
+            compositeB: compositeB,
+            localFBOs: localFBOs,
+            passes: passes,
+            parallaxDepth: parallaxDepth
+        )
     }
 }
 

--- a/LiveWallpaper/Infrastructure/WPESceneAssetProvider.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneAssetProvider.swift
@@ -1,42 +1,11 @@
 #if !LITE_BUILD
 import Foundation
 
-/// Why a consumer wants a file URL for an asset that the provider may only
-/// hold inside a packed container. Lets a package-backed provider decide how
-/// (and whether) to materialize the bytes on disk.
-enum WPESceneAssetURLPurpose: Equatable, Sendable {
-    /// AVFoundation video — needs a stable on-disk URL it can stream from.
-    case avFoundationVideo
-    /// Audio playback through AVAudioPlayer / AVAudioFile.
-    case audioPlayback
-    /// ImageIO / Core Text consumers that read from a URL.
-    case fileConsumer
-}
-
 enum WPESceneAssetProviderError: Error, Equatable, Sendable {
     case invalidRelativePath(String)
     case fileMissing(String)
     case unreadable(String)
     case stagingUnavailable(String)
-}
-
-/// A file URL handed to a consumer that needs one. For a directory-backed
-/// provider it is the project file itself (no copy, no release work). For a
-/// package-backed provider it is a staged temporary file whose lifetime is
-/// reference-counted by the stager; the consumer must `release()` once done.
-struct WPEStagedAssetURL: Sendable {
-    let url: URL
-    private let releaseHandler: (@Sendable () -> Void)?
-
-    init(url: URL, releaseHandler: (@Sendable () -> Void)? = nil) {
-        self.url = url
-        self.releaseHandler = releaseHandler
-    }
-
-    /// Idempotent: a directory-backed URL has no handler and releasing is a no-op.
-    func release() {
-        releaseHandler?()
-    }
 }
 
 /// Single boundary through which the scene runtime reads project assets. Two
@@ -49,9 +18,11 @@ protocol WPESceneAssetProvider: Sendable {
     /// `.mappedIfSafe` so the RSS profile matches the historical extracted-cache
     /// path; package backends read the entry's slice.
     func data(atRelativePath relativePath: String) throws -> Data
-    /// Returns a file URL for the asset, materializing it on disk only when the
-    /// backend cannot expose the project file directly.
-    func stagedURL(atRelativePath relativePath: String, purpose: WPESceneAssetURLPurpose) throws -> WPEStagedAssetURL
+    /// A file URL for a consumer that needs one. A directory backend returns the
+    /// project file itself; a package backend stages the entry into the
+    /// provider's session-lifetime temp dir (cleaned on deinit — no per-URL
+    /// release).
+    func stagedURL(atRelativePath relativePath: String) throws -> URL
     /// True when the asset exists and is a readable regular file/entry.
     func exists(atRelativePath relativePath: String) -> Bool
     /// All relative asset paths the provider can serve (sorted). Diagnostic /
@@ -84,8 +55,8 @@ final class WPESecurityScopedSceneAssetProvider: WPESceneAssetProvider, @uncheck
         try wrapped.data(atRelativePath: relativePath)
     }
 
-    func stagedURL(atRelativePath relativePath: String, purpose: WPESceneAssetURLPurpose) throws -> WPEStagedAssetURL {
-        try wrapped.stagedURL(atRelativePath: relativePath, purpose: purpose)
+    func stagedURL(atRelativePath relativePath: String) throws -> URL {
+        try wrapped.stagedURL(atRelativePath: relativePath)
     }
 
     func exists(atRelativePath relativePath: String) -> Bool {

--- a/LiveWallpaper/Infrastructure/WPESceneReachability.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneReachability.swift
@@ -37,8 +37,13 @@ enum WPESceneReachability {
         return ids.filter { !$0.isEmpty }
     }
 
-    /// Subset whose live descriptor reads in place from a packed `scene.pkg`.
-    /// Their source archive is a runtime dependency and must never be reclaimed.
+    /// Ids whose live **descriptor** (applied config or saved bookmark) reads in
+    /// place from a packed `scene.pkg` — their source archive is a runtime
+    /// dependency and must never be reclaimed. Recent-history-only items are not
+    /// covered here (history stores `WPEOrigin`, not the descriptor's storage);
+    /// those rely on import-time `purgeStaleCache` removing the legacy cache so
+    /// the id never reaches the reclaimer's completed-cache set. A residual
+    /// failed-purge edge is tracked as a follow-up (persist storage in history).
     static func packageBackedWorkshopIDs() -> Set<String> {
         var ids: Set<String> = []
         func add(_ descriptor: SceneDescriptor?) {

--- a/LiveWallpaper/Infrastructure/WPESceneReachability.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneReachability.swift
@@ -1,0 +1,57 @@
+#if !LITE_BUILD
+import Foundation
+import LiveWallpaperCore
+
+/// Single source of truth for "which WPE scenes can the user still reach". Used
+/// by launch cache GC and the cache-settings purge/reclaim UI so neither path
+/// reclaims a scene that's applied, bookmarked, or in recent history.
+@MainActor
+enum WPESceneReachability {
+    /// Workshop ids referenced by any applied screen config, saved bookmark, or
+    /// recent import — plus all of their declared dependencies.
+    static func referencedWorkshopIDs() -> Set<String> {
+        var ids: Set<String> = []
+
+        func add(_ origin: WPEOrigin?) {
+            guard let origin else { return }
+            ids.insert(origin.workshopID)
+            ids.formUnion(origin.dependencyWorkshopIDs)
+        }
+        func add(_ descriptor: SceneDescriptor?) {
+            guard let descriptor else { return }
+            ids.insert(descriptor.workshopID)
+            ids.formUnion(descriptor.dependencyWorkshopIDs)
+        }
+
+        for config in SettingsManager.shared.loadConfigurations() {
+            add(config.activeWallpaper.sceneDescriptor)
+            add(config.wpeOrigin)
+        }
+        for entry in SettingsManager.shared.loadGlobalSettings().recentWPEImports {
+            add(entry.origin)
+        }
+        for bookmark in BookmarkStore.shared.bookmarks {
+            add(bookmark.wpeOrigin)
+            add(bookmark.content.sceneDescriptor)
+        }
+        return ids.filter { !$0.isEmpty }
+    }
+
+    /// Subset whose live descriptor reads in place from a packed `scene.pkg`.
+    /// Their source archive is a runtime dependency and must never be reclaimed.
+    static func packageBackedWorkshopIDs() -> Set<String> {
+        var ids: Set<String> = []
+        func add(_ descriptor: SceneDescriptor?) {
+            guard let descriptor, case .packageSource = descriptor.assetStorage else { return }
+            ids.insert(descriptor.workshopID)
+        }
+        for config in SettingsManager.shared.loadConfigurations() {
+            add(config.activeWallpaper.sceneDescriptor)
+        }
+        for bookmark in BookmarkStore.shared.bookmarks {
+            add(bookmark.content.sceneDescriptor)
+        }
+        return ids
+    }
+}
+#endif

--- a/LiveWallpaper/Infrastructure/WallpaperEngineCache.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineCache.swift
@@ -286,6 +286,52 @@ actor WallpaperEngineCache {
         return freed
     }
 
+    /// Launch-time orphan GC: hard-deletes every per-workshop cache directory
+    /// whose id is **not** in `keepIDs`. The keep-set is the union of every
+    /// workshop the user can still reach — applied screen configs, saved
+    /// bookmarks, recent imports, and all of their declared dependencies — so
+    /// only a genuinely abandoned scene (no config, no bookmark, off the recent
+    /// list) is reclaimed. Mirrors `WPEVideoTextureDiskCache`'s orphan sweep;
+    /// returns freed bytes.
+    ///
+    /// Unlike the video cache (whose source bytes always live inside each
+    /// scene's `.tex`), a legacy extracted scene whose source archive was
+    /// already reclaimed has no other copy — but if it is unreferenced it is
+    /// also unreachable from the UI, so dropping it loses nothing the user can
+    /// act on. Referenced ids are never touched, preserving every in-use unique
+    /// copy.
+    @discardableResult
+    func collectOrphans(keepIDs: Set<String>) -> UInt64 {
+        guard fileManager.fileExists(atPath: rootURL.path),
+              let children = try? fileManager.contentsOfDirectory(
+                at: rootURL,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+              ) else {
+            return 0
+        }
+
+        var freed: UInt64 = 0
+        for child in children {
+            let id = child.lastPathComponent
+            guard WPEPathSafety.isSafeWorkshopID(id) else { continue }
+            guard (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
+            if keepIDs.contains(id) { continue }
+
+            let bytes = directoryByteCount(at: child)
+            do {
+                try fileManager.removeItem(at: child)
+                freed += bytes
+            } catch {
+                Logger.warning("WPE cache orphan GC: failed to remove \(id): \(error.localizedDescription)", category: .screenManager)
+            }
+        }
+        if freed > 0 {
+            Logger.info("WPE cache orphan GC reclaimed \(freed) bytes from unreferenced scenes", category: .screenManager)
+        }
+        return freed
+    }
+
     private func directoryByteCount(at url: URL) -> UInt64 {
         guard let enumerator = fileManager.enumerator(
             at: url,

--- a/LiveWallpaper/Infrastructure/WallpaperEngineCache.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineCache.swift
@@ -293,33 +293,57 @@ actor WallpaperEngineCache {
 
     /// `.inflight`/`.replaced` are transient extraction sidecars
     /// (`WallpaperEnginePackage.extractAll`); they pass `isSafeWorkshopID` but
-    /// are not finished per-workshop caches, so every enumeration skips them —
-    /// reporting or reclaiming one could corrupt an in-flight extraction.
+    /// are not finished per-workshop caches, so normal enumeration skips them —
+    /// reporting or reclaiming one could corrupt an in-flight extraction. The
+    /// launch GC additionally sweeps *stale* (crash-leftover) sidecars by age.
     private func isExtractionSidecar(_ name: String) -> Bool {
         name.hasSuffix(".inflight") || name.hasSuffix(".replaced")
     }
 
+    /// Any sidecar older than this is a crash leftover, never an active
+    /// extraction (a streamed extract finishes in seconds-to-minutes), so it is
+    /// safe for the launch GC to reclaim.
+    private static let staleSidecarMaxAge: TimeInterval = 3600
+
     /// Launch-time orphan GC: hard-deletes every per-workshop cache directory
     /// whose id is **not** in `keepIDs` (the reachable set: applied configs,
-    /// bookmarks, recent imports, and their dependencies). Mirrors the video
-    /// cache's orphan sweep; returns freed bytes. An unreferenced scene is also
-    /// unreachable from the UI, so dropping it loses nothing actionable;
-    /// referenced ids are never touched.
+    /// bookmarks, recent imports, and their dependencies). Also reclaims stale
+    /// extraction sidecars (crash leftovers older than `staleSidecarMaxAge`)
+    /// while sparing young ones that may be live. Returns freed bytes. An
+    /// unreferenced scene is also unreachable from the UI, so dropping it loses
+    /// nothing actionable; referenced ids are never touched.
     @discardableResult
     func collectOrphans(keepIDs: Set<String>) -> UInt64 {
         guard fileManager.fileExists(atPath: rootURL.path),
               let children = try? fileManager.contentsOfDirectory(
                 at: rootURL,
-                includingPropertiesForKeys: [.isDirectoryKey],
+                includingPropertiesForKeys: [.isDirectoryKey, .contentModificationDateKey],
                 options: [.skipsHiddenFiles]
               ) else {
             return 0
         }
 
+        let sidecarCutoff = Date().addingTimeInterval(-Self.staleSidecarMaxAge)
         var freed: UInt64 = 0
         for child in children {
             let id = child.lastPathComponent
-            guard WPEPathSafety.isSafeWorkshopID(id), !isExtractionSidecar(id) else { continue }
+
+            if isExtractionSidecar(id) {
+                // Reclaim only sidecars old enough to be a guaranteed leftover;
+                // a young one may belong to an extraction in progress right now.
+                guard let mtime = (try? child.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate,
+                      mtime < sidecarCutoff else { continue }
+                let bytes = directoryByteCount(at: child)
+                do {
+                    try fileManager.removeItem(at: child)
+                    freed += bytes
+                } catch {
+                    Logger.warning("WPE cache orphan GC: failed to remove stale sidecar \(id): \(error.localizedDescription)", category: .screenManager)
+                }
+                continue
+            }
+
+            guard WPEPathSafety.isSafeWorkshopID(id) else { continue }
             guard (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
             if keepIDs.contains(id) { continue }
 
@@ -332,7 +356,7 @@ actor WallpaperEngineCache {
             }
         }
         if freed > 0 {
-            Logger.info("WPE cache orphan GC reclaimed \(freed) bytes from unreferenced scenes", category: .screenManager)
+            Logger.info("WPE cache orphan GC reclaimed \(freed) bytes from unreferenced scenes / stale sidecars", category: .screenManager)
         }
         return freed
     }

--- a/LiveWallpaper/Infrastructure/WallpaperEngineCache.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineCache.swift
@@ -179,7 +179,7 @@ actor WallpaperEngineCache {
         var ids: Set<String> = []
         for child in children {
             let id = child.lastPathComponent
-            guard WPEPathSafety.isSafeWorkshopID(id) else { continue }
+            guard WPEPathSafety.isSafeWorkshopID(id), !isExtractionSidecar(id) else { continue }
             guard (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
             if cacheHasPayload(child), !requireCompletedManifest || readManifest(in: child) != nil {
                 ids.insert(id)
@@ -227,7 +227,7 @@ actor WallpaperEngineCache {
 
         for child in children {
             let workshopID = child.lastPathComponent
-            guard WPEPathSafety.isSafeWorkshopID(workshopID) else { continue }
+            guard WPEPathSafety.isSafeWorkshopID(workshopID), !isExtractionSidecar(workshopID) else { continue }
             guard (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
 
             let bytes = directoryByteCount(at: child)
@@ -255,7 +255,7 @@ actor WallpaperEngineCache {
         var freed: UInt64 = 0
         for child in children {
             let workshopID = child.lastPathComponent
-            guard WPEPathSafety.isSafeWorkshopID(workshopID) else { continue }
+            guard WPEPathSafety.isSafeWorkshopID(workshopID), !isExtractionSidecar(workshopID) else { continue }
             let bytes = directoryByteCount(at: child)
             do {
                 try fileManager.removeItem(at: child)
@@ -268,12 +268,17 @@ actor WallpaperEngineCache {
         return freed
     }
 
-    /// Removes per-workshop directories whose `lastUsed` (manifest extractedAt or directory mtime) is older than `cutoff`.
+    /// Removes per-workshop directories whose `lastUsed` (manifest extractedAt or
+    /// directory mtime) is older than `cutoff`. `keepingIDs` are never removed —
+    /// the caller passes the reachable set (applied / bookmarked / recent) so a
+    /// scene the user still uses is never treated as "unused" just because its
+    /// extraction is old.
     @discardableResult
-    func purgeOlderThan(_ cutoff: Date) -> UInt64 {
+    func purgeOlderThan(_ cutoff: Date, keepingIDs: Set<String> = []) -> UInt64 {
         let snapshot = stats()
         var freed: UInt64 = 0
         for entry in snapshot.entries {
+            guard !keepingIDs.contains(entry.workshopID) else { continue }
             guard let lastUsed = entry.lastUsed, lastUsed < cutoff else { continue }
             do {
                 try purge(workshopID: entry.workshopID)
@@ -286,20 +291,20 @@ actor WallpaperEngineCache {
         return freed
     }
 
+    /// `.inflight`/`.replaced` are transient extraction sidecars
+    /// (`WallpaperEnginePackage.extractAll`); they pass `isSafeWorkshopID` but
+    /// are not finished per-workshop caches, so every enumeration skips them —
+    /// reporting or reclaiming one could corrupt an in-flight extraction.
+    private func isExtractionSidecar(_ name: String) -> Bool {
+        name.hasSuffix(".inflight") || name.hasSuffix(".replaced")
+    }
+
     /// Launch-time orphan GC: hard-deletes every per-workshop cache directory
-    /// whose id is **not** in `keepIDs`. The keep-set is the union of every
-    /// workshop the user can still reach — applied screen configs, saved
-    /// bookmarks, recent imports, and all of their declared dependencies — so
-    /// only a genuinely abandoned scene (no config, no bookmark, off the recent
-    /// list) is reclaimed. Mirrors `WPEVideoTextureDiskCache`'s orphan sweep;
-    /// returns freed bytes.
-    ///
-    /// Unlike the video cache (whose source bytes always live inside each
-    /// scene's `.tex`), a legacy extracted scene whose source archive was
-    /// already reclaimed has no other copy — but if it is unreferenced it is
-    /// also unreachable from the UI, so dropping it loses nothing the user can
-    /// act on. Referenced ids are never touched, preserving every in-use unique
-    /// copy.
+    /// whose id is **not** in `keepIDs` (the reachable set: applied configs,
+    /// bookmarks, recent imports, and their dependencies). Mirrors the video
+    /// cache's orphan sweep; returns freed bytes. An unreferenced scene is also
+    /// unreachable from the UI, so dropping it loses nothing actionable;
+    /// referenced ids are never touched.
     @discardableResult
     func collectOrphans(keepIDs: Set<String>) -> UInt64 {
         guard fileManager.fileExists(atPath: rootURL.path),
@@ -314,7 +319,7 @@ actor WallpaperEngineCache {
         var freed: UInt64 = 0
         for child in children {
             let id = child.lastPathComponent
-            guard WPEPathSafety.isSafeWorkshopID(id) else { continue }
+            guard WPEPathSafety.isSafeWorkshopID(id), !isExtractionSidecar(id) else { continue }
             guard (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
             if keepIDs.contains(id) { continue }
 

--- a/LiveWallpaper/Infrastructure/WallpaperEnginePackage.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEnginePackage.swift
@@ -13,6 +13,22 @@ struct WallpaperEnginePackage: Sendable, Equatable {
     let magic: String
     let entries: [Entry]
     let dataStart: UInt64
+    /// Lowercased entry-name → entry, built once at parse so case-insensitive
+    /// lookups are O(1) instead of an O(n) lowercased scan per read (matters for
+    /// large packages + multi-root fallback cascades). First match wins.
+    let nameIndex: [String: Entry]
+
+    init(magic: String, entries: [Entry], dataStart: UInt64) {
+        self.magic = magic
+        self.entries = entries
+        self.dataStart = dataStart
+        var index: [String: Entry] = [:]
+        index.reserveCapacity(entries.count)
+        for entry in entries where index[entry.name.lowercased()] == nil {
+            index[entry.name.lowercased()] = entry
+        }
+        self.nameIndex = index
+    }
 
     /// Max bytes for an entry name (a full relative path in UTF-8). The old cap
     /// of 255 wrongly rejected legitimate packages: a path with multi-byte CJK
@@ -316,10 +332,10 @@ struct WallpaperEnginePackage: Sendable, Equatable {
         return data
     }
 
-    /// Convenience: locate an entry by case-insensitive name match.
+    /// Convenience: locate an entry by case-insensitive name match (O(1) via the
+    /// prebuilt `nameIndex`).
     func entry(named name: String) -> Entry? {
-        let target = name.lowercased()
-        return entries.first { $0.name.lowercased() == target }
+        nameIndex[name.lowercased()]
     }
 
     /// Normalizes a requested relative path into the same canonical form used

--- a/LiveWallpaper/LiveWallpaperApp.swift
+++ b/LiveWallpaper/LiveWallpaperApp.swift
@@ -148,7 +148,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if !runtimeOptions.isTesting, manager.featureCatalog.isEnabled(.wpeImport) {
             Task { @MainActor in
                 try? await Task.sleep(for: .seconds(2))
-                let keepIDs = Self.referencedWPEWorkshopIDs()
+                let keepIDs = WPESceneReachability.referencedWorkshopIDs()
                 let cache = WallpaperEngineCache()
                 await cache.collectOrphans(keepIDs: keepIDs)
                 var referenced = keepIDs
@@ -222,45 +222,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NotificationCenter.default.removeObserver(observer)
         }
     }
-
-    #if !LITE_BUILD
-    /// Workshop IDs referenced by any saved screen configuration, saved
-    /// bookmark, or recent import — every scene the user still has set up,
-    /// starred, or could re-apply. Used as the keep-set for both the extracted-
-    /// package cache and the video-texture cache GC, so nothing reachable is
-    /// ever reclaimed. `@MainActor` because it reads `BookmarkStore.shared`.
-    @MainActor
-    private static func referencedWPEWorkshopIDs() -> Set<String> {
-        var ids: Set<String> = []
-        for config in SettingsManager.shared.loadConfigurations() {
-            if let descriptor = config.activeWallpaper.sceneDescriptor {
-                ids.insert(descriptor.workshopID)
-                ids.formUnion(descriptor.dependencyWorkshopIDs)
-            }
-            if let origin = config.wpeOrigin {
-                ids.insert(origin.workshopID)
-                ids.formUnion(origin.dependencyWorkshopIDs)
-            }
-        }
-        for entry in SettingsManager.shared.loadGlobalSettings().recentWPEImports {
-            ids.insert(entry.origin.workshopID)
-            ids.formUnion(entry.origin.dependencyWorkshopIDs)
-        }
-        // Saved bookmarks (favorites): never reclaim a scene the user starred,
-        // even when it isn't currently applied to any screen.
-        for bookmark in BookmarkStore.shared.bookmarks {
-            if let origin = bookmark.wpeOrigin {
-                ids.insert(origin.workshopID)
-                ids.formUnion(origin.dependencyWorkshopIDs)
-            }
-            if let descriptor = bookmark.content.sceneDescriptor {
-                ids.insert(descriptor.workshopID)
-                ids.formUnion(descriptor.dependencyWorkshopIDs)
-            }
-        }
-        return ids.filter { !$0.isEmpty }
-    }
-    #endif
 
     // MARK: - Dock Visibility
 

--- a/LiveWallpaper/LiveWallpaperApp.swift
+++ b/LiveWallpaper/LiveWallpaperApp.swift
@@ -140,13 +140,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         #if !LITE_BUILD
-        // Reclaim video-texture cache files for scenes that are no longer
-        // installed. Deferred so it never contends with first-frame work.
+        // Reclaim disk for scenes the user can no longer reach. Deferred so it
+        // never contends with first-frame work. First drop legacy extracted
+        // `wpe-cache` directories for unreferenced ids, then reclaim video-
+        // texture buckets against the *post-GC* cache contents (so a just-
+        // removed orphan's videos go too).
         if !runtimeOptions.isTesting, manager.featureCatalog.isEnabled(.wpeImport) {
             Task { @MainActor in
                 try? await Task.sleep(for: .seconds(2))
-                var referenced = Self.referencedWPEWorkshopIDs()
-                referenced.formUnion(await WallpaperEngineCache().listAvailableWorkshopIDs())
+                let keepIDs = Self.referencedWPEWorkshopIDs()
+                let cache = WallpaperEngineCache()
+                await cache.collectOrphans(keepIDs: keepIDs)
+                var referenced = keepIDs
+                referenced.formUnion(await cache.listAvailableWorkshopIDs())
                 await WPEVideoTextureDiskCache.shared.collectOrphans(referencedWorkshopIDs: referenced)
             }
         }
@@ -218,10 +224,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     #if !LITE_BUILD
-    /// Workshop IDs referenced by any saved screen configuration or recent
-    /// import — every scene the user still has set up or could re-apply.
-    /// Unioned with the extracted-package cache to form the keep-set for
-    /// video-texture cache GC.
+    /// Workshop IDs referenced by any saved screen configuration, saved
+    /// bookmark, or recent import — every scene the user still has set up,
+    /// starred, or could re-apply. Used as the keep-set for both the extracted-
+    /// package cache and the video-texture cache GC, so nothing reachable is
+    /// ever reclaimed. `@MainActor` because it reads `BookmarkStore.shared`.
+    @MainActor
     private static func referencedWPEWorkshopIDs() -> Set<String> {
         var ids: Set<String> = []
         for config in SettingsManager.shared.loadConfigurations() {
@@ -237,6 +245,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         for entry in SettingsManager.shared.loadGlobalSettings().recentWPEImports {
             ids.insert(entry.origin.workshopID)
             ids.formUnion(entry.origin.dependencyWorkshopIDs)
+        }
+        // Saved bookmarks (favorites): never reclaim a scene the user starred,
+        // even when it isn't currently applied to any screen.
+        for bookmark in BookmarkStore.shared.bookmarks {
+            if let origin = bookmark.wpeOrigin {
+                ids.insert(origin.workshopID)
+                ids.formUnion(origin.dependencyWorkshopIDs)
+            }
+            if let descriptor = bookmark.content.sceneDescriptor {
+                ids.insert(descriptor.workshopID)
+                ids.formUnion(descriptor.dependencyWorkshopIDs)
+            }
         }
         return ids.filter { !$0.isEmpty }
     }

--- a/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
+++ b/LiveWallpaper/Runtime/AmbientWallpaperSessionBuilder.swift
@@ -147,7 +147,11 @@ final class AmbientWallpaperSessionBuilder {
             Logger.warning("Scene source unavailable for in-place read: \(descriptor.workshopID)", category: .screenManager)
             return nil
         }
-        if descriptor.assetStorage == .cache {
+        // A legacy `.cache` scene needs its extracted directory only when we
+        // actually fell back to it (`provider == nil`). When the cache was
+        // purged but the import source was still resolvable, `sceneAssets`
+        // returns an in-place provider instead, so the missing directory is fine.
+        if descriptor.assetStorage == .cache, assets.provider == nil {
             guard fileManager.fileExists(atPath: cacheURL.path) else {
                 Logger.warning("Scene descriptor cache directory missing: \(cacheURL.path)", category: .screenManager)
                 return nil
@@ -215,6 +219,19 @@ final class AmbientWallpaperSessionBuilder {
     ) -> (provider: (any WPESceneAssetProvider)?, projectRoot: URL)? {
         switch descriptor.assetStorage {
         case .cache:
+            // The known-good extracted copy wins whenever it is present — it was
+            // validated against a fingerprint at import and can't have drifted.
+            // Only when it is gone (purged / reclaimed) do we read in place from
+            // the still-resolvable import source, so clearing the cache no longer
+            // kills a legacy scene. The stale cache descriptor is left as-is;
+            // launch orphan GC / manual cleanup reclaim the directory later.
+            if fileManager.fileExists(atPath: cacheURL.path) {
+                return (nil, cacheURL)
+            }
+            if let upgraded = cacheFallbackSourceProvider(origin: origin, fileManager: fileManager) {
+                Logger.info("WPE scene cache absent; reading in place from source for \(descriptor.workshopID)", category: .screenManager)
+                return upgraded
+            }
             return (nil, cacheURL)
         case .sourceDirectory:
             guard let source = resolveSourceFolder(origin: origin) else { return nil }
@@ -250,6 +267,33 @@ final class AmbientWallpaperSessionBuilder {
             return nil
         }
         return (resolved.url, resolved.url.startAccessingSecurityScopedResource())
+    }
+
+    /// Lazy migration backstop for a legacy `.cache` descriptor whose extracted
+    /// directory is gone: builds an in-place provider from the still-resolvable
+    /// import source — `.packageSource` when a `scene.pkg` sits at the source
+    /// root, otherwise a directory provider. Returns `nil` when the source can't
+    /// be opened, leaving the caller to report the missing cache. The returned
+    /// provider owns the source's security scope for its lifetime.
+    private func cacheFallbackSourceProvider(
+        origin: WPEOrigin?,
+        fileManager: FileManager
+    ) -> (provider: (any WPESceneAssetProvider)?, projectRoot: URL)? {
+        guard let source = resolveSourceFolder(origin: origin) else { return nil }
+        let packageURL = source.url.appendingPathComponent("scene.pkg", isDirectory: false)
+        if fileManager.fileExists(atPath: packageURL.path),
+           let pkg = try? WPEPackageSceneAssetProvider(packageURL: packageURL) {
+            let provider = WPESecurityScopedSceneAssetProvider(
+                wrapped: pkg, scopedURL: source.url, didStartAccessing: source.didStart
+            )
+            return (provider, source.url)
+        }
+        let provider = WPESecurityScopedSceneAssetProvider(
+            wrapped: WPEDirectorySceneAssetProvider(rootURL: source.url),
+            scopedURL: source.url,
+            didStartAccessing: source.didStart
+        )
+        return (provider, source.url)
     }
     #endif
 

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -1762,10 +1762,27 @@ final class ScreenManager {
                 return descriptor.propertyOverrides
             }
             let cacheRoot = supportRoot.appendingPathComponent(descriptor.cacheRelativePath, isDirectory: true)
-            return WallpaperEngineProjectPropertySchema.effectiveSceneValues(
-                descriptor: descriptor,
-                cacheRootURL: cacheRoot
-            )
+            if FileManager.default.fileExists(atPath: cacheRoot.path) {
+                return WallpaperEngineProjectPropertySchema.effectiveSceneValues(
+                    descriptor: descriptor,
+                    cacheRootURL: cacheRoot
+                )
+            }
+            // Cache purged but the import source may still be resolvable — read
+            // `project.json` in place so property diffing matches the render
+            // path's lazy fallback. Falls back to bare overrides otherwise.
+            guard let origin,
+                  case .success(let resolved) = SecurityScopedBookmarkResolver.shared.resolve(
+                    origin.sourceFolderBookmark, target: .transient
+                  ) else {
+                return descriptor.propertyOverrides
+            }
+            return SecurityScopedBookmarkResolver.withScopedAccess(resolved.url) { _ in
+                WallpaperEngineProjectPropertySchema.effectiveSceneValues(
+                    descriptor: descriptor,
+                    cacheRootURL: resolved.url
+                )
+            }
         case .sourceDirectory, .packageSource:
             guard let origin,
                   case .success(let resolved) = SecurityScopedBookmarkResolver.shared.resolve(

--- a/LiveWallpaper/Views/WPECacheManagementView.swift
+++ b/LiveWallpaper/Views/WPECacheManagementView.swift
@@ -20,6 +20,11 @@ struct WPECacheManagementView: View {
     /// already unpacked into the cache — reclaimable without losing wallpapers.
     @State private var reclaimableArchiveBytes: Int64 = 0
     @State private var lastReclaimedBytes: UInt64?
+    /// Reachable scene ids (applied / bookmarked / recent / deps), refreshed
+    /// alongside stats. Drives the keep-set for "Clear Unused" so its button
+    /// state, confirmation count, and action all agree — and so it's computed
+    /// once per refresh rather than per render.
+    @State private var reachableIDs: Set<String> = []
 
     private let cache: WallpaperEngineCache
 
@@ -81,7 +86,7 @@ struct WPECacheManagementView: View {
                         }
                         .destructiveControlTint()
                         .controlSize(.regular)
-                        .disabled(stats.entries.allSatisfy { ($0.lastUsed ?? .distantPast) > Date().addingTimeInterval(-30 * 86_400) })
+                        .disabled(unusedCandidates(olderThanDays: 30).isEmpty)
 
                         Spacer()
                     }
@@ -294,6 +299,7 @@ struct WPECacheManagementView: View {
         isLoading = true
         let snapshot = await cache.stats()
         stats = snapshot
+        reachableIDs = WPESceneReachability.referencedWorkshopIDs()
         isLoading = false
         #if DIRECT_DISTRIBUTION
         let cachedIDs = await cache.listCompletedWorkshopIDs()
@@ -349,21 +355,27 @@ struct WPECacheManagementView: View {
         }
     }
 
+    /// Entries old enough to count as "unused" that are also unreachable
+    /// (not applied / bookmarked / recent). Single definition shared by the
+    /// button's disabled state, the confirmation count, and the purge itself.
+    private func unusedCandidates(olderThanDays days: Int) -> [WPECacheStats.Entry] {
+        let cutoff = Date().addingTimeInterval(TimeInterval(-days * 86_400))
+        return (stats?.entries ?? []).filter {
+            !reachableIDs.contains($0.workshopID) && ($0.lastUsed ?? .distantPast) <= cutoff
+        }
+    }
+
     private func purgeOlderThan(days: Int) async {
         let cutoff = Date().addingTimeInterval(TimeInterval(-days * 86_400))
-        let freed = await cache.purgeOlderThan(cutoff, keepingIDs: WPESceneReachability.referencedWorkshopIDs())
+        let freed = await cache.purgeOlderThan(cutoff, keepingIDs: reachableIDs)
         lastFreedBytes = freed
         await refreshStats()
         NotificationCenter.default.post(name: .wpeHistoryDidChange, object: nil)
     }
 
-    /// Surface the unified Liquid Glass confirmation so users see exactly which entries (count + total size) are about to be removed before bulk purging. Reachable scenes (applied / bookmarked / recent) are excluded so "unused" means unused.
+    /// Surface the unified Liquid Glass confirmation so users see exactly which entries (count + total size) are about to be removed before bulk purging.
     private func confirmPurgeOlderThan(days: Int) {
-        let cutoff = Date().addingTimeInterval(TimeInterval(-days * 86_400))
-        let keepIDs = WPESceneReachability.referencedWorkshopIDs()
-        let candidates = (stats?.entries ?? []).filter {
-            !keepIDs.contains($0.workshopID) && ($0.lastUsed ?? .distantPast) <= cutoff
-        }
+        let candidates = unusedCandidates(olderThanDays: days)
         let totalBytes = candidates.reduce(UInt64(0)) { $0 + $1.sizeBytes }
         let size = byteFormatter.string(fromByteCount: Int64(totalBytes))
         pendingDestructive = PendingDestructive(

--- a/LiveWallpaper/Views/WPECacheManagementView.swift
+++ b/LiveWallpaper/Views/WPECacheManagementView.swift
@@ -33,7 +33,7 @@ struct WPECacheManagementView: View {
                 summaryRow
             } header: {
                 HStack {
-                    Text("Imported Project Cache")
+                    Text("Imported Project Cache (Legacy)")
                     Spacer()
                     if let stats {
                         Text(verbatim: "\(byteFormatter.string(fromByteCount: Int64(stats.totalBytes))) · \(stats.entries.count)")
@@ -74,7 +74,7 @@ struct WPECacheManagementView: View {
                         .destructiveControlTint()
                         .controlSize(.regular)
 
-                        Button {
+                        Button(role: .destructive) {
                             confirmPurgeOlderThan(days: 30)
                         } label: {
                             Label("Clear Unused > 30 days", systemImage: "calendar.badge.minus")
@@ -158,6 +158,7 @@ struct WPECacheManagementView: View {
                     Text(verbatim: "\(byteFormatter.string(fromByteCount: Int64(videoStats.totalBytes))) · \(videoStats.fileCount)")
                         .font(.caption2.monospacedDigit())
                         .foregroundStyle(.secondary)
+                        .accessibilityLabel(Text("Video cache totals \(byteFormatter.string(fromByteCount: Int64(videoStats.totalBytes))) across \(videoStats.fileCount) files"))
                 }
             }
         } footer: {
@@ -206,7 +207,7 @@ struct WPECacheManagementView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
-                    Text("Moves the source .pkg of items you've already imported to the Trash (recoverable). Your wallpapers keep working — they render from the cache.")
+                    Text("Moves the source .pkg of legacy imports (already unpacked into the cache) to the Trash (recoverable). Wallpapers that read in place from their source are left untouched.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -296,7 +297,7 @@ struct WPECacheManagementView: View {
         isLoading = false
         #if DIRECT_DISTRIBUTION
         let cachedIDs = await cache.listCompletedWorkshopIDs()
-            .subtracting(packageBackedWorkshopIDs())
+            .subtracting(WPESceneReachability.packageBackedWorkshopIDs())
         reclaimableArchiveBytes = await Task.detached {
             WPEDownloadArchiveReclaimer().reclaimableBytes(cachedIDs: cachedIDs)
         }.value
@@ -309,7 +310,7 @@ struct WPECacheManagementView: View {
     /// refreshes so the reclaimable figure drops to zero.
     private func reclaimArchives() async {
         let cachedIDs = await cache.listCompletedWorkshopIDs()
-            .subtracting(packageBackedWorkshopIDs())
+            .subtracting(WPESceneReachability.packageBackedWorkshopIDs())
         let result = await Task.detached {
             WPEDownloadArchiveReclaimer().reclaim(cachedIDs: cachedIDs)
         }.value
@@ -350,16 +351,19 @@ struct WPECacheManagementView: View {
 
     private func purgeOlderThan(days: Int) async {
         let cutoff = Date().addingTimeInterval(TimeInterval(-days * 86_400))
-        let freed = await cache.purgeOlderThan(cutoff)
+        let freed = await cache.purgeOlderThan(cutoff, keepingIDs: WPESceneReachability.referencedWorkshopIDs())
         lastFreedBytes = freed
         await refreshStats()
         NotificationCenter.default.post(name: .wpeHistoryDidChange, object: nil)
     }
 
-    /// Surface the unified Liquid Glass confirmation so users see exactly which entries (count + total size) are about to be removed before bulk purging.
+    /// Surface the unified Liquid Glass confirmation so users see exactly which entries (count + total size) are about to be removed before bulk purging. Reachable scenes (applied / bookmarked / recent) are excluded so "unused" means unused.
     private func confirmPurgeOlderThan(days: Int) {
         let cutoff = Date().addingTimeInterval(TimeInterval(-days * 86_400))
-        let candidates = (stats?.entries ?? []).filter { ($0.lastUsed ?? .distantPast) <= cutoff }
+        let keepIDs = WPESceneReachability.referencedWorkshopIDs()
+        let candidates = (stats?.entries ?? []).filter {
+            !keepIDs.contains($0.workshopID) && ($0.lastUsed ?? .distantPast) <= cutoff
+        }
         let totalBytes = candidates.reduce(UInt64(0)) { $0 + $1.sizeBytes }
         let size = byteFormatter.string(fromByteCount: Int64(totalBytes))
         pendingDestructive = PendingDestructive(
@@ -397,31 +401,6 @@ struct WPECacheManagementView: View {
         (stats?.totalBytes ?? 0) > 1_073_741_824
     }
 
-    #if DIRECT_DISTRIBUTION
-    /// Workshop ids whose live descriptor reads in place from a packed source
-    /// `scene.pkg`. For these the source archive is a *runtime dependency*, not
-    /// redundant post-extraction dead weight, so it must never be offered for
-    /// reclaim — trashing it would break the wallpaper. (Normally these never
-    /// appear in the extracted-cache set at all; this guards the edge where a
-    /// legacy extracted copy still lingers after the same id was re-imported
-    /// in place.)
-    private func packageBackedWorkshopIDs() -> Set<String> {
-        var ids: Set<String> = []
-        for config in SettingsManager.shared.loadConfigurations() {
-            if let descriptor = config.activeWallpaper.sceneDescriptor,
-               case .packageSource = descriptor.assetStorage {
-                ids.insert(descriptor.workshopID)
-            }
-        }
-        for bookmark in BookmarkStore.shared.bookmarks {
-            if let descriptor = bookmark.content.sceneDescriptor,
-               case .packageSource = descriptor.assetStorage {
-                ids.insert(descriptor.workshopID)
-            }
-        }
-        return ids
-    }
-    #endif
 
     private func displayTitle(for workshopID: String) -> String {
         let history = SettingsManager.shared.loadGlobalSettings().recentWPEImports
@@ -435,18 +414,24 @@ struct WPECacheManagementView: View {
         return "\(size) · used \(relative)"
     }
 
-    private var byteFormatter: ByteCountFormatter {
+    // Backed by shared instances — these formatters are otherwise rebuilt on
+    // every access (per cache row, per refresh), which is a measurable allocation
+    // cost in a list that updates often.
+    private var byteFormatter: ByteCountFormatter { Self.sharedByteFormatter }
+    private var relativeFormatter: RelativeDateTimeFormatter { Self.sharedRelativeFormatter }
+
+    private static let sharedByteFormatter: ByteCountFormatter = {
         let f = ByteCountFormatter()
         f.allowedUnits = [.useKB, .useMB, .useGB]
         f.countStyle = .file
         f.includesUnit = true
         return f
-    }
+    }()
 
-    private var relativeFormatter: RelativeDateTimeFormatter {
+    private static let sharedRelativeFormatter: RelativeDateTimeFormatter = {
         let f = RelativeDateTimeFormatter()
         f.unitsStyle = .full
         return f
-    }
+    }()
 }
 #endif

--- a/LiveWallpaper/Views/WPECacheManagementView.swift
+++ b/LiveWallpaper/Views/WPECacheManagementView.swift
@@ -47,6 +47,11 @@ struct WPECacheManagementView: View {
                     Text("Freed \(Int64(last), format: .byteCount(style: .file)).", comment: "WPE cache management footer shown after a purge. Placeholder is the freed byte total, rendered through SwiftUI's byteCount format style.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                } else {
+                    Text("New scenes read their assets in place from the source, so this cache only holds older imports. Unreferenced leftovers are reclaimed automatically at startup.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
 
@@ -291,6 +296,7 @@ struct WPECacheManagementView: View {
         isLoading = false
         #if DIRECT_DISTRIBUTION
         let cachedIDs = await cache.listCompletedWorkshopIDs()
+            .subtracting(packageBackedWorkshopIDs())
         reclaimableArchiveBytes = await Task.detached {
             WPEDownloadArchiveReclaimer().reclaimableBytes(cachedIDs: cachedIDs)
         }.value
@@ -303,6 +309,7 @@ struct WPECacheManagementView: View {
     /// refreshes so the reclaimable figure drops to zero.
     private func reclaimArchives() async {
         let cachedIDs = await cache.listCompletedWorkshopIDs()
+            .subtracting(packageBackedWorkshopIDs())
         let result = await Task.detached {
             WPEDownloadArchiveReclaimer().reclaim(cachedIDs: cachedIDs)
         }.value
@@ -389,6 +396,32 @@ struct WPECacheManagementView: View {
     private var isOversized: Bool {
         (stats?.totalBytes ?? 0) > 1_073_741_824
     }
+
+    #if DIRECT_DISTRIBUTION
+    /// Workshop ids whose live descriptor reads in place from a packed source
+    /// `scene.pkg`. For these the source archive is a *runtime dependency*, not
+    /// redundant post-extraction dead weight, so it must never be offered for
+    /// reclaim — trashing it would break the wallpaper. (Normally these never
+    /// appear in the extracted-cache set at all; this guards the edge where a
+    /// legacy extracted copy still lingers after the same id was re-imported
+    /// in place.)
+    private func packageBackedWorkshopIDs() -> Set<String> {
+        var ids: Set<String> = []
+        for config in SettingsManager.shared.loadConfigurations() {
+            if let descriptor = config.activeWallpaper.sceneDescriptor,
+               case .packageSource = descriptor.assetStorage {
+                ids.insert(descriptor.workshopID)
+            }
+        }
+        for bookmark in BookmarkStore.shared.bookmarks {
+            if let descriptor = bookmark.content.sceneDescriptor,
+               case .packageSource = descriptor.assetStorage {
+                ids.insert(descriptor.workshopID)
+            }
+        }
+        return ids
+    }
+    #endif
 
     private func displayTitle(for workshopID: String) -> String {
         let history = SettingsManager.shared.loadGlobalSettings().recentWPEImports

--- a/LiveWallpaperTests/WPEInPlaceAssetReadingTests.swift
+++ b/LiveWallpaperTests/WPEInPlaceAssetReadingTests.swift
@@ -128,6 +128,22 @@ struct WPEInPlaceAssetReadingTests {
         #expect(try Data(contentsOf: stagedURL) == payload)
     }
 
+    @Test("Package entry lookup is case-insensitive and first-match-wins on collision")
+    func packageEntryFirstMatchWins() throws {
+        let root = try makeTempDir()
+        let pkg = makePackageData([
+            (name: "Material.json", data: Data("first".utf8)),
+            (name: "material.json", data: Data("second".utf8)),
+        ])
+        let pkgURL = root.appendingPathComponent("scene.pkg")
+        try pkg.write(to: pkgURL)
+
+        let provider = try WPEPackageSceneAssetProvider(packageURL: pkgURL)
+        // The prebuilt lowercased index resolves any case to the first stored entry.
+        #expect(try provider.data(atRelativePath: "material.json") == Data("first".utf8))
+        #expect(try provider.data(atRelativePath: "MATERIAL.JSON") == Data("first".utf8))
+    }
+
     // MARK: - SceneDescriptor.assetStorage
 
     @Test("SceneDescriptor without assetStorage decodes as .cache")

--- a/LiveWallpaperTests/WPEInPlaceAssetReadingTests.swift
+++ b/LiveWallpaperTests/WPEInPlaceAssetReadingTests.swift
@@ -122,11 +122,10 @@ struct WPEInPlaceAssetReadingTests {
         try pkg.write(to: pkgURL)
 
         let provider = try WPEPackageSceneAssetProvider(packageURL: pkgURL)
-        let staged = try provider.stagedURL(atRelativePath: "audio/clip.mp3", purpose: .audioPlayback)
-        defer { staged.release() }
+        let stagedURL = try provider.stagedURL(atRelativePath: "audio/clip.mp3")
 
-        #expect(FileManager.default.fileExists(atPath: staged.url.path))
-        #expect(try Data(contentsOf: staged.url) == payload)
+        #expect(FileManager.default.fileExists(atPath: stagedURL.path))
+        #expect(try Data(contentsOf: stagedURL) == payload)
     }
 
     // MARK: - SceneDescriptor.assetStorage

--- a/LiveWallpaperTests/WallpaperEngineCacheTests.swift
+++ b/LiveWallpaperTests/WallpaperEngineCacheTests.swift
@@ -228,6 +228,43 @@ struct WallpaperEngineCacheTests {
         #expect(remaining == ["keep"])
     }
 
+    @Test("collectOrphans() reclaims stale extraction sidecars but spares young ones")
+    func collectOrphansSidecarAgeGate() async throws {
+        let env = try TempCacheEnvironment.make(workshopID: "sidecars")
+        defer { env.cleanup() }
+        let live = try await env.cache.ensureExtracted(workshopID: "live", sourcePkgURL: env.pkgURL)
+
+        let fm = FileManager.default
+        let staleSidecar = env.cacheRoot.appendingPathComponent("999.inflight", isDirectory: true)
+        let youngSidecar = env.cacheRoot.appendingPathComponent("888.replaced", isDirectory: true)
+        for sidecar in [staleSidecar, youngSidecar] {
+            try fm.createDirectory(at: sidecar, withIntermediateDirectories: true)
+            try Data([0x00, 0x01]).write(to: sidecar.appendingPathComponent("partial.bin"))
+        }
+        // Age the stale sidecar well past the GC threshold; leave the other fresh.
+        try fm.setAttributes([.modificationDate: Date().addingTimeInterval(-7200)], ofItemAtPath: staleSidecar.path)
+
+        _ = await env.cache.collectOrphans(keepIDs: ["live"])
+
+        #expect(!fm.fileExists(atPath: staleSidecar.path), "stale crash sidecar must be reclaimed")
+        #expect(fm.fileExists(atPath: youngSidecar.path), "young sidecar (possible live extraction) must be spared")
+        #expect(fm.fileExists(atPath: live.path), "referenced scene must be untouched")
+    }
+
+    @Test("purgeOlderThan() never removes ids in the keep-set")
+    func purgeOlderThanRespectsKeepSet() async throws {
+        let env = try TempCacheEnvironment.make(workshopID: "keepset")
+        defer { env.cleanup() }
+        _ = try await env.cache.ensureExtracted(workshopID: "keep", sourcePkgURL: env.pkgURL)
+        _ = try await env.cache.ensureExtracted(workshopID: "drop", sourcePkgURL: env.pkgURL)
+
+        // Future cutoff → both are "older than cutoff"; only the non-kept id goes.
+        let freed = await env.cache.purgeOlderThan(Date().addingTimeInterval(60), keepingIDs: ["keep"])
+
+        #expect(freed > 0)
+        #expect(await env.cache.stats().entries.map(\.workshopID) == ["keep"])
+    }
+
     @Test("collectOrphans() keeps everything when all ids are referenced and frees nothing")
     func collectOrphansNoOpWhenAllReferenced() async throws {
         let env = try TempCacheEnvironment.make(workshopID: "all-kept")

--- a/LiveWallpaperTests/WallpaperEngineCacheTests.swift
+++ b/LiveWallpaperTests/WallpaperEngineCacheTests.swift
@@ -209,6 +209,39 @@ struct WallpaperEngineCacheTests {
         #expect(afterStats.totalBytes == 0)
     }
 
+    @Test("collectOrphans() drops unreferenced workshops and keeps referenced ones")
+    func collectOrphansDropsUnreferenced() async throws {
+        let env = try TempCacheEnvironment.make(workshopID: "orphans")
+        defer { env.cleanup() }
+
+        let keepURL = try await env.cache.ensureExtracted(workshopID: "keep", sourcePkgURL: env.pkgURL)
+        let dropURL = try await env.cache.ensureExtracted(workshopID: "drop", sourcePkgURL: env.pkgURL)
+        #expect(FileManager.default.fileExists(atPath: keepURL.path))
+        #expect(FileManager.default.fileExists(atPath: dropURL.path))
+
+        let freed = await env.cache.collectOrphans(keepIDs: ["keep"])
+
+        #expect(freed > 0)
+        #expect(FileManager.default.fileExists(atPath: keepURL.path), "referenced scene must survive")
+        #expect(!FileManager.default.fileExists(atPath: dropURL.path), "unreferenced scene must be reclaimed")
+        let remaining = await env.cache.stats().entries.map(\.workshopID)
+        #expect(remaining == ["keep"])
+    }
+
+    @Test("collectOrphans() keeps everything when all ids are referenced and frees nothing")
+    func collectOrphansNoOpWhenAllReferenced() async throws {
+        let env = try TempCacheEnvironment.make(workshopID: "all-kept")
+        defer { env.cleanup() }
+
+        _ = try await env.cache.ensureExtracted(workshopID: "one", sourcePkgURL: env.pkgURL)
+        _ = try await env.cache.ensureExtracted(workshopID: "two", sourcePkgURL: env.pkgURL)
+
+        let freed = await env.cache.collectOrphans(keepIDs: ["one", "two"])
+
+        #expect(freed == 0)
+        #expect(await env.cache.stats().entries.count == 2)
+    }
+
     @Test("purgeOlderThan() only drops entries whose lastUsed predates the cutoff")
     func purgeOlderThanScopesByLastUsed() async throws {
         let env = try TempCacheEnvironment.make(workshopID: "older")

--- a/Packages/LiveWallpaperSharedUI/Sources/LiveWallpaperSharedUI/Components/DestructiveActionPolicy.swift
+++ b/Packages/LiveWallpaperSharedUI/Sources/LiveWallpaperSharedUI/Components/DestructiveActionPolicy.swift
@@ -116,9 +116,9 @@ public enum DestructiveAction: Identifiable, Equatable {
         case .resetAllSettings:
             return "All preferences, screen configurations, playlists, schedules, and bookmarks return to their defaults. This cannot be undone."
         case .clearAllWPECache(let count, let byteSize):
-            return "Removes \(count) extracted project\(count == 1 ? "" : "s") · \(byteSize). Source folders on disk are untouched; re-applying a wallpaper will re-extract on demand."
+            return "Removes \(count) legacy extracted project\(count == 1 ? "" : "s") · \(byteSize). Original source folders are untouched; wallpapers whose source is still available read in place from it instead."
         case .removeWPECacheEntry(let displayName):
-            return "'\(displayName)' will be re-extracted next time you apply it. The history entry and original source folder stay untouched."
+            return "'\(displayName)' will read its assets directly from the source folder next time you apply it (if still available). The history entry and original source folder stay untouched."
         case .applyConfigurationToAllDisplays(let count):
             return "This replaces the wallpaper on \(count) other display\(count == 1 ? "" : "s") with the same content and settings as this one."
         case .clearCurrentWallpaper(let displayName):


### PR DESCRIPTION
Launch-time orphan GC reclaims unreferenced legacy `wpe-cache` dirs (keep-set = applied ∪ bookmarked ∪ recent ∪ deps), the reclaimer never trashes a package-backed scene's source `.pkg`, and a purged `.cache` scene now reads in place from its still-resolvable source. Plus a multi-model-review cleanup: dropped speculative provider API (URLPurpose/staged-release), O(1) package TOC index, sidecar-safe GC, keep-set-aware "Clear Unused", refreshed stale "re-extract from cache" UI copy.

Note: this branch also carries an unrelated puppet attachment fix (`0c64e83`) committed here. Build + cache/provider suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)