### PR TITLE
Tidy debug logging + fix Pro Release build

### DIFF
--- a/LiveWallpaper/Infrastructure/WPESceneDebugArtifacts.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDebugArtifacts.swift
@@ -57,6 +57,12 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
     private let bindingDiagnosticsLock = NSLock()
     private var bindingDiagnostics: [String] = []
     private let maxBindingDiagnostics = 512
+
+    /// Caps on the scene-debug directory so DEBUG builds (where dumps default on)
+    /// don't accumulate unbounded PNG/MSL artifacts. The oldest session folders
+    /// are pruned first when either bound is exceeded; the newest is always kept.
+    private let maxSessionFolders = 40
+    private let maxTotalBytes: UInt64 = 512 * 1024 * 1024  // 512 MiB
     private let isoFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withYear, .withMonth, .withDay, .withTime]
@@ -102,6 +108,7 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
     func beginSession(workshopID: String, descriptor: String) -> URL? {
         guard isEnabled else { return nil }
         guard let root = Self.rootURL else { return nil }
+        pruneOldSessions(under: root)
 
         let stamp = compactTimestamp(from: Date())
         let folder = root.appendingPathComponent("\(stamp)-\(workshopID)", isDirectory: true)
@@ -141,6 +148,57 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
             category: .wpeRender
         )
         return folder
+    }
+
+    /// Prune oldest session folders so the scene-debug root stays under both the
+    /// folder-count and total-byte caps. Runs async on the write queue so it
+    /// never blocks scene load. Best-effort — failures are ignored, and the
+    /// single newest session is always retained.
+    private func pruneOldSessions(under root: URL) {
+        let maxFolders = maxSessionFolders
+        let maxBytes = maxTotalBytes
+        writeQueue.async {
+            let fm = FileManager.default
+            let keys: [URLResourceKey] = [.contentModificationDateKey, .isDirectoryKey]
+            guard let children = try? fm.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: keys,
+                options: [.skipsHiddenFiles]
+            ) else { return }
+
+            // Newest first, so we keep the most recent sessions and trim the tail.
+            let folders = children
+                .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+                .map { url -> (url: URL, date: Date, size: UInt64) in
+                    let date = (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+                    return (url, date, Self.directorySize(of: url, fm: fm))
+                }
+                .sorted { $0.date > $1.date }
+
+            var runningBytes: UInt64 = 0
+            for (index, folder) in folders.enumerated() {
+                runningBytes += folder.size
+                let overCount = index + 1 > maxFolders
+                let overBytes = index > 0 && runningBytes > maxBytes
+                if overCount || overBytes {
+                    try? fm.removeItem(at: folder.url)
+                }
+            }
+        }
+    }
+
+    private static func directorySize(of url: URL, fm: FileManager) -> UInt64 {
+        guard let enumerator = fm.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.totalFileAllocatedSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return 0 }
+        var total: UInt64 = 0
+        for case let fileURL as URL in enumerator {
+            let size = (try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey]).totalFileAllocatedSize) ?? 0
+            total += UInt64(size)
+        }
+        return total
     }
 
     /// Drop the current session reference. Files stay on disk.

--- a/LiveWallpaper/Infrastructure/WPEVideoTextureDiskCache.swift
+++ b/LiveWallpaper/Infrastructure/WPEVideoTextureDiskCache.swift
@@ -221,7 +221,7 @@ actor WPEVideoTextureDiskCache {
             Logger.info("WPE video cache LRU evicted \(freed) bytes (cap \(maxBytes))", category: .wpeRender)
         }
         if total > maxBytes {
-            Logger.warning("WPE video cache still over cap (\(total) > \(maxBytes)) — remaining files are in use", category: .wpeRender)
+            Logger.notice("WPE video cache still over cap (\(total) > \(maxBytes)) — remaining files are in use", category: .wpeRender)
         }
     }
 

--- a/LiveWallpaper/Runtime/Audio/SystemAudioCaptureManager.swift
+++ b/LiveWallpaper/Runtime/Audio/SystemAudioCaptureManager.swift
@@ -83,7 +83,7 @@ final class SystemAudioCaptureManager {
         guard serviceBox == nil else { return }
         guard #available(macOS 14.2, *) else {
             state = .unsupported
-            Logger.warning("[AudioCapture] manager: system audio capture needs macOS 14.2+", category: .audioCapture)
+            Logger.info("[AudioCapture] manager: system audio capture needs macOS 14.2+", category: .audioCapture)
             return
         }
         let service = SystemAudioCaptureService(broker: Self.broker)

--- a/LiveWallpaper/Runtime/WPECorpusPlaybackHarness.swift
+++ b/LiveWallpaper/Runtime/WPECorpusPlaybackHarness.swift
@@ -221,7 +221,7 @@ final class WPECorpusPlaybackHarness {
         for (offset, project) in projects.enumerated() {
             if isCancelled() || Task.isCancelled {
                 let report = makeReport(total: projects.count, entries: entries)
-                Logger.warning("WPE corpus playback cancelled with \(entries.count)/\(projects.count) entries", category: .screenManager)
+                Logger.info("WPE corpus playback cancelled with \(entries.count)/\(projects.count) entries", category: .screenManager)
                 progress(.cancelled(report))
                 return
             }

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -375,7 +375,7 @@ final class WPEMetalRenderExecutor {
                         frameState: &frameState
                     )
                 } catch {
-                    Logger.warning(
+                    Logger.info(
                         "[WPE.bypass] skipped layer \(layer.graphLayer.objectID): source \(firstSource) not blittable (\(error))",
                         category: .wpeRender
                     )
@@ -858,7 +858,7 @@ final class WPEMetalRenderExecutor {
     func present(texture source: MTLTexture, in view: MTKView) throws -> Bool {
         guard let drawable = view.currentDrawable else {
             #if DEBUG
-            Logger.warning(
+            Logger.info(
                 "[present] view.currentDrawable=nil — source=\(source.width)x\(source.height) view.bounds=\(view.bounds) drawableSize=\(view.drawableSize)",
                 category: .wpeRender
             )
@@ -1986,7 +1986,7 @@ final class WPEMetalRenderExecutor {
             )
             let key = "decide:\(layer.objectID)"
             if loggedSubregionDiag.insert(key).inserted {
-                Logger.warning(
+                Logger.info(
                     "🟦[ComposeSubregion] decide objID=\(layer.objectID) shader=\(pass.pass.shader) target=\(String(describing: pass.pass.target)) decision=\(decision) sceneSize=\(Int(currentSceneSize.width))x\(Int(currentSceneSize.height)) origin=\(layer.geometry.origin.x),\(layer.geometry.origin.y) size=\(String(describing: layer.geometry.size)) scale=\(layer.geometry.scale.x)",
                     category: .wpeRender
                 )
@@ -2045,7 +2045,7 @@ final class WPEMetalRenderExecutor {
         ) + cameraParallax.pixelOffset(depth: layer.parallaxDepth, sceneSize: sceneSize)
         if WPEMetalSceneCaptureUtilityModels.isSceneCaptureUtilityModelPath(layer.imagePath),
            loggedSubregionDiag.insert("quad:\(layer.objectID)").inserted {
-            Logger.warning(
+            Logger.info(
                 "🟩[ComposeSubregion] quad objID=\(layer.objectID) center=(\(Int(center.x)),\(Int(center.y))) size=(\(Int(width)),\(Int(height))) sceneSize=(\(Int(sceneWidth)),\(Int(sceneHeight))) centerNDC=(\(String(format: "%.2f", center.x / max(sceneWidth * 0.5, 1))),\(String(format: "%.2f", center.y / max(sceneHeight * 0.5, 1)))) srcTex=\(sourceTexture.width)x\(sourceTexture.height)",
                 category: .wpeRender
             )
@@ -2345,7 +2345,7 @@ final class WPEMetalRenderExecutor {
 
         if !loggedWaterWavesDispatch {
             loggedWaterWavesDispatch = true
-            Logger.warning(
+            Logger.info(
                 "WPE waterwaves dispatch ran (builtin effect_waterwaves): debugMode=\(debugMode) hasMask=\(hasMask) mask=\(maskTexture.width)x\(maskTexture.height) dest=\(destination.texture.width)x\(destination.texture.height) speed=\(speed) scale=\(scale) strength=\(strength)",
                 category: .wpeRender
             )

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -345,7 +345,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             if case .dependency = entry.key { return partial + entry.value }
             return partial
         }
-        Logger.warning(
+        Logger.notice(
             "Scene \(workshopID) resolution summary — events:\(snapshot.events.count) resolved:\(snapshot.resolvedCount) scene:\(counts[.scene, default: 0]) builtin:\(counts[.builtin, default: 0]) engineAssets:\(counts[.engineAssets, default: 0]) dependency:\(dependencyCount)",
             category: .screenManager
         )
@@ -355,7 +355,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
                 .map { "\($0.ref) → \($0.finalOutcome.debugLabel)" }
                 .joined(separator: " | ")
             let suffix = missed.count > 40 ? " | +\(missed.count - 40) more" : ""
-            Logger.warning(
+            Logger.notice(
                 "Scene \(workshopID) misses (top 40 of \(missed.count)): \(summary)\(suffix)",
                 category: .screenManager
             )
@@ -591,7 +591,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             // BC/DXT/RG88/R8 etc. — decode by sampling into rgba8 so we can view it.
             texture = decoded
         } else {
-            Logger.warning(
+            Logger.info(
                 "[WPEMetalCaptureScene] texture dump: unsupported pixel format \(rawTexture.pixelFormat.rawValue) for \(basename)",
                 category: .wpeRender
             )
@@ -608,7 +608,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         )
 
         guard let provider = CGDataProvider(data: Data(bytes) as CFData) else {
-            Logger.warning("[WPEMetalCaptureScene] texture dump: CGDataProvider failed for \(basename)", category: .wpeRender)
+            Logger.info("[WPEMetalCaptureScene] texture dump: CGDataProvider failed for \(basename)", category: .wpeRender)
             return
         }
         let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
@@ -626,7 +626,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             shouldInterpolate: false,
             intent: .defaultIntent
         ) else {
-            Logger.warning("[WPEMetalCaptureScene] texture dump: CGImage failed for \(basename)", category: .wpeRender)
+            Logger.info("[WPEMetalCaptureScene] texture dump: CGImage failed for \(basename)", category: .wpeRender)
             return
         }
 
@@ -648,13 +648,13 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             guard let tiff = nsImage.tiffRepresentation,
                   let bitmap = NSBitmapImageRep(data: tiff),
                   let png = bitmap.representation(using: .png, properties: [:]) else {
-                Logger.warning("[WPEMetalCaptureScene] texture dump: PNG encode failed for \(basename)", category: .wpeRender)
+                Logger.info("[WPEMetalCaptureScene] texture dump: PNG encode failed for \(basename)", category: .wpeRender)
                 return
             }
             try png.write(to: url)
             Logger.notice("[WPEMetalCaptureScene] texture dump → \(url.path)", category: .wpeRender)
         } catch {
-            Logger.warning(
+            Logger.info(
                 "[WPEMetalCaptureScene] texture dump failed for \(basename): \(error.localizedDescription)",
                 category: .wpeRender
             )
@@ -676,7 +676,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         }
         let device = texture.device
         guard texture.pixelFormat == .rgba8Unorm || texture.pixelFormat == .rgba8Unorm_srgb else {
-            Logger.warning(
+            Logger.info(
                 "[WPEMetalCaptureScene] outputTexture dump: unsupported pixel format \(texture.pixelFormat.rawValue)",
                 category: .wpeRender
             )
@@ -686,13 +686,13 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         let bytesPerRow = texture.width * bytesPerPixel
         let totalBytes = bytesPerRow * texture.height
         guard let buffer = device.makeBuffer(length: totalBytes, options: .storageModeShared) else {
-            Logger.warning("[WPEMetalCaptureScene] outputTexture dump: makeBuffer failed", category: .wpeRender)
+            Logger.info("[WPEMetalCaptureScene] outputTexture dump: makeBuffer failed", category: .wpeRender)
             return
         }
         guard let queue = device.makeCommandQueue(),
               let cb = queue.makeCommandBuffer(),
               let blit = cb.makeBlitCommandEncoder() else {
-            Logger.warning("[WPEMetalCaptureScene] outputTexture dump: cannot create blit encoder", category: .wpeRender)
+            Logger.info("[WPEMetalCaptureScene] outputTexture dump: cannot create blit encoder", category: .wpeRender)
             return
         }
         blit.copy(
@@ -710,7 +710,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         cb.commit()
         cb.waitUntilCompleted()
         guard cb.status == .completed else {
-            Logger.warning(
+            Logger.info(
                 "[WPEMetalCaptureScene] outputTexture dump: blit failed (status=\(cb.status.rawValue))",
                 category: .wpeRender
             )
@@ -719,7 +719,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
 
         let provider = CGDataProvider(dataInfo: nil, data: buffer.contents(), size: totalBytes) { _, _, _ in }
         guard let provider else {
-            Logger.warning("[WPEMetalCaptureScene] outputTexture dump: CGDataProvider failed", category: .wpeRender)
+            Logger.info("[WPEMetalCaptureScene] outputTexture dump: CGDataProvider failed", category: .wpeRender)
             return
         }
         let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
@@ -737,7 +737,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             shouldInterpolate: false,
             intent: .defaultIntent
         ) else {
-            Logger.warning("[WPEMetalCaptureScene] outputTexture dump: CGImage failed", category: .wpeRender)
+            Logger.info("[WPEMetalCaptureScene] outputTexture dump: CGImage failed", category: .wpeRender)
             return
         }
         let nsImage = NSImage(cgImage: cg, size: CGSize(width: texture.width, height: texture.height))
@@ -759,7 +759,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             guard let tiff = nsImage.tiffRepresentation,
                   let bitmap = NSBitmapImageRep(data: tiff),
                   let png = bitmap.representation(using: .png, properties: [:]) else {
-                Logger.warning("[WPEMetalCaptureScene] outputTexture dump: PNG encode failed", category: .wpeRender)
+                Logger.info("[WPEMetalCaptureScene] outputTexture dump: PNG encode failed", category: .wpeRender)
                 return
             }
             try png.write(to: url)
@@ -775,7 +775,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
                 category: .wpeRender
             )
         } catch {
-            Logger.warning(
+            Logger.info(
                 "[WPEMetalCaptureScene] outputTexture dump failed: \(error.localizedDescription)",
                 category: .wpeRender
             )
@@ -802,7 +802,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         }
         let manager = MTLCaptureManager.shared()
         guard manager.supportsDestination(.gpuTraceDocument) else {
-            Logger.warning(
+            Logger.info(
                 "[WPEMetalCaptureScene] device does not support gpuTraceDocument capture; ensure MetalCaptureEnabled is YES in Info.plist and Xcode is attached.",
                 category: .wpeRender
             )
@@ -815,7 +815,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         do {
             traceURL = try Self.makeCaptureURL(workshopID: descriptor.workshopID)
         } catch {
-            Logger.warning(
+            Logger.info(
                 "[WPEMetalCaptureScene] could not create capture directory: \(error.localizedDescription)",
                 category: .wpeRender
             )
@@ -834,7 +834,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             )
             return GPUCaptureHandle(manager: manager, outputURL: traceURL)
         } catch {
-            Logger.warning(
+            Logger.info(
                 "[WPEMetalCaptureScene] capture start failed: \(error.localizedDescription)",
                 category: .wpeRender
             )

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -523,15 +523,32 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         _ = id
     }
 
+    #if DEBUG
+    /// Whether the current scene is in the GPU-capture set. `WPEMetalCaptureScene`
+    /// holds a string array (the Developer Tools "GPU capture" list); a single
+    /// `defaults write ... WPEMetalCaptureScene <id>` string — optionally comma/
+    /// space separated — is still honored for back-compat with the CLI workflow.
+    private func gpuCaptureRequestedForCurrentScene() -> Bool {
+        let d = UserDefaults.standard
+        let raw: [String]
+        if let arr = d.stringArray(forKey: "WPEMetalCaptureScene") {
+            raw = arr
+        } else if let s = d.string(forKey: "WPEMetalCaptureScene") {
+            raw = s.split(whereSeparator: { ",; ".contains($0) }).map(String.init)
+        } else {
+            raw = []
+        }
+        let wanted = Set(raw.map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty })
+        return wanted.contains(descriptor.workshopID)
+    }
+    #endif
+
     /// Iterate every entry in `loadedTextures` and dump each to a PNG so we
     /// can verify whether the source-image upload actually carried bytes to
     /// the GPU. Same gate as the GPU trace + outputTexture dump.
     private func dumpLoadedTexturesIfRequested() {
         #if DEBUG
-        let wantedID = UserDefaults.standard.string(forKey: "WPEMetalCaptureScene")
-        guard let wantedID, !wantedID.isEmpty, wantedID == descriptor.workshopID else {
-            return
-        }
+        guard gpuCaptureRequestedForCurrentScene() else { return }
         for (path, texture) in loadedTextures {
             let safeName = path
                 .replacingOccurrences(of: "/", with: "_")
@@ -670,10 +687,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// `WPEMetalCaptureScene` UserDefault as the GPU trace capture.
     private func dumpOutputTextureIfRequested(_ texture: MTLTexture) {
         #if DEBUG
-        let wantedID = UserDefaults.standard.string(forKey: "WPEMetalCaptureScene")
-        guard let wantedID, !wantedID.isEmpty, wantedID == descriptor.workshopID else {
-            return
-        }
+        guard gpuCaptureRequestedForCurrentScene() else { return }
         let device = texture.device
         guard texture.pixelFormat == .rgba8Unorm || texture.pixelFormat == .rgba8Unorm_srgb else {
             Logger.info(
@@ -796,10 +810,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     ///   defaults delete Taijia.LiveWallpaper WPEMetalCaptureScene
     private func beginGPUCaptureIfRequested() -> GPUCaptureHandle? {
         #if DEBUG
-        let wantedID = UserDefaults.standard.string(forKey: "WPEMetalCaptureScene")
-        guard let wantedID, !wantedID.isEmpty, wantedID == descriptor.workshopID else {
-            return nil
-        }
+        guard gpuCaptureRequestedForCurrentScene() else { return nil }
         let manager = MTLCaptureManager.shared()
         guard manager.supportsDestination(.gpuTraceDocument) else {
             Logger.info(

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -1172,7 +1172,7 @@ final class ScreenManager {
     
     // MARK: - Memory Management
     private func handleLowMemory() {
-        Logger.warning("Low memory condition detected, optimizing resource usage", category: .memory)
+        Logger.notice("Low memory condition detected, optimizing resource usage", category: .memory)
 
         for screen in screens {
             guard let playback = screen.playbackController, playback.isPlaying else { continue }

--- a/LiveWallpaper/SettingsManager.swift
+++ b/LiveWallpaper/SettingsManager.swift
@@ -561,7 +561,7 @@ final class SettingsManager {
         if url.exists {
             return url
         }
-        Logger.warning("Last used directory no longer exists: \(path)", category: .fileAccess)
+        Logger.info("Last used directory no longer exists: \(path)", category: .fileAccess)
         return nil
     }
 

--- a/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
+++ b/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
@@ -214,7 +214,7 @@ final class WallpaperVideoPlayer {
                             category: .videoPlayer
                         )
                     } catch {
-                        Logger.warning(
+                        Logger.info(
                             "In-memory load failed (\(error.localizedDescription)) — falling back to streaming",
                             category: .videoPlayer
                         )

--- a/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
+++ b/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
@@ -9,6 +9,13 @@ import AppKit
 /// `WPECorpusPlaybackHarness` run, surfaces per-scene outcomes in a table,
 /// and lets the maintainer export the resulting JSON report for triage.
 struct DeveloperToolsView: View {
+    @State private var flagRefresh = 0
+
+    // Corpus Test machinery is DEBUG-only: the `WPECorpusPlaybackHarness` /
+    // `WPECorpusPlaybackReport` types it drives are themselves `#if DEBUG`, so
+    // none of this can compile (or run) in Release. Release Developer Tools
+    // shows only the Diagnostics tab.
+    #if DEBUG
     @State private var isRunning = false
     @State private var progressLabel: String = ""
     @State private var progressFraction: Double = 0
@@ -20,10 +27,7 @@ struct DeveloperToolsView: View {
     @State private var runTask: Task<Void, Never>?
     @State private var singleSceneWorkshopID: String = ""
     @State private var singleSceneStatus: String = ""
-    @State private var flagRefresh = 0
-    @State private var waterWavesDebug = WPEWaterWavesDebugMode.current
     @State private var selectedTab: DevToolsTab = .corpusTest
-    @State private var activeWaterWavesPath = WPESceneDebugArtifacts.shared.waterWavesPath
 
     private enum DevToolsTab: String, CaseIterable, Identifiable {
         case corpusTest
@@ -36,6 +40,7 @@ struct DeveloperToolsView: View {
             }
         }
     }
+    #endif
 
     var body: some View {
         DetailPageScaffold(
@@ -43,10 +48,12 @@ struct DeveloperToolsView: View {
             header: { header },
             content: { content }
         )
+        #if DEBUG
         .onDisappear {
             runTask?.cancel()
             cancelRequested = true
         }
+        #endif
     }
 
     private var header: some View {
@@ -60,6 +67,7 @@ struct DeveloperToolsView: View {
 
     @ViewBuilder
     private var metadata: some View {
+        #if DEBUG
         if selectedTab == .diagnostics {
             Text("Diagnostic flags — persist until toggled off or reset.", comment: "Developer Tools header subtitle on the diagnostics tab.")
                 .foregroundStyle(.secondary)
@@ -78,10 +86,15 @@ struct DeveloperToolsView: View {
             Text("Visible while Developer Mode is on. Disable it in Settings → General → Advanced.", comment: "Developer Tools header subtitle explaining the runtime gate.")
                 .foregroundStyle(.secondary)
         }
+        #else
+        Text("Diagnostic flags — persist until toggled off or reset.", comment: "Developer Tools header subtitle on the diagnostics tab.")
+            .foregroundStyle(.secondary)
+        #endif
     }
 
     @ViewBuilder
     private var actions: some View {
+        #if DEBUG
         if selectedTab == .corpusTest {
             HStack(spacing: 8) {
                 if isRunning {
@@ -108,11 +121,13 @@ struct DeveloperToolsView: View {
                 }
             }
         }
+        #endif
     }
 
     @ViewBuilder
     private var content: some View {
         VStack(alignment: .leading, spacing: 16) {
+            #if DEBUG
             Picker(selection: $selectedTab) {
                 ForEach(DevToolsTab.allCases) { tab in
                     Text(verbatim: tab.title).tag(tab)
@@ -129,10 +144,14 @@ struct DeveloperToolsView: View {
             case .diagnostics:
                 diagnosticsFlagsSection
             }
+            #else
+            diagnosticsFlagsSection
+            #endif
         }
         .padding(16)
     }
 
+    #if DEBUG
     @ViewBuilder
     private var corpusTestContent: some View {
         configurationSection
@@ -212,6 +231,7 @@ struct DeveloperToolsView: View {
             .padding(.vertical, 4)
         }
     }
+    #endif
 
     // MARK: - Diagnostic flags
 
@@ -222,22 +242,34 @@ struct DeveloperToolsView: View {
         var id: String { key }
     }
 
-    private static let diagnosticBoolFlags: [DiagnosticBoolFlag] = [
-        .init(key: "WPEMetalCaptureScene", title: "Capture scene textures",
-              help: "Dump decoded scene/composite textures (incl. BC/DXT) under scene-debug."),
-        .init(key: "WPEMetalBypassEffects", title: "Bypass effect passes",
-              help: "Draw only base image layers, skipping effects (note: breaks solid-color layers)."),
-        .init(key: "WPESceneDebugArtifactsEnabled", title: "Scene debug artifacts",
-              help: "Write per-scene logs, first-frame snapshot, and texture metadata to scene-debug."),
-        .init(key: "WPEAudioCaptureProbe", title: "Audio capture probe",
-              help: "Probe the Core Audio process tap under the sandbox (audio-reactive bring-up)."),
-        .init(key: "WPEAudioDebugLog", title: "Audio debug log",
-              help: "Verbose audio-reactive DSP logging."),
-        .init(key: "WPEPuppetLogSkinningReason", title: "Log puppet skinning gate",
-              help: "Log why each puppet's GPU skinning is enabled or gated off (blink/body-sway depend on it). Filter logs for 🦴 [puppet-skin]. Logged once per change."),
-        .init(key: "WPEPuppetDeferMeshWarp", title: "Defer puppet mesh warp",
-              help: "Run the puppet base + effect chain in atlas/local UV space and warp the skinned mesh at composite, so effect masks align with the puppet. Reload the scene to apply."),
-    ]
+    /// Diagnostics whose backing behavior is compiled into every build (dump /
+    /// capture / verbose-log paths that work in Release too).
+    private static let diagnosticBoolFlags: [DiagnosticBoolFlag] = {
+        var flags: [DiagnosticBoolFlag] = [
+            .init(key: "WPEMetalCaptureScene", title: "Capture scene textures",
+                  help: "Dump decoded scene/composite textures (incl. BC/DXT) under scene-debug."),
+            .init(key: "WPESceneDebugArtifactsEnabled", title: "Scene debug artifacts",
+                  help: "Write per-scene logs, first-frame snapshot, and texture metadata to scene-debug."),
+            .init(key: "WPEAudioCaptureProbe", title: "Audio capture probe",
+                  help: "Probe the Core Audio process tap under the sandbox (audio-reactive bring-up)."),
+            .init(key: "WPEAudioDebugLog", title: "Audio debug log",
+                  help: "Verbose audio-reactive DSP logging."),
+        ]
+        // These three read `#if DEBUG`-only gates in WPEMetalRenderExecutor, so
+        // their toggles do nothing in Release. Only surface them where the
+        // backing behavior actually exists.
+        #if DEBUG
+        flags += [
+            .init(key: "WPEPuppetLogSkinningReason", title: "Log puppet skinning gate",
+                  help: "Log why each puppet's GPU skinning is enabled or gated off (blink/body-sway depend on it). Filter logs for 🦴 [puppet-skin]. Logged once per change."),
+            .init(key: "WPEMetalBypassEffects", title: "Bypass effect passes",
+                  help: "Draw only base image layers, skipping effects (note: breaks solid-color layers)."),
+            .init(key: "WPEPuppetDeferMeshWarp", title: "Defer puppet mesh warp",
+                  help: "Run the puppet base + effect chain in atlas/local UV space and warp the skinned mesh at composite, so effect masks align with the puppet. Reload the scene to apply."),
+        ]
+        #endif
+        return flags
+    }()
 
     private static let diagnosticStringKeys: [String] = [
         WPEWaterWavesDebugMode.defaultsKey,
@@ -259,48 +291,6 @@ struct DeveloperToolsView: View {
             }
         ) {
             VStack(alignment: .leading, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Picker(selection: Binding(
-                        get: { waterWavesDebug },
-                        set: { setWaterWavesDebug($0) }
-                    )) {
-                        ForEach(WPEWaterWavesDebugMode.allCases) { mode in
-                            Text(verbatim: mode.title).tag(mode)
-                        }
-                    } label: {
-                        Text(verbatim: "Waterwaves debug")
-                    }
-                    Text(verbatim: "Visualize where the waterwaves effect triggers: Mask / Overlay show the masked region on the character, Displacement shows the wave field. Applies on the next rendered frame.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    HStack(spacing: 4) {
-                        Text(verbatim: "Active waterwaves path:")
-                            .font(.caption)
-                        Text(verbatim: activeWaterWavesPath)
-                            .font(.caption.bold())
-                            .foregroundStyle(waterWavesPathColor)
-                    }
-                    .accessibilityElement(children: .combine)
-
-                    if waterWavesDebug != .off && activeWaterWavesPath == "Inactive" {
-                        Text(verbatim: "⚠️ Waterwaves debug is on but no waterwaves effect is rendering in the current scene.")
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                    }
-                }
-
-                Toggle(isOn: boolBinding("WPEWaterWavesTrace")) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(verbatim: "Waterwaves uniform trace")
-                        Text(verbatim: "Log packed waterwaves uniforms per pass + dump the translated MSL to scene-debug. Needs scene debug artifacts on.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                Divider()
-
                 ForEach(Self.diagnosticBoolFlags) { flag in
                     Toggle(isOn: boolBinding(flag.key)) {
                         VStack(alignment: .leading, spacing: 2) {
@@ -318,12 +308,6 @@ struct DeveloperToolsView: View {
             }
             .padding(.vertical, 4)
             .id(flagRefresh)
-            .task {
-                while !Task.isCancelled {
-                    activeWaterWavesPath = WPESceneDebugArtifacts.shared.waterWavesPath
-                    try? await Task.sleep(nanoseconds: 700_000_000)
-                }
-            }
         }
     }
 
@@ -337,23 +321,6 @@ struct DeveloperToolsView: View {
         )
     }
 
-    private func setWaterWavesDebug(_ mode: WPEWaterWavesDebugMode) {
-        waterWavesDebug = mode
-        if mode == .off {
-            UserDefaults.standard.removeObject(forKey: WPEWaterWavesDebugMode.defaultsKey)
-        } else {
-            UserDefaults.standard.set(mode.storageValue, forKey: WPEWaterWavesDebugMode.defaultsKey)
-        }
-    }
-
-    private var waterWavesPathColor: Color {
-        switch activeWaterWavesPath {
-        case "Builtin": return .green
-        case "Transpiled": return .orange
-        default: return .secondary
-        }
-    }
-
     private func resetDiagnosticFlags() {
         for flag in Self.diagnosticBoolFlags {
             UserDefaults.standard.removeObject(forKey: flag.key)
@@ -362,10 +329,10 @@ struct DeveloperToolsView: View {
             UserDefaults.standard.removeObject(forKey: key)
         }
         UserDefaults.standard.removeObject(forKey: WPEWaterWavesTrace.defaultsKey)
-        waterWavesDebug = .off
         flagRefresh += 1
     }
 
+    #if DEBUG
     private func errorBanner(_ message: String) -> some View {
         Label(message, systemImage: "exclamationmark.triangle.fill")
             .foregroundStyle(.orange)
@@ -645,5 +612,6 @@ struct DeveloperToolsView: View {
         }
         return lines.isEmpty ? entry.title : lines.joined(separator: "\n")
     }
+    #endif
 }
 #endif

--- a/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
+++ b/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
@@ -14,8 +14,11 @@ struct DeveloperToolsView: View {
     // Corpus Test machinery is DEBUG-only: the `WPECorpusPlaybackHarness` /
     // `WPECorpusPlaybackReport` types it drives are themselves `#if DEBUG`, so
     // none of this can compile (or run) in Release. Release Developer Tools
-    // shows only the Diagnostics tab.
+    // shows only the Diagnostics tab. The GPU-capture list is DEBUG-only too —
+    // the renderer reads `WPEMetalCaptureScene` only under `#if DEBUG`.
     #if DEBUG
+    @State private var captureIDs: [String] = UserDefaults.standard.stringArray(forKey: "WPEMetalCaptureScene") ?? []
+    @State private var newCaptureID: String = ""
     @State private var isRunning = false
     @State private var progressLabel: String = ""
     @State private var progressFraction: Double = 0
@@ -246,8 +249,6 @@ struct DeveloperToolsView: View {
     /// capture / verbose-log paths that work in Release too).
     private static let diagnosticBoolFlags: [DiagnosticBoolFlag] = {
         var flags: [DiagnosticBoolFlag] = [
-            .init(key: "WPEMetalCaptureScene", title: "Capture scene textures",
-                  help: "Dump decoded scene/composite textures (incl. BC/DXT) under scene-debug."),
             .init(key: "WPESceneDebugArtifactsEnabled", title: "Scene debug artifacts",
                   help: "Write per-scene logs, first-frame snapshot, and texture metadata to scene-debug."),
             .init(key: "WPEAudioCaptureProbe", title: "Audio capture probe",
@@ -275,6 +276,7 @@ struct DeveloperToolsView: View {
         WPEWaterWavesDebugMode.defaultsKey,
         "WPEDumpScenePasses",
         "WPEDumpScenePassesAtTime",
+        "WPEMetalCaptureScene",
     ]
 
     private var diagnosticsFlagsSection: some View {
@@ -301,6 +303,11 @@ struct DeveloperToolsView: View {
                         }
                     }
                 }
+
+                #if DEBUG
+                Divider()
+                gpuCaptureList
+                #endif
 
                 Text(verbatim: "Flags persist in UserDefaults until toggled off. \"Reset all\" clears every flag here (including scene-dump targets) so a forgotten toggle never affects normal playback.")
                     .font(.caption)
@@ -329,10 +336,72 @@ struct DeveloperToolsView: View {
             UserDefaults.standard.removeObject(forKey: key)
         }
         UserDefaults.standard.removeObject(forKey: WPEWaterWavesTrace.defaultsKey)
+        #if DEBUG
+        captureIDs = []
+        #endif
         flagRefresh += 1
     }
 
     #if DEBUG
+    private func addCaptureID() {
+        let id = newCaptureID.trimmingCharacters(in: .whitespaces)
+        guard !id.isEmpty, !captureIDs.contains(id) else { return }
+        captureIDs.append(id)
+        UserDefaults.standard.set(captureIDs, forKey: "WPEMetalCaptureScene")
+        newCaptureID = ""
+    }
+
+    private func removeCaptureID(_ id: String) {
+        captureIDs.removeAll { $0 == id }
+        if captureIDs.isEmpty {
+            UserDefaults.standard.removeObject(forKey: "WPEMetalCaptureScene")
+        } else {
+            UserDefaults.standard.set(captureIDs, forKey: "WPEMetalCaptureScene")
+        }
+    }
+
+    private var gpuCaptureList: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(verbatim: "GPU capture scene IDs")
+                .font(.callout.weight(.medium))
+            Text(verbatim: "Scenes whose workshopID is listed get a Metal .gputrace (→ /tmp) plus output/texture PNG dumps (→ App Support/LiveWallpaper/gpu-traces/) on next load. Reload the wallpaper after editing.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if captureIDs.isEmpty {
+                Text(verbatim: "No scenes selected.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(captureIDs, id: \.self) { id in
+                    HStack(spacing: 8) {
+                        Text(verbatim: id).monospaced()
+                        Spacer()
+                        Button(role: .destructive) {
+                            removeCaptureID(id)
+                        } label: {
+                            Image(systemName: "minus.circle.fill")
+                        }
+                        .buttonStyle(.borderless)
+                        .help(Text(verbatim: "Stop capturing this scene"))
+                    }
+                }
+            }
+            HStack(spacing: 8) {
+                TextField("Workshop ID", text: $newCaptureID)
+                    .textFieldStyle(.roundedBorder)
+                    .disableAutocorrection(true)
+                    .frame(maxWidth: 200)
+                    .onSubmit { addCaptureID() }
+                Button {
+                    addCaptureID()
+                } label: {
+                    Label("Add", systemImage: "plus")
+                }
+                .disabled(newCaptureID.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+    }
+
     private func errorBanner(_ message: String) -> some View {
         Label(message, systemImage: "exclamationmark.triangle.fill")
             .foregroundStyle(.orange)

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Persistence/ResourceUtilities.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Persistence/ResourceUtilities.swift
@@ -33,7 +33,7 @@ public final class ResourceUtilities {
         if let data = tryBookmark(url, options: primaryOptions, keys: snapshotKeys) {
             return data
         }
-        Logger.warning(
+        Logger.info(
             "Bookmark step 1 (security-scope + resource keys) failed; retrying without resource keys",
             category: .fileAccess
         )

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Schema/GlobalSettings.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Schema/GlobalSettings.swift
@@ -57,11 +57,23 @@ public struct GlobalSettings: Codable, Sendable {
     /// independently checks its own file against this budget.
     public var videoCacheMaxBytesPerScreen: Int = GlobalSettings.defaultVideoCacheBytes
 
+    /// Default for `developerModeEnabled`: ON in DEBUG builds so the Developer
+    /// Tools surface is reachable during development without a manual opt-in,
+    /// OFF in Release so ordinary users never see it. An explicit, persisted
+    /// user choice still wins over this default (see the decoder below).
+    public static var defaultDeveloperModeEnabled: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+
     /// Pro-only runtime opt-in that surfaces the Developer Tools sidebar
     /// entry and enables `WKWebView.isInspectable` on every HTML wallpaper.
-    /// Persisted so the choice survives relaunch; default `false` keeps the
-    /// diagnostic surface invisible to ordinary users.
-    public var developerModeEnabled: Bool = false
+    /// Persisted so the choice survives relaunch; defaults on in DEBUG and off
+    /// in Release via `defaultDeveloperModeEnabled`.
+    public var developerModeEnabled: Bool = GlobalSettings.defaultDeveloperModeEnabled
 
     /// Pro-only master switch for audio-reactive wallpapers. When true, the app
     /// captures system audio output (Core Audio process tap) so audio-reactive
@@ -110,7 +122,7 @@ public struct GlobalSettings: Codable, Sendable {
         deletedWorkshopIDs: [String] = [],
         applicationPerformanceRules: [ApplicationPerformanceRule] = [],
         videoCacheMaxBytesPerScreen: Int = GlobalSettings.defaultVideoCacheBytes,
-        developerModeEnabled: Bool = false,
+        developerModeEnabled: Bool = GlobalSettings.defaultDeveloperModeEnabled,
         audioResponseEnabled: Bool = false
     ) {
         self.globalPauseOnBattery = globalPauseOnBattery
@@ -150,7 +162,7 @@ public struct GlobalSettings: Codable, Sendable {
         applicationPerformanceRules = (try? c.decodeIfPresent([ApplicationPerformanceRule].self, forKey: .applicationPerformanceRules)) ?? []
         let storedCache = (try? c.decodeIfPresent(Int.self, forKey: .videoCacheMaxBytesPerScreen)) ?? GlobalSettings.defaultVideoCacheBytes
         videoCacheMaxBytesPerScreen = GlobalSettings.clampedVideoCacheBytes(storedCache)
-        developerModeEnabled = (try? c.decodeIfPresent(Bool.self, forKey: .developerModeEnabled)) ?? false
+        developerModeEnabled = (try? c.decodeIfPresent(Bool.self, forKey: .developerModeEnabled)) ?? GlobalSettings.defaultDeveloperModeEnabled
         audioResponseEnabled = (try? c.decodeIfPresent(Bool.self, forKey: .audioResponseEnabled)) ?? false
     }
 }

--- a/Packages/LiveWallpaperProFeatures/Sources/LiveWallpaperProFeatures/SystemMonitor/SystemMonitor.swift
+++ b/Packages/LiveWallpaperProFeatures/Sources/LiveWallpaperProFeatures/SystemMonitor/SystemMonitor.swift
@@ -197,7 +197,7 @@ public final class SystemMonitor {
         if isLow != isMemoryLow {
             isMemoryLow = isLow
             if isLow {
-                Logger.warning("System memory usage is high: \(Int(systemMemoryUsage * 100))%", category: .memory)
+                Logger.notice("System memory usage is high: \(Int(systemMemoryUsage * 100))%", category: .memory)
                 NotificationCenter.default.post(
                     name: .systemMemoryWarning,
                     object: nil,


### PR DESCRIPTION
Cleanup pass over the debug/logging surface.

- **Log-level hygiene**: ~31 normal-path `Logger.warning` calls downgraded to `.info`/`.notice` so the persistent `runtime.log` stays signal-dense (genuine problems still log at warning).
- **Diagnostics UI**: retired the stale waterwaves debug controls, replaced the broken "Capture scene textures" bool toggle with an editable GPU-capture **scene-ID list** (single-string `defaults write WPEMetalCaptureScene <id>` still honored), and `#if DEBUG`-gated three toggles whose behavior is DEBUG-only.
- **Pro Release fix**: that gating also fixes a pre-existing Release compile break — `DeveloperToolsView` referenced `#if DEBUG`-only corpus types unconditionally, so the Corpus Test tab is now DEBUG-gated.
- **scene-debug** dir capped at 40 sessions / 512 MiB.
- **Developer Mode** now defaults ON in Debug, OFF in Release (explicit user choice still wins).

Verified: `LiveWallpaper` builds clean in both Debug and Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)