### PR TITLE
fix(wpe-metal): audio-reactive scene rendering corrections

### DIFF
--- a/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDocumentParser.swift
@@ -691,10 +691,12 @@ enum WPESceneDocumentParser {
             delay: parseDouble(dict["cameraparallaxdelay"]) ?? parallaxDefaults.delay,
             mouseInfluence: parseDouble(dict["cameraparallaxmouseinfluence"]) ?? parallaxDefaults.mouseInfluence
         )
+        let supportsAudioProcessing = parseBool(dict["supportsaudioprocessing"]) ?? false
         return WPESceneGeneral(
             clearColor: clearColor,
             orthogonalProjection: projection,
-            cameraParallax: cameraParallax
+            cameraParallax: cameraParallax,
+            supportsAudioProcessing: supportsAudioProcessing
         )
     }
 

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -17,17 +17,57 @@ enum WPEMetalSceneCaptureUtilityModels {
     /// (e.g. scene 3479521040's DoF layer was a `fullscreenlayer`). Tolerates a
     /// leading `../<dependencyID>/` resolver prefix.
     static func isSceneCaptureUtilityModelPath(_ path: String) -> Bool {
-        let normalized = path.replacingOccurrences(of: "\\", with: "/").lowercased()
-        let stripped: String
-        if normalized.hasPrefix("../") {
-            let parts = normalized.split(separator: "/", omittingEmptySubsequences: false)
-            stripped = parts.count >= 3 ? parts.dropFirst(2).joined(separator: "/") : normalized
-        } else {
-            stripped = normalized
-        }
+        let stripped = strippedUtilityPath(path)
         return stripped == "models/util/composelayer.json"
             || stripped == "models/util/projectlayer.json"
             || stripped == "models/util/fullscreenlayer.json"
+    }
+
+    /// Output geometry for a scene-capture utility (passthrough) layer's FINAL
+    /// scene composite. The capture / `previous` sampling always stays
+    /// full-frame 1:1 (the 98f79b5 lesson); only the output composite of a
+    /// plain `composelayer.json` that hosts a *spatial* effect authored into a
+    /// real sub-rect (e.g. an audio-bar visualizer box) is confined to that box.
+    enum OutputGeometry { case fullscreen, subregion }
+
+    /// `fullscreenlayer.json` (DoF/post-process) and `projectlayer.json`
+    /// (projection/autosize) always cover the frame. A `composelayer.json`
+    /// stays fullscreen too unless its authored footprint is a safe sub-scene
+    /// rectangle: axis-aligned, positive-scale, finite, and clearly smaller
+    /// than the scene. Rotated / mirrored / oversized / full-coverage compose
+    /// layers stay fullscreen — this preserves 98f79b5's decision for scene
+    /// 3479521040's 5000×2300 rotated passthrough layer.
+    static func outputGeometry(
+        path: String,
+        geometry: WPERenderLayerGeometry,
+        sceneSize: CGSize
+    ) -> OutputGeometry {
+        guard strippedUtilityPath(path) == "models/util/composelayer.json" else { return .fullscreen }
+        guard let size = geometry.size else { return .fullscreen }
+        let sceneW = max(Float(sceneSize.width), 1)
+        let sceneH = max(Float(sceneSize.height), 1)
+        let width = Float(size.width) * max(abs(Float(geometry.scale.x)), 0.0001)
+        let height = Float(size.height) * max(abs(Float(geometry.scale.y)), 0.0001)
+        guard width.isFinite, height.isFinite, width > 1, height > 1 else { return .fullscreen }
+        let rotationEpsilon = 0.001
+        if abs(geometry.angles.x) > rotationEpsilon
+            || abs(geometry.angles.y) > rotationEpsilon
+            || abs(geometry.angles.z) > rotationEpsilon {
+            return .fullscreen
+        }
+        if geometry.scale.x < 0 || geometry.scale.y < 0 { return .fullscreen }
+        let fullCoverage: Float = 0.95
+        if width >= sceneW * fullCoverage && height >= sceneH * fullCoverage { return .fullscreen }
+        return .subregion
+    }
+
+    private static func strippedUtilityPath(_ path: String) -> String {
+        let normalized = path.replacingOccurrences(of: "\\", with: "/").lowercased()
+        if normalized.hasPrefix("../") {
+            let parts = normalized.split(separator: "/", omittingEmptySubsequences: false)
+            return parts.count >= 3 ? parts.dropFirst(2).joined(separator: "/") : normalized
+        }
+        return normalized
     }
 }
 
@@ -65,6 +105,16 @@ final class WPEMetalRenderExecutor {
         #else
         return false
         #endif
+    }
+
+    /// Rollback gate for sub-region compose-layer output (the audio-visualizer
+    /// "box" fix). Default ON. `defaults write Taijia.LiveWallpaper
+    /// WPEMetalSubregionComposeOutput -bool NO` reverts every scene-capture
+    /// utility layer to the legacy unconditional-fullscreen output.
+    static var subregionComposeOutputEnabled: Bool {
+        UserDefaults.standard.object(forKey: "WPEMetalSubregionComposeOutput") == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: "WPEMetalSubregionComposeOutput")
     }
 
     /// Mirrors the slot-0 precedence used by
@@ -176,6 +226,12 @@ final class WPEMetalRenderExecutor {
     /// One-shot guard so the waterwaves dispatch logs its first live execution per renderer
     /// (confirms the builtin effect_waterwaves path actually runs + the debug flag value reaching it).
     private var loggedWaterWavesDispatch = false
+    /// Scene size (ortho-projection pixels) for the frame currently encoding.
+    /// Stashed at frame start so `usesObjectQuadGeometry` can judge a
+    /// scene-capture utility layer's footprint without threading `sceneSize`
+    /// through its dozen call sites. Safe because the render loop encodes one
+    /// frame at a time.
+    private var currentSceneSize: CGSize = .zero
 
     #if DEBUG
     /// Diagnostic: when `WPEDumpScenePasses` (UserDefault) equals the sceneID,
@@ -238,6 +294,7 @@ final class WPEMetalRenderExecutor {
             previousNamedTextures: reusableHistory?.namedTextures ?? [:]
         )
         frameState.cameraParallax = runtimeUniforms.cameraParallax
+        currentSceneSize = size
         var didEncode = false
         let bypassEffects = Self.bypassEffectsForDebug
         let attachmentContext = makeAttachmentFrameContext(
@@ -674,18 +731,7 @@ final class WPEMetalRenderExecutor {
                 matching: Self.translatedUniformNameCandidates(for: u)
             ) ?? u.defaultValue
             if let length = u.arrayLength {
-                let flat = Self.vectorValue(value, count: length * 4)
-                for i in 0..<length {
-                    let slotIndex = u.slot + i
-                    guard slotIndex < slots.count else { break }
-                    let base = i * 4
-                    slots[slotIndex] = SIMD4<Float>(
-                        flat.indices.contains(base) ? flat[base] : 0,
-                        flat.indices.contains(base + 1) ? flat[base + 1] : 0,
-                        flat.indices.contains(base + 2) ? flat[base + 2] : 0,
-                        flat.indices.contains(base + 3) ? flat[base + 3] : 0
-                    )
-                }
+                Self.packArrayUniform(value, glslType: u.glslType, length: length, slot: u.slot, into: &slots)
                 continue
             }
             switch u.glslType {
@@ -1876,10 +1922,19 @@ final class WPEMetalRenderExecutor {
             return layer.parallaxDepth != 0 && cameraParallax.smoothed != SIMD2<Float>(0, 0)
         }
         // WPE fullscreen/passthrough utility layers (compose/project/fullscreen)
-        // render fullscreen and copy the captured frame 1:1, never as a
-        // shrunken object quad.
+        // capture + copy the full frame 1:1. Their FINAL scene composite stays
+        // fullscreen too, EXCEPT a plain `composelayer.json` authored into a
+        // safe sub-rect (an audio-bar visualizer box), whose output is confined
+        // to that box via the object quad. Capture/effect passes target the
+        // layer composite (not `.scene`), so they were already excluded by the
+        // `guard case .scene` above and remain fullscreen.
         if WPEMetalSceneCaptureUtilityModels.isSceneCaptureUtilityModelPath(layer.imagePath) {
-            return false
+            guard Self.subregionComposeOutputEnabled else { return false }
+            return WPEMetalSceneCaptureUtilityModels.outputGeometry(
+                path: layer.imagePath,
+                geometry: layer.geometry,
+                sceneSize: currentSceneSize
+            ) == .subregion
         }
         return true
     }
@@ -1901,6 +1956,31 @@ final class WPEMetalRenderExecutor {
             let parallax = cameraParallax.pixelOffset(depth: layer.parallaxDepth, sceneSize: sceneSize)
             return WPEObjectQuadUniforms(
                 centerAndSize: SIMD4<Float>(parallax.x, parallax.y, sceneWidth, sceneHeight),
+                sceneSizeAndRotation: SIMD4<Float>(sceneWidth, sceneHeight, 0, 0),
+                uvSignAndPadding: SIMD4<Float>(1, 1, 0, 0)
+            )
+        }
+        // Scene-capture utility (passthrough) compose layers confined to a
+        // sub-rect use WPE's native object coordinates directly — origin is the
+        // box CENTER in scene-centered pixels (0,0 = scene center, +Y up), which
+        // is exactly what `wpe_object_quad_vertex` expects in `centerAndSize.xy`.
+        // The normal-object `originX - sceneWidth*0.5` anchor below assumes a
+        // different convention and would double-shift a center-origin utility
+        // layer off-screen (origin (-772,494) → NDC (-1.40,-0.54) instead of the
+        // correct (-0.40,+0.46)). Only reached for `.subregion` layers (see
+        // `usesObjectQuadGeometry` / `WPEMetalSceneCaptureUtilityModels`).
+        if WPEMetalSceneCaptureUtilityModels.isSceneCaptureUtilityModelPath(layer.imagePath) {
+            let utilWidth = max(Float(geometry.size?.width ?? CGFloat(sourceTexture.width))
+                * max(abs(Float(geometry.scale.x)), 0.0001), 0.0001)
+            let utilHeight = max(Float(geometry.size?.height ?? CGFloat(sourceTexture.height))
+                * max(abs(Float(geometry.scale.y)), 0.0001), 0.0001)
+            let originX = Float(geometry.origin.x)
+            let originY = Float(geometry.origin.y)
+            let centerX = (originX >= 0 && originX <= 1) ? originX * sceneWidth : originX
+            let centerY = (originY >= 0 && originY <= 1) ? originY * sceneHeight : originY
+            let parallax = cameraParallax.pixelOffset(depth: layer.parallaxDepth, sceneSize: sceneSize)
+            return WPEObjectQuadUniforms(
+                centerAndSize: SIMD4<Float>(centerX + parallax.x, centerY + parallax.y, utilWidth, utilHeight),
                 sceneSizeAndRotation: SIMD4<Float>(sceneWidth, sceneHeight, 0, 0),
                 uvSignAndPadding: SIMD4<Float>(1, 1, 0, 0)
             )
@@ -2458,39 +2538,7 @@ final class WPEMetalRenderExecutor {
                 destinationTexture: destinationTexture
             ) ?? Self.translatedUniformValue(for: u, in: pass)
             if let length = u.arrayLength {
-                let raw = Self.vectorValue(value, count: length)
-                for i in 0..<length {
-                    let v = raw.indices.contains(i) ? raw[i] : 0
-                    let slotIndex = u.slot + i
-                    guard slotIndex < slots.count else { break }
-                    switch u.glslType {
-                    case "vec2":
-                        let stride = 2
-                        slots[slotIndex] = SIMD4<Float>(
-                            raw.indices.contains(i * stride) ? raw[i * stride] : 0,
-                            raw.indices.contains(i * stride + 1) ? raw[i * stride + 1] : 0,
-                            0, 0
-                        )
-                    case "vec3":
-                        let stride = 3
-                        slots[slotIndex] = SIMD4<Float>(
-                            raw.indices.contains(i * stride) ? raw[i * stride] : 0,
-                            raw.indices.contains(i * stride + 1) ? raw[i * stride + 1] : 0,
-                            raw.indices.contains(i * stride + 2) ? raw[i * stride + 2] : 0,
-                            0
-                        )
-                    case "vec4":
-                        let stride = 4
-                        slots[slotIndex] = SIMD4<Float>(
-                            raw.indices.contains(i * stride) ? raw[i * stride] : 0,
-                            raw.indices.contains(i * stride + 1) ? raw[i * stride + 1] : 0,
-                            raw.indices.contains(i * stride + 2) ? raw[i * stride + 2] : 0,
-                            raw.indices.contains(i * stride + 3) ? raw[i * stride + 3] : 0
-                        )
-                    default:
-                        slots[slotIndex].x = v
-                    }
-                }
+                Self.packArrayUniform(value, glslType: u.glslType, length: length, slot: u.slot, into: &slots)
                 continue
             }
             switch u.glslType {
@@ -2605,6 +2653,43 @@ final class WPEMetalRenderExecutor {
         case .animated(let v): return Float(v.scalar(at: 0) ?? Double(fallback))
         case .string(let s): return Float(s) ?? fallback
         case nil:            return fallback
+        }
+    }
+
+    /// Packs a GLSL array uniform (`elemType name[length]`) into `length`
+    /// consecutive `float4` slots — one array element per slot, the element's
+    /// components in `.x`/`.xy`/`.xyz`/`.xyzw`. This mirrors the transpiler's
+    /// per-element read `u.vals[slot + i].<swizzle>` (see
+    /// `WPEShaderTranspiler.renderMSL`). Both pack overloads route here so the
+    /// scalar/vec packing can never drift apart again — the previous divergence
+    /// (`values:` overload packed every array as `vec4[N]`; the per-pass
+    /// overload under-read `vec2/3/4[N]` with `count: length`) silently
+    /// corrupted scalar `float[N]` uniforms such as `g_AudioSpectrum*[N]`.
+    private static func packArrayUniform(
+        _ value: WPESceneShaderConstantValue?,
+        glslType: String,
+        length: Int,
+        slot: Int,
+        into slots: inout [SIMD4<Float>]
+    ) {
+        let components: Int
+        switch glslType {
+        case "vec2": components = 2
+        case "vec3": components = 3
+        case "vec4": components = 4
+        default: components = 1 // float / int / bool — scalar element, read via `.x`
+        }
+        let flat = vectorValue(value, count: length * components)
+        for i in 0..<length {
+            let slotIndex = slot + i
+            guard slotIndex < slots.count else { break }
+            let base = i * components
+            slots[slotIndex] = SIMD4<Float>(
+                base < flat.count ? flat[base] : 0,
+                components > 1 && base + 1 < flat.count ? flat[base + 1] : 0,
+                components > 2 && base + 2 < flat.count ? flat[base + 2] : 0,
+                components > 3 && base + 3 < flat.count ? flat[base + 3] : 0
+            )
         }
     }
 

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -146,6 +146,12 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// when there are no dynamic textures or particles — otherwise the scene
     /// renders one frame and freezes. Computed once per load.
     private var hasAnimatedShaderPasses = false
+    /// WPE `general.supportsaudioprocessing`. An audio-reactive scene must stay
+    /// on the continuous-frame path so `g_AudioSpectrum*` re-samples every frame
+    /// — `pipelineHasAnimatedPasses` only catches audio shaders under
+    /// `effects/`/`workshop/`, so a custom-path audio shader would otherwise
+    /// freeze on the static/on-demand path.
+    private var sceneSupportsAudioProcessing = false
     private(set) var lastRuntimeUniforms: WPEMetalRuntimeUniforms?
     /// Property-key → render-target bindings for the loaded scene, used by the
     /// incremental settings-apply path. Empty until `load()` completes.
@@ -453,6 +459,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             sceneCamera: document.camera
         )
         cameraParallaxSettings = document.general.cameraParallax
+        sceneSupportsAudioProcessing = document.general.supportsAudioProcessing
         cameraParallaxSmoother.reset()
         sceneRenderSize = cameraUniforms.renderSize
         debugStage("camera", "renderSize=\(Int(sceneRenderSize.width))x\(Int(sceneRenderSize.height))")
@@ -1547,6 +1554,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// run again).
     private var needsContinuousFrames: Bool {
         hasAnimatedShaderPasses
+            || sceneSupportsAudioProcessing
             || !dynamicTextureSources.isEmpty
             || !particleSystems.isEmpty
             || pointerDrivenContent
@@ -1613,6 +1621,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         soundRuntime?.stop()
         soundRuntime = nil
         cameraParallaxSettings = .disabled
+        sceneSupportsAudioProcessing = false
         cameraParallaxSmoother.reset()
         lastRuntimeUniforms = nil
         cachedSnapshot = nil

--- a/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
+++ b/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
@@ -453,6 +453,173 @@ struct WPEMetalRenderExecutorTests {
         #expect(slots[0] == SIMD4<Float>(8, 4, 7, 3))
     }
 
+    @Test("Scalar float[N] audio array packs one bin per slot in .x (both pack overloads)")
+    func audioSpectrumArrayPacksOneBinPerSlot() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+        // Distinct, recognizable per-bin values so a 4-per-slot mispack (the old
+        // `values:` overload bug) or a stride under-read would be obvious.
+        let bins = (0..<64).map { Double($0) + 1 }
+        let layout = [
+            WPEUniformSlot(name: "g_AudioSpectrum64Left", glslType: "float", slot: 0, slotCount: 64, arrayLength: 64)
+        ]
+
+        // `values:` overload (MSDF text path) — previously packed every array as vec4[N].
+        let slotsValues = executor.packTranslatedUniforms(
+            values: ["g_AudioSpectrum64Left": .vector(bins)],
+            layout: layout
+        )
+        for i in 0..<64 {
+            #expect(slotsValues[i].x == Float(bins[i]))
+            #expect(slotsValues[i].y == 0 && slotsValues[i].z == 0 && slotsValues[i].w == 0)
+        }
+
+        // Per-pass overload (live scene path) must agree bin-for-bin.
+        let pass = WPEPreparedRenderPass(
+            pass: WPERenderPass(
+                id: "audio.0",
+                phase: .effect(file: "effects/workshop/audio/effect.json"),
+                shader: "workshop/audio/bars",
+                source: .image("materials/base.png"),
+                target: .scene,
+                textures: [:],
+                binds: [:],
+                constants: [:],
+                combos: [:],
+                blending: "normal",
+                cullMode: "nocull",
+                depthTest: "disabled",
+                depthWrite: "disabled"
+            ),
+            shader: nil,
+            textureBindings: [:],
+            comboValues: [:],
+            uniformValues: ["g_AudioSpectrum64Left": .vector(bins)]
+        )
+        let slotsPass = executor.packTranslatedUniforms(for: pass, layout: layout)
+        for i in 0..<64 {
+            #expect(slotsPass[i].x == Float(bins[i]))
+        }
+    }
+
+    @Test("vec2[N] array packs two components per slot (.xy), tightly strided")
+    func vec2ArrayPacksTwoComponentsPerSlot() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+        // 4 elements × 2 components = 8 flat values.
+        let flat = (0..<8).map { Double($0) + 1 } // 1,2 | 3,4 | 5,6 | 7,8
+        let layout = [
+            WPEUniformSlot(name: "u_Points", glslType: "vec2", slot: 0, slotCount: 4, arrayLength: 4)
+        ]
+        let slots = executor.packTranslatedUniforms(
+            values: ["u_Points": .vector(flat)],
+            layout: layout
+        )
+        for i in 0..<4 {
+            #expect(slots[i].x == Float(flat[i * 2]))
+            #expect(slots[i].y == Float(flat[i * 2 + 1]))
+            #expect(slots[i].z == 0 && slots[i].w == 0)
+        }
+    }
+
+    @Test("Scene-capture utility output geometry: only a small axis-aligned composelayer is subregion")
+    func sceneCaptureUtilityOutputGeometryClassifier() throws {
+        let scene = CGSize(width: 3840, height: 2160)
+        func geo(
+            size: CGSize?,
+            scale: SIMD3<Double> = SIMD3<Double>(1, 1, 1),
+            angles: SIMD3<Double> = SIMD3<Double>(0, 0, 0)
+        ) -> WPERenderLayerGeometry {
+            WPERenderLayerGeometry(
+                origin: SIMD3<Double>(-772.6, 494.6, 0),
+                scale: scale,
+                angles: angles,
+                alignment: .center,
+                size: size,
+                alpha: 1,
+                color: SIMD3<Double>(1, 1, 1),
+                brightness: 1
+            )
+        }
+        typealias Models = WPEMetalSceneCaptureUtilityModels
+
+        // The audio-bar box (scene 3460973721): 2560×1440 × 0.5 = 1280×720, axis-aligned.
+        #expect(Models.outputGeometry(
+            path: "models/util/composelayer.json",
+            geometry: geo(size: CGSize(width: 2560, height: 1440), scale: SIMD3<Double>(0.5, 0.5, 0.5)),
+            sceneSize: scene
+        ) == .subregion)
+        // ../<dependencyID>/ resolver prefix is tolerated.
+        #expect(Models.outputGeometry(
+            path: "../3021673417/models/util/composelayer.json",
+            geometry: geo(size: CGSize(width: 2560, height: 1440), scale: SIMD3<Double>(0.5, 0.5, 0.5)),
+            sceneSize: scene
+        ) == .subregion)
+
+        // fullscreenlayer (DoF) and projectlayer (projection) always fullscreen.
+        #expect(Models.outputGeometry(path: "models/util/fullscreenlayer.json",
+            geometry: geo(size: CGSize(width: 1280, height: 720)), sceneSize: scene) == .fullscreen)
+        #expect(Models.outputGeometry(path: "models/util/projectlayer.json",
+            geometry: geo(size: CGSize(width: 1280, height: 720)), sceneSize: scene) == .fullscreen)
+
+        // Scene 3479521040 regression guards: rotated and oversized compose stay fullscreen.
+        #expect(Models.outputGeometry(path: "models/util/composelayer.json",
+            geometry: geo(size: CGSize(width: 1280, height: 720), angles: SIMD3<Double>(0, 0, 0.4)),
+            sceneSize: scene) == .fullscreen)
+        #expect(Models.outputGeometry(path: "models/util/composelayer.json",
+            geometry: geo(size: CGSize(width: 5000, height: 2300)), sceneSize: scene) == .fullscreen)
+        // Mirrored (negative scale) and missing size also stay fullscreen.
+        #expect(Models.outputGeometry(path: "models/util/composelayer.json",
+            geometry: geo(size: CGSize(width: 1280, height: 720), scale: SIMD3<Double>(-1, 1, 1)),
+            sceneSize: scene) == .fullscreen)
+        #expect(Models.outputGeometry(path: "models/util/composelayer.json",
+            geometry: geo(size: nil), sceneSize: scene) == .fullscreen)
+    }
+
+    @Test("Subregion composelayer object quad uses WPE center-origin coordinates (no half-scene anchor)")
+    func subregionComposeObjectQuadUsesCenterOrigin() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+        let source = try makeRGBAInputTexture(device: device, bytes: Data(repeating: 255, count: 4))
+        let geometry = WPERenderLayerGeometry(
+            origin: SIMD3<Double>(-772.6, 494.6, 0),
+            scale: SIMD3<Double>(0.5, 0.5, 0.5),
+            angles: SIMD3<Double>(0, 0, 0),
+            alignment: .center,
+            size: CGSize(width: 2560, height: 1440),
+            alpha: 1,
+            color: SIMD3<Double>(1, 1, 1),
+            brightness: 1
+        )
+        let layer = WPERenderLayer(
+            objectID: "audio",
+            objectName: "音频响应",
+            imagePath: "models/util/composelayer.json",
+            materialPath: "materials/util/composelayer.json",
+            geometry: geometry,
+            compositeA: "a",
+            compositeB: "b",
+            localFBOs: [],
+            passes: []
+        )
+        let quad = executor.objectQuadUniforms(
+            for: layer,
+            sceneSize: CGSize(width: 3840, height: 2160),
+            sourceTexture: source
+        )
+        // Center = authored center-origin pixels directly (NOT origin - sceneSize/2,
+        // which would give (-2692.6, -585.4) → off-screen). Size = footprint × scale.
+        #expect(abs(quad.centerAndSize.x - (-772.6)) < 0.01)
+        #expect(abs(quad.centerAndSize.y - 494.6) < 0.01)
+        #expect(abs(quad.centerAndSize.z - 1280) < 0.01)
+        #expect(abs(quad.centerAndSize.w - 720) < 0.01)
+        // Derived clip-space center stays on-screen (|NDC| < 1), upper-left.
+        let ndcX = quad.centerAndSize.x / (3840 / 2)
+        let ndcY = quad.centerAndSize.y / (2160 / 2)
+        #expect(ndcX > -1 && ndcX < 0)
+        #expect(ndcY > 0 && ndcY < 1)
+    }
+
     @Test("Copies sampled input texture to offscreen output")
     func copiesInputTexture() throws {
         let device = try #require(MTLCreateSystemDefaultDevice())

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPESceneDocument.swift
@@ -368,15 +368,22 @@ public struct WPESceneGeneral: Equatable, Sendable {
     public let clearColor: SIMD3<Double>
     public let orthogonalProjection: WPESceneOrthogonalProjection
     public let cameraParallax: WPESceneCameraParallaxSettings
+    /// WPE `general.supportsaudioprocessing`: the scene declares audio-reactive
+    /// content (a shader/effect samples `g_AudioSpectrum*`). Used by the renderer
+    /// to keep the view on the continuous-frame path so the visualizer animates
+    /// with audio instead of freezing on the static/on-demand path.
+    public let supportsAudioProcessing: Bool
 
     public init(
         clearColor: SIMD3<Double>,
         orthogonalProjection: WPESceneOrthogonalProjection,
-        cameraParallax: WPESceneCameraParallaxSettings = .disabled
+        cameraParallax: WPESceneCameraParallaxSettings = .disabled,
+        supportsAudioProcessing: Bool = false
     ) {
         self.clearColor = clearColor
         self.orthogonalProjection = orthogonalProjection
         self.cameraParallax = cameraParallax
+        self.supportsAudioProcessing = supportsAudioProcessing
     }
 
     public static let defaultGeneral = WPESceneGeneral(


### PR DESCRIPTION
Fixes WPE audio visualizers rendering at the wrong position/size on Metal. A small axis-aligned passthrough `composelayer` now composites into its authored box (audio-bar visualizers) instead of fullscreen; DoF/projection/rotated/oversized stay fullscreen (gate `WPEMetalSubregionComposeOutput`). Also unifies the two uniform-pack overloads so scalar `float[N]` (`g_AudioSpectrum*`) packs one bin per slot, and keeps `supportsaudioprocessing` scenes on the continuous-frame path.

Build + 59 executor tests green (packing round-trip, classifier incl. scene 3479521040 regression guard, center-origin geometry). On-device validation pending: scene 3460973721 bars confined to box, scene 3479521040 DoF not regressed. Follow-up (step 2): `previous` sub-region rect sampling for non-REPLACE transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)