### PR TITLE
feat(wpe-diag): puppet skinning-gate reason log + Diagnostics toggles

### DIFF
--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -107,6 +107,21 @@ final class WPEMetalRenderExecutor {
         #endif
     }
 
+    /// Diagnostic: log each puppet's GPU-skinning gate result (enabled, or the
+    /// disable reason — `unresolved-attachment` / `missing-hierarchy` /
+    /// `palette-unresolved` / `skin-index-out-of-range` / `palette-unbounded` /
+    /// `no-animation` / `user-disabled`). A gated-off puppet falls back to the
+    /// static rest pose (no blink/sway), so this surfaces *why* a puppet doesn't
+    /// animate. Logged once per object per change (not per frame). DEBUG-only.
+    /// Enable: `defaults write Taijia.LiveWallpaper WPEPuppetLogSkinningReason -bool YES`.
+    static var logPuppetSkinningReason: Bool {
+        #if DEBUG
+        return UserDefaults.standard.bool(forKey: "WPEPuppetLogSkinningReason")
+        #else
+        return false
+        #endif
+    }
+
     /// Rollback gate for sub-region compose-layer output (the audio-visualizer
     /// "box" fix). Default ON. `defaults write Taijia.LiveWallpaper
     /// WPEMetalSubregionComposeOutput -bool NO` reverts every scene-capture
@@ -1152,12 +1167,43 @@ final class WPEMetalRenderExecutor {
                 runtimeUniforms: runtimeUniforms
             )
         }
+        #if DEBUG
+        if Self.logPuppetSkinningReason {
+            logResolvedPuppetSkinning(pipeline: pipeline, skinningByObjectID: skinningByObjectID)
+        }
+        #endif
         return PuppetAttachmentFrameContext(
             layersByObjectID: layersByID,
             skinningByObjectID: skinningByObjectID,
             sceneSize: sceneSize
         )
     }
+
+    #if DEBUG
+    /// Per-objectID dedup so the skinning-gate reason logs once per change, not per frame.
+    private var lastLoggedPuppetSkinningReason: [String: String] = [:]
+
+    /// Logs why each puppet's GPU skinning is enabled or gated off (see `logPuppetSkinningReason`).
+    private func logResolvedPuppetSkinning(
+        pipeline: WPEPreparedRenderPipeline,
+        skinningByObjectID: [String: PuppetSkinningState]
+    ) {
+        for layer in pipeline.layers where layer.puppetModel != nil {
+            let objectID = layer.graphLayer.objectID
+            let state = skinningByObjectID[objectID]
+            let enabled = state?.enabled ?? false
+            let reason = state?.reason ?? "no-state"
+            let summary = "\(enabled ? "ENABLED" : "DISABLED")/\(reason)"
+            guard lastLoggedPuppetSkinningReason[objectID] != summary else { continue }
+            lastLoggedPuppetSkinningReason[objectID] = summary
+            Logger.info(
+                "🦴 [puppet-skin] obj=\(objectID) name=\(layer.graphLayer.objectName) "
+                    + "skinning=\(enabled ? "ENABLED" : "DISABLED") reason=\(reason)",
+                category: .wpeRender
+            )
+        }
+    }
+    #endif
 
     /// The default-on skinning gate: only enable GPU skinning when the puppet's hierarchy, skin
     /// indices, palette bounds, and attached children are all supported. Otherwise the puppet renders

--- a/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
+++ b/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
@@ -233,6 +233,10 @@ struct DeveloperToolsView: View {
               help: "Probe the Core Audio process tap under the sandbox (audio-reactive bring-up)."),
         .init(key: "WPEAudioDebugLog", title: "Audio debug log",
               help: "Verbose audio-reactive DSP logging."),
+        .init(key: "WPEPuppetLogSkinningReason", title: "Log puppet skinning gate",
+              help: "Log why each puppet's GPU skinning is enabled or gated off (blink/body-sway depend on it). Filter logs for 🦴 [puppet-skin]. Logged once per change."),
+        .init(key: "WPEPuppetDeferMeshWarp", title: "Defer puppet mesh warp",
+              help: "Run the puppet base + effect chain in atlas/local UV space and warp the skinned mesh at composite, so effect masks align with the puppet. Reload the scene to apply."),
     ]
 
     private static let diagnosticStringKeys: [String] = [


### PR DESCRIPTION
Adds a DEBUG diagnostic that logs **why each puppet's GPU skinning is enabled or gated off** — `unresolved-attachment` / `missing-hierarchy` / `palette-unresolved` / `skin-index-out-of-range` / `palette-unbounded` / `no-animation` / `user-disabled`. A gated-off puppet falls back to the static rest pose (no blink / no body-sway), so this surfaces *why* a puppet doesn't animate (e.g. Plana 3461168300). Logged once per object per change (not per frame), filter for `🦴 [puppet-skin]`.

Exposes two puppet flags as toggles in the **WPE Diagnostics** panel (previously only settable via `defaults write`):
- `WPEPuppetLogSkinningReason` — the new skinning-gate log.
- `WPEPuppetDeferMeshWarp` — the deferred-mesh-warp fix (PR #115).

Build green. DEBUG-only / default-off → zero behavioral change in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)