### PR TITLE
feat(wpe-diag): include palette-unbounded detail (frame/space/delta) in skinning reason

### DIFF
--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -1261,8 +1261,8 @@ final class WPEMetalRenderExecutor {
         guard Self.skinBlendIndicesAreInRange(in: model.meshes, paletteCount: evaluation.palette.count) else {
             return disabled("skin-index-out-of-range")
         }
-        guard sampledPalettesAreFiniteAndBounded(layers: animationLayers, bones: model.bones, meshes: model.meshes) else {
-            return disabled("palette-unbounded")
+        if let detail = paletteBoundFailureDetail(layers: animationLayers, bones: model.bones, meshes: model.meshes) {
+            return disabled("palette-unbounded[\(detail)]")
         }
         return PuppetSkinningState(
             enabled: true,
@@ -1276,14 +1276,18 @@ final class WPEMetalRenderExecutor {
     /// Samples the palette across the clip and rejects skinning if any frame is non-finite or moves a
     /// skinned vertex further than a puppet-size-relative bound — the catch for an otherwise "finite"
     /// but exploding palette that frame-0==identity alone would not detect.
-    private func sampledPalettesAreFiniteAndBounded(
+    /// Returns nil when every sampled frame's palette is finite and bounded; otherwise a short
+    /// failure detail (frame / transform space / vertex-delta vs. allowed) that rides on the
+    /// `palette-unbounded` reason so the skinning-gate log shows WHY a puppet was rejected — a near-miss
+    /// delta means the threshold is too tight, a huge delta means the palette evaluation is exploding.
+    private func paletteBoundFailureDetail(
         layers: [WPEPuppetAnimationLayer],
         bones: [WPEPuppetBone],
         meshes: [WPEPuppetMesh]
-    ) -> Bool {
-        guard let base = layers.first(where: { !$0.additive }) ?? layers.first else { return false }
+    ) -> String? {
+        guard let base = layers.first(where: { !$0.additive }) ?? layers.first else { return "no-base-layer" }
         let fps = Double(base.animation.fps)
-        guard fps.isFinite, fps > 0 else { return false }
+        guard fps.isFinite, fps > 0 else { return "bad-fps" }
         let last = max(base.animation.frameCount, 1)
         let frames = Array(Set([0, 1, last / 4, last / 2, (last * 3) / 4, last])).sorted()
         let extent = Self.modelExtent(meshes: meshes)
@@ -1294,13 +1298,17 @@ final class WPEMetalRenderExecutor {
             guard evaluation.parentChannelMapSucceeded,
                   !evaluation.palette.isEmpty,
                   evaluation.palette.allSatisfy(WPEPuppetAnimationEvaluator.matrixIsFinite) else {
-                return false
+                let finite = evaluation.palette.allSatisfy(WPEPuppetAnimationEvaluator.matrixIsFinite)
+                return "frame=\(frame) parentMap=\(evaluation.parentChannelMapSucceeded) "
+                    + "empty=\(evaluation.palette.isEmpty) finite=\(finite)"
             }
-            guard Self.maxSkinnedVertexDelta(meshes: meshes, palette: evaluation.palette) <= maxAllowedDelta else {
-                return false
+            let delta = Self.maxSkinnedVertexDelta(meshes: meshes, palette: evaluation.palette)
+            guard delta <= maxAllowedDelta else {
+                return "frame=\(frame) space=\(evaluation.transformSpace?.rawValue ?? "nil") "
+                    + "Δ=\(Int(delta))>\(Int(maxAllowedDelta)) extent=\(Int(extent))"
             }
         }
-        return true
+        return nil
     }
 
     /// Every skin-blend index with positive, finite weight must address a real palette entry. The


### PR DESCRIPTION
Follow-up to #118. Adds the failure detail to the `palette-unbounded` skinning-gate reason — frame, transform space, vertex delta vs. allowed threshold, model extent — so the log distinguishes a near-miss from an explosion.

NOTE: an earlier commit here also relaxed the vertex-delta bound (0.12→1.5×extent); **reverted** — on-device that let Plana's puppet skin with visibly broken deformation (crown static, jaw-only, stretching), i.e. the bound was masking a genuine skinning-evaluation bug, not merely being too tight. Diagnostic-only now; the eval fix is tracked separately.

DEBUG-only. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)