### PR TITLE
fix(wpe-particle): honor animationmode=randomframe; drop ×2 sprite-rate hack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,7 @@ docs/
 
 .vm-bridge/
 cache/
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/LiveWallpaper/Runtime/WPEParticleSystem.swift
+++ b/LiveWallpaper/Runtime/WPEParticleSystem.swift
@@ -198,6 +198,10 @@ final class WPEParticleSystem {
         /// operator pumps a deterministic noise field every frame.
         var turbulenceSpeed: Float
         var turbulencePhase: Float
+        /// Sprite-sheet frame this particle locks onto when the system is
+        /// in `.randomFrame` mode (chosen once at spawn). Ignored by
+        /// `.sequence` particles, which animate off `age/lifetime`.
+        var staticFrame: Float
     }
 
     init?(
@@ -224,7 +228,8 @@ final class WPEParticleSystem {
             lifetime: 0,
             age: .greatestFiniteMagnitude,
             turbulenceSpeed: 0,
-            turbulencePhase: 0
+            turbulencePhase: 0,
+            staticFrame: 0
         ), count: cap)
         guard let buffer = device.makeBuffer(
             length: cap * MemoryLayout<WPEParticleInstance>.stride,
@@ -352,29 +357,26 @@ final class WPEParticleSystem {
     func tick(now: Double) {
         advance(now: now)
         let pointer = instanceBuffer.contents().bindMemory(to: WPEParticleInstance.self, capacity: capacity)
-        // Sprite-sheet animation is **lifetime-relative**: a particle
-        // sees `sequenceMultiplier` full atlas cycles over the course
-        // of its life, regardless of `duration`. Almamu's wall-clock
-        // reading (90 fps for leaves7) produces visible flicker even
-        // with cross-fade; the lifetime-relative reading gives the
-        // smooth ~10 fps "leaves slowly rotating as they fall" pace
-        // workshop authors clearly tuned for. `frameCount = 1`
-        // collapses to a static sprite.
-        let frameCount: Float
-        let cyclesPerLifetime: Float
-        if let sheet = spriteSheet, sheet.frameCount > 1 {
-            frameCount = Float(sheet.frameCount)
-            // `sequenceMultiplier × 2` empirically lands between Almamu's
-            // wall-clock rate (visibly fast/flickery at default settings)
-            // and a pure lifetime-relative single-multiplier reading
-            // (too slow on leaves2). For leaves7 (sequenceMultiplier 3,
-            // lifetime ~9s, 30 frames): 6 cycles ≈ 20 fps — the natural
-            // "leaves slowly rotating as they fall" pace.
-            cyclesPerLifetime = max(0.0001, Float(definition.sequenceMultiplier) * 2)
-        } else {
-            frameCount = 1
-            cyclesPerLifetime = 0
-        }
+        // Sprite-sheet frame selection splits on `animationmode`:
+        //
+        //   • `.sequence` — animate the atlas **lifetime-relative**: a
+        //     particle sees `sequenceMultiplier` full cycles over its
+        //     life (wildfire: multiplier 1, 32 frames over ~2.5s ≈ 13 fps).
+        //     We deliberately ignore the `.tex-json` wall-clock `duration`
+        //     (Almamu's ~90 fps reading on leaves7 flickers); the lifetime
+        //     reading matches the pace workshop authors tune for. There is
+        //     NO ×2 fudge — that was a single-scene hack that doubled every
+        //     `sequence` particle's speed (see WPE wildfire too-fast bug).
+        //
+        //   • `.randomFrame` — each particle froze on one atlas cell at
+        //     spawn (`spawn(into:)`), so it never animates; we emit that
+        //     fixed `staticFrame` (debris shards, embers — a *different
+        //     static* piece per particle, the WPE shatter look).
+        //
+        // `frameCount = 1` (no sheet) collapses to a static sprite either way.
+        let frameCount: Float = Float(max(1, spriteSheet?.frameCount ?? 1))
+        let animatesSequence = definition.animationMode == .sequence && frameCount > 1
+        let cyclesPerLifetime = max(0.0001, Float(definition.sequenceMultiplier))
         let visualScaleSigns = sceneTransform.visualScaleSigns()
         var written = 0
         for index in 0..<capacity {
@@ -384,11 +386,14 @@ final class WPEParticleSystem {
             let alpha = particle.alphaBase * envelope
             let lifetimeFraction = particle.lifetime > 0 ? min(1, max(0, particle.age / particle.lifetime)) : 0
             let frameIndex: Float
-            if cyclesPerLifetime > 0 {
+            if animatesSequence {
                 let raw = lifetimeFraction * cyclesPerLifetime * frameCount
                 frameIndex = raw.truncatingRemainder(dividingBy: frameCount)
             } else {
-                frameIndex = 0
+                // `.randomFrame` (or single-frame sprite): the spawn-time
+                // locked cell, floored so the shader's cross-fade picks it
+                // cleanly with blend 0.
+                frameIndex = particle.staticFrame
             }
             pointer[written] = WPEParticleInstance(
                 positionAndSize: SIMD4<Float>(
@@ -561,6 +566,16 @@ final class WPEParticleSystem {
         let angularVec = uniformVector(definition.angularVelocityMin, definition.angularVelocityMax)
         let turbulenceSpeed = Float(uniform(definition.turbulenceSpeedMin, definition.turbulenceSpeedMax))
         let turbulencePhase = Float(uniform(definition.turbulencePhaseMin, definition.turbulencePhaseMax))
+        // `.randomFrame`: lock onto one atlas cell for life so each shard
+        // is a different *static* piece of the sheet (WPE shatter look).
+        // `.sequence` / single-frame sprites leave this at 0 — `tick`
+        // computes their animated frame from age instead.
+        let staticFrame: Float
+        if definition.animationMode == .randomFrame, let sheet = spriteSheet, sheet.frameCount > 1 {
+            staticFrame = Float(Int.random(in: 0..<sheet.frameCount, using: &rng))
+        } else {
+            staticFrame = 0
+        }
         particles[slot] = Particle(
             position: position,
             velocity: velocity,
@@ -576,7 +591,8 @@ final class WPEParticleSystem {
             lifetime: max(0.0001, lifetime),
             age: 0,
             turbulenceSpeed: turbulenceSpeed,
-            turbulencePhase: turbulencePhase
+            turbulencePhase: turbulencePhase,
+            staticFrame: staticFrame
         )
     }
 

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPEParticleDefinition.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPEParticleDefinition.swift
@@ -19,6 +19,28 @@ public enum WPEParticleBlendMode: String, Sendable, CaseIterable, Equatable {
     }
 }
 
+/// How a particle walks its sprite-sheet atlas over its lifetime.
+///
+/// - `.sequence`: play the atlas frames in order, `sequencemultiplier`
+///   full cycles across the particle's life (the default WPE playback).
+/// - `.randomFrame`: each particle locks onto ONE random frame at spawn
+///   and never animates — WPE's `"animationmode": "randomframe"`, used by
+///   shatter/debris/ember presets so every shard is a *different static*
+///   piece of the atlas rather than the whole atlas flip-booking.
+///
+/// A particle JSON that omits `animationmode` defaults to `.sequence`.
+public enum WPEParticleAnimationMode: String, Sendable, Equatable, CaseIterable {
+    case sequence
+    case randomFrame
+
+    public init(wpeString raw: String?) {
+        switch raw?.lowercased() {
+        case "randomframe": self = .randomFrame
+        default: self = .sequence
+        }
+    }
+}
+
 /// A WPE particle "control point" — a named anchor an emitter or operator can
 /// reference. `id 0` is the emitter's spawn origin by convention. `flags & 1`
 /// means the point tracks the mouse pointer (WPE's "Lock to pointer"); the
@@ -110,6 +132,10 @@ public struct WPEParticleDefinition: Equatable, Sendable {
     /// runtime can pick a sub-frame index every tick. `1` is the
     /// WPE default; `0` freezes on frame 0.
     public let sequenceMultiplier: Double
+    /// `animationmode` from the particle JSON — whether the sprite sheet
+    /// animates over the lifetime (`.sequence`) or each particle freezes
+    /// on a random frame (`.randomFrame`).
+    public let animationMode: WPEParticleAnimationMode
     /// Parsed control points (mouse anchors). `id 0` is the emitter origin.
     public let controlPoints: [WPEParticleControlPoint]
     /// `controlpointattract` operators (cursor follow/avoid forces).
@@ -169,6 +195,7 @@ public struct WPEParticleDefinition: Equatable, Sendable {
         turbulencePhaseMin: Double = 0,
         turbulencePhaseMax: Double = 0,
         sequenceMultiplier: Double = 1,
+        animationMode: WPEParticleAnimationMode = .sequence,
         controlPoints: [WPEParticleControlPoint] = [],
         attractors: [WPEParticleControlPointAttractor] = []
     ) {
@@ -214,6 +241,7 @@ public struct WPEParticleDefinition: Equatable, Sendable {
         self.turbulencePhaseMin = min(turbulencePhaseMin, turbulencePhaseMax)
         self.turbulencePhaseMax = max(turbulencePhaseMin, turbulencePhaseMax)
         self.sequenceMultiplier = max(0, sequenceMultiplier)
+        self.animationMode = animationMode
         self.controlPoints = controlPoints
         self.attractors = attractors
     }
@@ -273,6 +301,7 @@ public struct WPEParticleDefinition: Equatable, Sendable {
             turbulencePhaseMin: turbulencePhaseMin,
             turbulencePhaseMax: turbulencePhaseMax,
             sequenceMultiplier: sequenceMultiplier,
+            animationMode: animationMode,
             controlPoints: controlPoints,
             attractors: attractors
         )
@@ -328,6 +357,7 @@ public enum WPEParticleDefinitionParser {
             ?? 0
         let startDelay = WPEValueParser.double(json["starttime"]) ?? 0
         let sequenceMultiplier = WPEValueParser.double(json["sequencemultiplier"]) ?? 1
+        let animationMode = WPEParticleAnimationMode(wpeString: json["animationmode"] as? String)
 
         var rate: Double = 0
         var origin: SIMD3<Double> = SIMD3(0, 0, 0)
@@ -541,6 +571,7 @@ public enum WPEParticleDefinitionParser {
             turbulencePhaseMin: turbulencePhaseMin,
             turbulencePhaseMax: turbulencePhaseMax,
             sequenceMultiplier: sequenceMultiplier,
+            animationMode: animationMode,
             controlPoints: controlPoints,
             attractors: attractors
         )

--- a/scripts/wpe-particle-diff.py
+++ b/scripts/wpe-particle-diff.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""WPE particle-fidelity gap auditor (control-variable debug tool).
+
+Goal: for every scene's particle systems, list each WPE field / emitter
+attribute / initializer / operator that our Swift parser
+(`WPEParticleDefinition.swift`) does NOT consume — i.e. the things WPE
+authored that we silently drop, which is exactly why a preset mis-renders
+on device (the leaf animates when it should freeze, the smoke is too thick,
+the fire plays too fast, …).
+
+This is the static half of the three-way diff that found the
+`animationmode` / `colorchange` gaps:
+
+    WPE source JSON   vs   our supported-key allowlist (below, kept in sync
+                           with WPEParticleDefinition.swift by hand)
+
+The dynamic half — comparing on-device output against the scene's own
+`preview.gif` — has to be done by eye; this tool eliminates "we never
+parsed that field" as a confounding variable first.
+
+Usage:
+    # one scene, tight iteration
+    python3 scripts/wpe-particle-diff.py --corpus-root <dir> --scene-id 3460973721
+
+    # whole corpus, ranked by how many particles hit each gap
+    python3 scripts/wpe-particle-diff.py --corpus-root <dir> --report /tmp/gaps.json
+
+`--corpus-root` is a directory of workshop-ID folders, each containing a
+`scene.pkg` (read in place — particle JSONs are tiny, we never extract the
+55 MB payload) or an already-unpacked `particles/` tree.
+
+The tool only reads files; it writes only the optional --report path.
+"""
+from __future__ import annotations
+import argparse
+import json
+import re
+import struct
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+# ---------- PKGV index reader (mirrors WallpaperEnginePackage.swift) ----------
+
+def _u32(buf: bytes, off: int) -> tuple[int, int]:
+    return struct.unpack_from("<I", buf, off)[0], off + 4
+
+
+def pkg_particle_entries(pkg: Path):
+    """Yield (name, bytes) for every `particles/*.json` entry in a scene.pkg,
+    reading only those entries' payloads (not the whole 55 MB package)."""
+    data = pkg.read_bytes()
+    off = 0
+    ml, off = _u32(data, off)
+    if not 4 <= ml <= 16:
+        return
+    magic = data[off:off + ml].decode("utf-8", "replace")
+    off += ml
+    if not magic.startswith("PKGV"):
+        return
+    n, off = _u32(data, off)
+    if n > 65_535:
+        return
+    entries = []
+    for _ in range(n):
+        nl, off = _u32(data, off)
+        name = data[off:off + nl].decode("utf-8", "replace")
+        off += nl
+        o, off = _u32(data, off)
+        s, off = _u32(data, off)
+        entries.append((name, o, s))
+    payload_start = off
+    for name, o, s in entries:
+        if re.fullmatch(r"particles/.*\.json", name):
+            yield name, data[payload_start + o:payload_start + o + s]
+
+
+# ---------- supported-key allowlists (sync with WPEParticleDefinition.swift) ----------
+# Anything WPE writes that is NOT in these sets is a gap we report.
+
+# Top-level particle JSON keys the parser reacts to. The "ignored-OK" ones
+# are structural/cosmetic and safe to drop; everything else is impactful.
+SUPPORTED_TOP_KEYS = {
+    "material", "children", "maxcount", "starttime", "sequencemultiplier",
+    "animationmode", "emitter", "initializer", "operator", "controlpoint",
+}
+IGNORED_TOP_OK = {"name", "id", "flags", "renderer"}
+
+# Emitter attributes the parser reads (rate / origin / distance / directions).
+SUPPORTED_EMITTER = {"rate", "origin", "distancemin", "distancemax", "directions"}
+IGNORED_EMITTER_OK = {"name", "id"}
+
+# Initializer `name`s the parser handles.
+SUPPORTED_INITIALIZERS = {
+    "lifetimerandom", "lifetime", "sizerandom", "size",
+    "velocityrandom", "velocity", "colorrandom", "color",
+    "alpharandom", "alpha", "rotationrandom", "angularvelocityrandom",
+    "turbulentvelocityrandom",
+}
+
+# Operator `name`s the parser handles.
+SUPPORTED_OPERATORS = {
+    "controlpointattract", "alphafade", "movement", "angularmovement",
+    "turbulence",
+}
+
+# Sub-parameters we read incompletely even though the parent IS supported —
+# surfaced as "partial" so they're visible without being scored as hard gaps.
+PARTIAL_NOTES = {
+    "emitter.directions": "read as an abs() per-axis mask, not a biased emission cone",
+    "initializer.exponent": "distribution exponent ignored (uniform sampling only)",
+}
+
+
+def audit_particle(name: str, doc: dict) -> dict:
+    gaps = {
+        "file": name,
+        "animationmode": doc.get("animationmode", "(default: sequence)"),
+        "unsupported_top_keys": [],
+        "unsupported_emitter_fields": [],
+        "unsupported_initializers": [],
+        "unsupported_operators": [],
+        "partial": [],
+    }
+
+    for k in doc:
+        if k not in SUPPORTED_TOP_KEYS and k not in IGNORED_TOP_OK:
+            gaps["unsupported_top_keys"].append(k)
+
+    emitters = doc.get("emitter") or []
+    if isinstance(emitters, list):
+        for em in emitters:
+            if not isinstance(em, dict):
+                continue
+            for k in em:
+                if k not in SUPPORTED_EMITTER and k not in IGNORED_EMITTER_OK:
+                    gaps["unsupported_emitter_fields"].append(k)
+            if "directions" in em:
+                gaps["partial"].append("emitter.directions")
+
+    for ini in doc.get("initializer") or []:
+        if isinstance(ini, dict):
+            nm = (ini.get("name") or "").lower()
+            if nm and nm not in SUPPORTED_INITIALIZERS:
+                gaps["unsupported_initializers"].append(nm)
+            if "exponent" in ini:
+                gaps["partial"].append("initializer.exponent")
+
+    for op in doc.get("operator") or []:
+        if isinstance(op, dict):
+            nm = (op.get("name") or "").lower()
+            if nm and nm not in SUPPORTED_OPERATORS:
+                gaps["unsupported_operators"].append(nm)
+
+    # dedup, keep order-insensitive but stable
+    for key in ("unsupported_top_keys", "unsupported_emitter_fields",
+                "unsupported_initializers", "unsupported_operators", "partial"):
+        gaps[key] = sorted(set(gaps[key]))
+    return gaps
+
+
+def has_gaps(g: dict) -> bool:
+    return any(g[k] for k in (
+        "unsupported_top_keys", "unsupported_emitter_fields",
+        "unsupported_initializers", "unsupported_operators"))
+
+
+def iter_scene_particles(workshop_dir: Path):
+    """Yield (relpath, parsed_json) for each particle in a scene dir,
+    from scene.pkg in place or an already-unpacked particles/ tree."""
+    pkg = workshop_dir / "scene.pkg"
+    if pkg.is_file():
+        for name, raw in pkg_particle_entries(pkg):
+            try:
+                yield name, json.loads(raw)
+            except Exception:
+                continue
+        return
+    for jp in sorted((workshop_dir / "particles").rglob("*.json")) \
+            if (workshop_dir / "particles").is_dir() else []:
+        try:
+            yield str(jp.relative_to(workshop_dir)), json.loads(jp.read_text(errors="replace"))
+        except Exception:
+            continue
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--corpus-root", type=Path, required=True)
+    p.add_argument("--scene-id", default=None, help="limit to one workshop ID")
+    p.add_argument("--report", type=Path, default=None, help="write JSON report")
+    p.add_argument("--all", action="store_true",
+                   help="list every particle, even fully-supported ones")
+    args = p.parse_args()
+
+    targets = ([args.corpus_root / args.scene_id] if args.scene_id
+               else sorted(d for d in args.corpus_root.iterdir() if d.is_dir()))
+
+    feature_hits: Counter = Counter()          # "operator:colorchange" -> #particles
+    scenes_with_gaps: dict[str, list] = {}
+    scanned_scenes = 0
+    scanned_particles = 0
+
+    for wd in targets:
+        if not wd.is_dir():
+            continue
+        per_scene = []
+        for relpath, doc in iter_scene_particles(wd):
+            if not isinstance(doc, dict):
+                continue
+            scanned_particles += 1
+            g = audit_particle(relpath, doc)
+            if has_gaps(g) or args.all:
+                per_scene.append(g)
+            for k in g["unsupported_top_keys"]:
+                feature_hits[f"top:{k}"] += 1
+            for k in g["unsupported_emitter_fields"]:
+                feature_hits[f"emitter:{k}"] += 1
+            for k in g["unsupported_initializers"]:
+                feature_hits[f"initializer:{k}"] += 1
+            for k in g["unsupported_operators"]:
+                feature_hits[f"operator:{k}"] += 1
+        if per_scene:
+            scanned_scenes += 1
+            scenes_with_gaps[wd.name] = per_scene
+
+    print(f"Scenes scanned: {len(targets)}   particles scanned: {scanned_particles}")
+    print(f"Scenes with at least one particle gap: {len(scenes_with_gaps)}\n")
+
+    print("--- most common unsupported features (particle count) ---")
+    if not feature_hits:
+        print("  (none — every particle's fields are fully consumed)")
+    for feat, cnt in feature_hits.most_common():
+        print(f"  {cnt:5d}  {feat}")
+
+    # Per-scene detail (capped for readability unless --report)
+    print("\n--- per-scene particle gaps ---")
+    for sid, particles in list(scenes_with_gaps.items())[:40]:
+        print(f"\n  {sid}:")
+        for g in particles:
+            bits = []
+            if g["unsupported_operators"]:
+                bits.append(f"op={g['unsupported_operators']}")
+            if g["unsupported_initializers"]:
+                bits.append(f"init={g['unsupported_initializers']}")
+            if g["unsupported_emitter_fields"]:
+                bits.append(f"emitter={g['unsupported_emitter_fields']}")
+            if g["unsupported_top_keys"]:
+                bits.append(f"top={g['unsupported_top_keys']}")
+            print(f"    - {g['file']}  [mode={g['animationmode']}]  " + "  ".join(bits))
+
+    if args.report:
+        args.report.write_text(json.dumps({
+            "feature_hits": dict(feature_hits),
+            "scenes": scenes_with_gaps,
+            "partial_notes": PARTIAL_NOTES,
+        }, indent=2, ensure_ascii=False))
+        print(f"\nFull report → {args.report}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes two particle render-fidelity bugs found by diffing real WPE scene data (probe scene 3460973721) against our parser/simulator.

**What changed**
- Parse `animationmode`. `randomframe` particles (debris/embers) now freeze on one random atlas cell per spawn instead of flip-booking the whole sprite sheet — that was the "static shards play as gif animation" bug.
- Drop the `sequenceMultiplier × 2` fudge in `WPEParticleSystem.tick()`; `sequence` particles (e.g. wildfire) now play at the authored rate instead of 2× too fast. No shader change — an integer frame index with blend 0 picks the cell cleanly.
- Add `scripts/wpe-particle-diff.py`: a corpus-wide auditor that lists every WPE particle field we don't yet consume, ranked by impact (the next gap to close is the `oscillatealpha`/`sizechange`/`colorchange` modulation operators behind over-dense "fog" effects).

**Testing**
- App + package build clean. Particle test suites: 21/22 pass. The one failure (`WPEParticleSystemTests.swift:301`, gravity Y-down model) is pre-existing — it fails identically on the clean tree and encodes the discredited Y-down convention the code comment warns against re-introducing. Untouched here.
- Needs on-device A/B vs the scene's own `preview.gif` to confirm the visual result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)