### PR TITLE
WPE runtime oracle: cross-device divergence pipeline (Phase 0–B + D-1 contract)

### DIFF
--- a/LiveWallpaper/Runtime/WPECanonicalTraceRecorder.swift
+++ b/LiveWallpaper/Runtime/WPECanonicalTraceRecorder.swift
@@ -1,0 +1,553 @@
+#if !LITE_BUILD && DEBUG
+import CryptoKit
+import Foundation
+import Metal
+
+/// DEBUG-only accumulator that mirrors the Windows RenderDoc oracle into the
+/// shared `wpe.trace.v1` schema from the Mac Metal path.
+///
+/// The recorder is fed from the existing scene-debug hooks (not `.gputrace`):
+/// the Swift render path still carries semantic names for passes, materials,
+/// samplers, uniforms, texture fallbacks, and render targets — exactly what the
+/// divergence engine needs to align against the Windows ground truth.
+///
+/// One `mac/trace.json` is written per scene load: passes accumulate during the
+/// first rendered frame, then `finishFrame` serialises once and latches so the
+/// live render loop never re-accumulates.
+final class WPECanonicalTraceRecorder {
+    static let shared = WPECanonicalTraceRecorder()
+
+    struct TextureBindingInput {
+        let slot: Int
+        let name: String?
+        let reference: WPETextureReference?
+        let texture: MTLTexture?
+        let fallbackToPrimary: Bool
+    }
+
+    private let lock = NSLock()
+    private var scene: SceneContext?
+    private var frameComplete = false
+    private var passes: [[String: Any]] = []
+    private var resources: ResourceTables = ResourceTables()
+
+    private init() {}
+
+    func beginScene(workshopID: String, projectJsonPath: String?, descriptor: String) {
+        guard WPESceneDebugArtifacts.shared.isEnabled else { return }
+        lock.lock()
+        scene = SceneContext(workshopID: workshopID, projectJsonPath: projectJsonPath, descriptor: descriptor)
+        frameComplete = false
+        passes.removeAll(keepingCapacity: true)
+        resources = ResourceTables()
+        lock.unlock()
+    }
+
+    func recordCustomPass(
+        pass: WPEPreparedRenderPass,
+        destination: (id: WPEMetalTargetID, texture: MTLTexture),
+        result: WPEShaderCompileResult,
+        textureBindings: [TextureBindingInput],
+        packedUniformSlots: [SIMD4<Float>],
+        usesObjectQuad: Bool
+    ) {
+        guard WPESceneDebugArtifacts.shared.isEnabled else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        guard scene != nil, !frameComplete else { return }
+
+        let ordinal = passes.count
+        let target = destination.id
+        let targetTexture = destination.texture
+        let targetResource = renderTargetResourceID(target)
+        let fragmentShaderID = shaderID(stage: "fs", stableInput: result.mslSource)
+        let vertexShaderID = shaderID(stage: "vs", stableInput: result.vertexFunctionName)
+        let packedBytes = packedUniformBytes(packedUniformSlots)
+        let bufferResource = "buf-mac-pass-\(ordinal)"
+
+        resources.renderTargets[targetResource] = renderTargetResource(target: target, texture: targetTexture, ordinal: ordinal)
+        resources.buffers[bufferResource] = [
+            "label": "Mac flat uniform slots pass \(ordinal)",
+            "byteLength": packedBytes.count,
+            "sha256": sha256Hex(packedBytes)
+        ]
+        resources.shaders[fragmentShaderID] = shaderResource(
+            stage: "fragment",
+            entryPoint: result.fragmentFunctionName,
+            source: result.mslSource,
+            path: "msl-\(pass.pass.id)-\(pass.pass.shader).metal",
+            layout: result.uniformLayout,
+            samplers: result.samplerNames
+        )
+        resources.shaders[vertexShaderID] = shaderResource(
+            stage: "vertex",
+            entryPoint: result.vertexFunctionName,
+            source: result.vertexFunctionName,
+            path: nil,
+            layout: [],
+            samplers: []
+        )
+
+        var textures: [[String: Any]] = []
+        for binding in textureBindings.sorted(by: { $0.slot < $1.slot }) {
+            let texID = textureResourceID(texture: binding.texture, fallbackKey: "\(ordinal)-\(binding.slot)")
+            resources.textures[texID] = textureResource(
+                id: texID, name: binding.name, reference: binding.reference, texture: binding.texture
+            )
+            textures.append([
+                "stage": "fragment",
+                "slot": binding.slot,
+                "name": jsonOrNull(binding.name),
+                "resource": texID,
+                "reference": jsonOrNull(Self.describe(reference: binding.reference)),
+                "fallback": binding.fallbackToPrimary,
+                "width": jsonOrNull(binding.texture?.width),
+                "height": jsonOrNull(binding.texture?.height),
+                "format": jsonOrNull(binding.texture.map { pixelFormatName($0.pixelFormat) })
+            ])
+        }
+
+        let draw: [String: Any] = [
+            "topology": usesObjectQuad ? "object-quad" : "fullscreen-quad",
+            "vertexCount": 4,
+            "indexCount": NSNull(),
+            "instanceCount": 1,
+            "viewport": [0, 0, Double(targetTexture.width), Double(targetTexture.height), 0, 1] as [Double],
+            "scissor": [Double]()
+        ]
+        let colorTargets: [[String: Any]] = [[
+            "slot": 0,
+            "resource": targetResource,
+            "load": NSNull(),
+            "store": "store",
+            "target": describe(target: target)
+        ]]
+        let constantBuffer: [String: Any] = [
+            "name": "mac_flat_slots",
+            "stage": "fragment",
+            "slot": 0,
+            "resource": bufferResource,
+            "rawBytesSha256": sha256Hex(packedBytes),
+            "variables": uniformVariables(layout: result.uniformLayout, slots: packedUniformSlots),
+            "packedSlots": packedUniformSlots.map { [Double($0.x), Double($0.y), Double($0.z), Double($0.w)] }
+        ]
+        let samplers: [[String: Any]] = result.samplerNames.enumerated().map { index, name in
+            ["stage": "fragment", "slot": index, "name": name]
+        }
+        let state: [String: Any] = [
+            "blend": NSNull(),
+            "depth": NSNull(),
+            "raster": NSNull(),
+            "samplers": samplers
+        ]
+        let output: [String: Any] = [
+            "resource": targetResource,
+            "png": NSNull(),
+            "sha256": NSNull(),
+            "visualStats": ["note": "Per-pass RT hash filled from scenePassDumps when WPEDumpScenePasses captured this pass."]
+        ]
+        let passRecord: [String: Any] = [
+            "ordinal": ordinal,
+            "eventId": NSNull(),
+            "layerId": jsonOrNull(layerID(forPassID: pass.pass.id)),
+            "passId": pass.pass.id,
+            "shaderName": pass.pass.shader,
+            "draw": draw,
+            "targets": ["color": colorTargets, "depth": NSNull()] as [String: Any],
+            "textures": textures,
+            "shaders": ["vs": vertexShaderID, "fs": fragmentShaderID],
+            "constantBuffers": [constantBuffer],
+            "state": state,
+            "output": output
+        ]
+        passes.append(passRecord)
+    }
+
+    /// Best-effort: fill per-pass output hashes from the scene-target snapshots
+    /// the executor collected. Only populated when `WPEDumpScenePasses` is on and
+    /// this runs before `finishFrame` latches the trace.
+    func recordPassOutputs(_ entries: [(label: String, texture: MTLTexture)]) {
+        guard WPESceneDebugArtifacts.shared.isEnabled else { return }
+        lock.lock()
+        let shouldRecord = !frameComplete
+        lock.unlock()
+        guard shouldRecord else { return }
+
+        // Read back + hash OUTSIDE the lock: getBytes on a scene-pass snapshot is
+        // expensive and must never block recordCustomPass on the render thread.
+        let hashed: [(label: String, sha256: String, visualStats: [String: Any])] = entries.compactMap { entry in
+            guard let metrics = textureMetrics(entry.texture) else { return nil }
+            return (entry.label, metrics.sha256, metrics.visualStats)
+        }
+        guard !hashed.isEmpty else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+        guard !frameComplete else { return }
+        for item in hashed {
+            // Match the first still-unhashed pass with this id, so repeated pass
+            // ids (e.g. ping-pong blur) fill in draw order instead of colliding.
+            guard let index = passes.firstIndex(where: {
+                ($0["passId"] as? String) == item.label
+                    && (($0["output"] as? [String: Any])?["sha256"] is NSNull)
+            }) else { continue }
+            var record = passes[index]
+            var output = record["output"] as? [String: Any] ?? [:]
+            output["sha256"] = item.sha256
+            output["visualStats"] = item.visualStats
+            record["output"] = output
+            passes[index] = record
+        }
+    }
+
+    func finishFrame(
+        outputTexture: MTLTexture,
+        runtimeUniforms: WPEMetalRuntimeUniforms?,
+        firstFrameStats: WPEMetalTextureVisualStats?,
+        resolutionDiagnostics: WPEResolutionDiagnosticsSnapshot
+    ) {
+        guard WPESceneDebugArtifacts.shared.isEnabled else { return }
+        lock.lock()
+        guard let scene, !frameComplete else { lock.unlock(); return }
+        frameComplete = true
+        let passSnapshot = passes
+        let resourceSnapshot = resources
+        lock.unlock()
+
+        // Everything below runs WITHOUT the lock: the final-texture readback and
+        // JSON serialization must not stall a concurrent render-thread call.
+        let width = outputTexture.width
+        let height = outputTexture.height
+        let finalHash = textureMetrics(outputTexture)?.sha256
+        let missedRefs = resolutionDiagnostics.missedRefs
+
+        let producer: [String: Any] = [
+            "side": "mac-metal",
+            "tool": "WPECanonicalTraceRecorder",
+            "toolVersion": "1",
+            "wpeVersion": "2.8.26",
+            "appBuild": jsonOrNull(Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String)
+        ]
+        let assetRoots: [String] = scene.projectJsonPath.map { [URL(fileURLWithPath: $0).deletingLastPathComponent().path] } ?? []
+        let sceneBlock: [String: Any] = [
+            "workshopId": scene.workshopID,
+            "projectJson": scene.projectJsonPath ?? "",
+            "projectJsonSha256": jsonOrNull(scene.projectJsonPath.flatMap { sha256File(path: $0) }),
+            "entryFile": jsonOrNull(scene.projectJsonPath.map { URL(fileURLWithPath: $0).lastPathComponent }),
+            "assetRoots": assetRoots
+        ]
+        let determinism: [String: Any] = [
+            "time": jsonOrNull(runtimeUniforms?.time),
+            "daytime": jsonOrNull(runtimeUniforms?.daytime),
+            "pointer": [runtimeUniforms?.pointerPosition.x ?? 0.5, runtimeUniforms?.pointerPosition.y ?? 0.5] as [Double],
+            "audioMode": "zeroed",
+            "mouseParallax": "centered"
+        ]
+        let firstMisses: [[String: Any]] = missedRefs.prefix(16).map {
+            ["ref": $0.ref, "outcome": $0.finalOutcome.debugLabel]
+        }
+        let resolutionSummary: [String: Any] = [
+            "events": resolutionDiagnostics.events.count,
+            "resolved": resolutionDiagnostics.resolvedCount,
+            "missing": missedRefs.count,
+            "firstMisses": firstMisses
+        ]
+        let capture: [String: Any] = [
+            "jobId": scene.workshopID,
+            "mode": "shader-first",
+            "frameOrdinal": 0,
+            "resolution": ["width": width, "height": height],
+            "wallpaperWindow": ["class": "MTKView", "hwnd": NSNull(), "pid": NSNull()] as [String: Any],
+            "determinism": determinism,
+            "resolutionSummary": resolutionSummary,
+            "descriptor": scene.descriptor
+        ]
+        let renderTargets: [String: [String: Any]] = resourceSnapshot.renderTargets.isEmpty
+            ? ["rt-scene": [
+                "label": "scene", "width": width, "height": height,
+                "format": pixelFormatName(outputTexture.pixelFormat), "lineage": [String]()
+            ]]
+            : resourceSnapshot.renderTargets
+        let resourceBlock: [String: Any] = [
+            "textures": resourceSnapshot.textures,
+            "renderTargets": renderTargets,
+            "buffers": resourceSnapshot.buffers,
+            "shaders": resourceSnapshot.shaders
+        ]
+        let finalBlock: [String: Any] = [
+            "resource": "rt-scene",
+            "png": NSNull(),
+            "sha256": jsonOrNull(finalHash),
+            "visualStats": firstFrameStats.map(Self.visualStats) ?? NSNull()
+        ]
+        let trace: [String: Any] = [
+            "schema": "wpe.trace.v1",
+            "producer": producer,
+            "scene": sceneBlock,
+            "capture": capture,
+            "resources": resourceBlock,
+            "passes": passSnapshot,
+            "final": finalBlock
+        ]
+        let passCount = passSnapshot.count
+
+        guard JSONSerialization.isValidJSONObject(trace),
+              let data = try? JSONSerialization.data(withJSONObject: trace, options: [.prettyPrinted, .sortedKeys]),
+              let text = String(data: data, encoding: .utf8) else {
+            WPESceneDebugArtifacts.shared.appendLog("[canonical-trace] trace.json serialization failed", level: .error)
+            return
+        }
+        WPESceneDebugArtifacts.shared.recordNote(name: "trace.json", contents: text)
+        WPESceneDebugArtifacts.shared.appendLog("[canonical-trace] wrote trace.json passes=\(passCount)", level: .info)
+    }
+
+    // MARK: - Description helpers (mirror WPESceneDebugArtifacts)
+
+    static func describe(reference: WPETextureReference?) -> String? {
+        guard let reference else { return nil }
+        switch reference {
+        case .image(let path): return "image(\(path))"
+        case .asset(let path): return "asset(\(path))"
+        case .fbo(let name): return "fbo(\(name))"
+        case .previous: return "previous"
+        }
+    }
+
+    private func describe(target: WPEMetalTargetID) -> String {
+        switch target {
+        case .scene: return "scene"
+        case .named(let name): return name
+        }
+    }
+
+    private func renderTargetResourceID(_ target: WPEMetalTargetID) -> String {
+        switch target {
+        case .scene: return "rt-scene"
+        case .named(let name): return "rt-\(safeID(name))"
+        }
+    }
+
+    // MARK: - Resource builders
+
+    private func shaderResource(
+        stage: String, entryPoint: String, source: String,
+        path: String?, layout: [WPEUniformSlot], samplers: [String]
+    ) -> [String: Any] {
+        let sourceHash = sha256Hex(Data(source.utf8))
+        let reflectionSamplers: [[String: Any]] = samplers.enumerated().map { index, name in
+            ["name": name, "slot": index, "type": "SAMPLER"]
+        }
+        let reflectionTextures: [[String: Any]] = samplers.enumerated().map { index, name in
+            ["name": name, "slot": index, "type": "TEXTURE"]
+        }
+        let constantBlocks: [[String: Any]] = layout.isEmpty ? [] : [["name": "mac_flat_slots", "slot": 0, "type": "CBUFFER"]]
+        let uniforms: [[String: Any]] = layout.map { slot in
+            [
+                "name": slot.name,
+                "type": slot.glslType,
+                "slot": slot.slot,
+                "slotCount": slot.slotCount,
+                "startOffset": slot.slot * MemoryLayout<SIMD4<Float>>.stride,
+                "arrayLength": jsonOrNull(slot.arrayLength),
+                "materialName": jsonOrNull(slot.materialName)
+            ]
+        }
+        let reflection: [String: Any] = [
+            "samplers": reflectionSamplers,
+            "textures": reflectionTextures,
+            "constantBlocks": constantBlocks,
+            "uniforms": uniforms
+        ]
+        return [
+            "stage": stage,
+            "sourceLanguage": "MSL",
+            "entryPoint": entryPoint,
+            "sourcePath": jsonOrNull(path),
+            "sourceSha256": sourceHash,
+            "disassembly": ["path": jsonOrNull(path), "sha256": sourceHash] as [String: Any],
+            "reflection": reflection
+        ]
+    }
+
+    private func uniformVariables(layout: [WPEUniformSlot], slots: [SIMD4<Float>]) -> [[String: Any]] {
+        layout.map { uniform in
+            let floats: [Double] = (0..<max(uniform.slotCount, 0)).flatMap { offset -> [Double] in
+                let index = uniform.slot + offset
+                guard slots.indices.contains(index) else { return [] }
+                let v = slots[index]
+                return [Double(v.x), Double(v.y), Double(v.z), Double(v.w)]
+            }
+            var variable: [String: Any] = [
+                "name": uniform.name,
+                "type": uniform.glslType,
+                "slot": uniform.slot,
+                "slotCount": uniform.slotCount,
+                "arrayLength": jsonOrNull(uniform.arrayLength),
+                "materialName": jsonOrNull(uniform.materialName),
+                "rawSlotFloats": floats
+            ]
+            switch uniform.glslType {
+            case "float", "int", "bool":
+                variable["value"] = jsonOrNull(floats.first)
+            case "vec2": variable["value"] = Array(floats.prefix(2))
+            case "vec3": variable["value"] = Array(floats.prefix(3))
+            case "vec4": variable["value"] = Array(floats.prefix(4))
+            case "mat4":
+                let m = Array(floats.prefix(16))
+                variable["value"] = m
+                if m.count == 16 {
+                    variable["matrix4x4"] = m
+                    variable["matrixMajor"] = "row"
+                }
+            default:
+                variable["value"] = floats
+            }
+            return variable
+        }
+    }
+
+    private func textureResource(id: String, name: String?, reference: WPETextureReference?, texture: MTLTexture?) -> [String: Any] {
+        [
+            "label": name ?? Self.describe(reference: reference) ?? id,
+            "sourcePath": jsonOrNull(Self.describe(reference: reference)),
+            "width": jsonOrNull(texture?.width),
+            "height": jsonOrNull(texture?.height),
+            "format": jsonOrNull(texture.map { pixelFormatName($0.pixelFormat) }),
+            "mips": jsonOrNull(texture?.mipmapLevelCount),
+            "sha256": NSNull(),
+            "png": NSNull()
+        ]
+    }
+
+    private func renderTargetResource(target: WPEMetalTargetID, texture: MTLTexture, ordinal: Int) -> [String: Any] {
+        [
+            "label": describe(target: target),
+            "width": texture.width,
+            "height": texture.height,
+            "format": pixelFormatName(texture.pixelFormat),
+            "lineage": ["pass-\(String(format: "%04d", ordinal))"]
+        ]
+    }
+
+    // MARK: - Texture metrics (best-effort, post-commit only)
+
+    private func textureMetrics(_ texture: MTLTexture) -> (sha256: String, visualStats: [String: Any])? {
+        guard let data = rgba8Bytes(texture) else { return nil }
+        let stats = WPEMetalTextureVisualStats.analyze(texture: texture)
+        let pixels = max(texture.width * texture.height, 1)
+        let visualStats: [String: Any] = [
+            "coverage": jsonOrNull(stats.map { Double($0.nonBlackPixelCount) / Double(pixels) }),
+            "meanRGBA": NSNull(),
+            "width": texture.width,
+            "height": texture.height,
+            "nonBlackPixelCount": jsonOrNull(stats?.nonBlackPixelCount),
+            "nonTransparentPixelCount": jsonOrNull(stats?.nonTransparentPixelCount)
+        ]
+        return (sha256Hex(data), visualStats)
+    }
+
+    private static func visualStats(_ stats: WPEMetalTextureVisualStats) -> [String: Any] {
+        [
+            "coverage": Double(stats.nonBlackPixelCount) / Double(max(stats.width * stats.height, 1)),
+            "meanRGBA": NSNull(),
+            "width": stats.width,
+            "height": stats.height,
+            "nonBlackPixelCount": stats.nonBlackPixelCount,
+            "nonTransparentPixelCount": stats.nonTransparentPixelCount,
+            "nonBlackCoversFullFrame": stats.nonBlackCoversFullFrame
+        ]
+    }
+
+    private func rgba8Bytes(_ texture: MTLTexture) -> Data? {
+        // 4-byte RGBA/BGRA unorm only. Channel order does not matter for the hash
+        // (it is self-consistent across Mac runs); HDR/float RTs are skipped.
+        switch texture.pixelFormat {
+        case .rgba8Unorm, .rgba8Unorm_srgb, .bgra8Unorm, .bgra8Unorm_srgb:
+            break
+        default:
+            return nil
+        }
+        // getBytes is only valid for CPU-visible storage. Reading a private or
+        // managed texture directly would return stale/garbage bytes on a discrete
+        // GPU, so skip (and log) rather than hashing nonsense.
+        guard texture.storageMode == .shared else {
+            WPESceneDebugArtifacts.shared.appendLog(
+                "[canonical-trace] skipped getBytes for non-shared texture (storageMode=\(texture.storageMode.rawValue))",
+                level: .warning
+            )
+            return nil
+        }
+        let bytesPerRow = texture.width * 4
+        var bytes = [UInt8](repeating: 0, count: bytesPerRow * texture.height)
+        bytes.withUnsafeMutableBytes { ptr in
+            guard let base = ptr.baseAddress else { return }
+            texture.getBytes(
+                base,
+                bytesPerRow: bytesPerRow,
+                from: MTLRegionMake2D(0, 0, texture.width, texture.height),
+                mipmapLevel: 0
+            )
+        }
+        return Data(bytes)
+    }
+
+    // MARK: - Small helpers
+
+    private func packedUniformBytes(_ slots: [SIMD4<Float>]) -> Data {
+        var data = Data(capacity: slots.count * MemoryLayout<SIMD4<Float>>.stride)
+        for slot in slots {
+            for value in [slot.x, slot.y, slot.z, slot.w] {
+                withUnsafeBytes(of: value) { data.append(contentsOf: $0) }
+            }
+        }
+        return data
+    }
+
+    private func pixelFormatName(_ format: MTLPixelFormat) -> String { "\(format.rawValue)" }
+
+    private func layerID(forPassID passID: String) -> String? {
+        guard let prefix = passID.split(separator: ".").first.map(String.init), prefix != passID else { return nil }
+        return prefix
+    }
+
+    private func shaderID(stage: String, stableInput: String) -> String {
+        "shader-\(stage)-\(sha256Hex(Data(stableInput.utf8)).prefix(16))"
+    }
+
+    private func textureResourceID(texture: MTLTexture?, fallbackKey: String) -> String {
+        guard let texture else { return "tex-missing-\(safeID(fallbackKey))" }
+        return "tex-\(UInt(bitPattern: ObjectIdentifier(texture).hashValue))"
+    }
+
+    private func safeID(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        return value.unicodeScalars.map { allowed.contains($0) ? String($0) : "_" }.joined()
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func sha256File(path: String) -> String? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+        return sha256Hex(data)
+    }
+
+    /// JSON-safe value: `NSNull` when `nil`, otherwise the wrapped value.
+    private func jsonOrNull<T>(_ value: T?) -> Any { value ?? NSNull() }
+    private static func jsonOrNull<T>(_ value: T?) -> Any { value ?? NSNull() }
+
+    private struct SceneContext {
+        let workshopID: String
+        let projectJsonPath: String?
+        let descriptor: String
+    }
+
+    private struct ResourceTables {
+        var textures: [String: [String: Any]] = [:]
+        var renderTargets: [String: [String: Any]] = [:]
+        var buffers: [String: [String: Any]] = [:]
+        var shaders: [String: [String: Any]] = [:]
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -250,6 +250,13 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             workshopID: descriptor.workshopID,
             descriptor: descriptorSummary
         )
+        #if !LITE_BUILD && DEBUG
+        WPECanonicalTraceRecorder.shared.beginScene(
+            workshopID: descriptor.workshopID,
+            projectJsonPath: projectManifestRootURL?.appendingPathComponent(descriptor.entryFile).path,
+            descriptor: descriptorSummary
+        )
+        #endif
         WPESceneDebugArtifacts.shared.appendLog(
             "load() began for \(descriptorSummary)",
             level: .info
@@ -493,20 +500,32 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         capture?.stop()
 
         if let outputTexture {
+            // Capture per-pass scene-target RT hashes BEFORE finishFrame latches
+            // and serializes the trace — otherwise recordPassOutputs runs after the
+            // trace is already written and the per-pass output hashes are dropped.
+            #if DEBUG
+            dumpScenePassesIfRequested()
+            #endif
             // The snapshot + visual-stats read-backs exist only to feed the
             // scene-debug artifacts (first-frame PNG + stats). The inspector
             // now shows the project's preview GIF, so skip the synchronous GPU
             // read-back entirely unless artifacts are actually being captured.
             if WPESceneDebugArtifacts.shared.isEnabled {
                 cachedSnapshot = snapshotter.snapshot(from: outputTexture)
-                if let stats = WPEMetalTextureVisualStats.analyze(texture: outputTexture) {
+                let stats = WPEMetalTextureVisualStats.analyze(texture: outputTexture)
+                if let stats {
                     WPESceneDebugArtifacts.shared.recordFirstFrameStats(stats)
                 }
+                #if !LITE_BUILD && DEBUG
+                WPECanonicalTraceRecorder.shared.finishFrame(
+                    outputTexture: outputTexture,
+                    runtimeUniforms: lastRuntimeUniforms,
+                    firstFrameStats: stats,
+                    resolutionDiagnostics: resolutionTracer.snapshot()
+                )
+                #endif
             }
             dumpOutputTextureIfRequested(outputTexture)
-            #if DEBUG
-            dumpScenePassesIfRequested()
-            #endif
         }
         hasPresentedFrame = true
         didLoad = true
@@ -549,6 +568,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             "[WPEDumpScenePasses] dumping \(dumps.count) scene-target passes\(suffix.isEmpty ? " (t0)" : " \(suffix)") for \(descriptor.workshopID)",
             category: .wpeRender
         )
+        #if !LITE_BUILD && DEBUG
+        WPECanonicalTraceRecorder.shared.recordPassOutputs(dumps)
+        #endif
         for (index, entry) in dumps.enumerated() {
             let safeLabel = entry.label
                 .replacingOccurrences(of: "/", with: "_")

--- a/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
+++ b/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
@@ -736,6 +736,28 @@ struct WPEMetalShaderDispatcher {
         depthPixelFormat: MTLPixelFormat
     ) throws {
         let result = try executor.compileCustomShader(for: pass)
+        // Dev-only: dump every transpiled layer's MSL + uniform/sampler interface
+        // so it can be cross-checked against the Windows RenderDoc oracle
+        // (tools/wpe-oracle shader-interface.md). No-op unless scene-debug is on.
+        if WPESceneDebugArtifacts.shared.isEnabled {
+            WPESceneDebugArtifacts.shared.recordNoteOnce(
+                name: "msl-\(pass.pass.id)-\(pass.pass.shader).metal",
+                contents: result.mslSource
+            )
+            var iface = "shader=\(pass.pass.shader) pass=\(pass.pass.id)\n"
+            iface += "vertexFunction=\(result.vertexFunctionName)\n"
+            iface += "fragmentFunction=\(result.fragmentFunctionName)\n"
+            iface += "samplerNames=\(result.samplerNames)\n"
+            iface += "uniformLayout (name | glslType | slot | slotCount | arrayLength | material):\n"
+            for slot in result.uniformLayout {
+                iface += "  \(slot.name) | \(slot.glslType) | \(slot.slot) | \(slot.slotCount)"
+                    + " | \(slot.arrayLength.map(String.init) ?? "-") | \(slot.materialName ?? "-")\n"
+            }
+            WPESceneDebugArtifacts.shared.recordNoteOnce(
+                name: "iface-\(pass.pass.id)-\(pass.pass.shader).txt",
+                contents: iface
+            )
+        }
         let usesObjectQuad = executor.usesObjectQuadGeometry(for: pass, layer: layer, cameraParallax: frameState.cameraParallax)
         let isWaveLikePass = Self.isWaveLikePass(pass)
         let isWaterWavesPass = Self.isWaterWavesPass(pass)

--- a/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
+++ b/LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift
@@ -779,6 +779,9 @@ struct WPEMetalShaderDispatcher {
 
         var primary: MTLTexture? = nil
         var resolvedTexturesBySlot: [Int: MTLTexture] = [:]
+        #if !LITE_BUILD && DEBUG
+        var canonicalTextureBindings: [WPECanonicalTraceRecorder.TextureBindingInput] = []
+        #endif
         for slot in 0..<WPEShaderTranspiler.customTextureSlotCount {
             // `textureBindings` is the pipeline-builder's *normalized* binding
             // table: it already rewrites an effect-bind `previous` to the pass's
@@ -831,6 +834,15 @@ struct WPEMetalShaderDispatcher {
             if let texture {
                 resolvedTexturesBySlot[slot] = texture
             }
+            #if !LITE_BUILD && DEBUG
+            canonicalTextureBindings.append(WPECanonicalTraceRecorder.TextureBindingInput(
+                slot: slot,
+                name: result.samplerNames.indices.contains(slot) ? result.samplerNames[slot] : nil,
+                reference: resolvedReference,
+                texture: texture,
+                fallbackToPrimary: fallbackToPrimary
+            ))
+            #endif
         }
 
         var packedUniformSlots: [SIMD4<Float>] = []
@@ -842,6 +854,16 @@ struct WPEMetalShaderDispatcher {
                 destinationTexture: usesObjectQuad ? (primary ?? destination.texture) : destination.texture
             )
         }
+        #if !LITE_BUILD && DEBUG
+        WPECanonicalTraceRecorder.shared.recordCustomPass(
+            pass: pass,
+            destination: destination,
+            result: result,
+            textureBindings: canonicalTextureBindings,
+            packedUniformSlots: packedUniformSlots,
+            usesObjectQuad: usesObjectQuad
+        )
+        #endif
 
         // Phase A: log the GPU-bound uniforms for waterwaves passes so the live values
         // (g_Time/g_Speed/g_Scale/g_Direction/g_Strength/g_Texture1Resolution) can be

--- a/tools/wpe-oracle/.gitattributes
+++ b/tools/wpe-oracle/.gitattributes
@@ -1,0 +1,2 @@
+# cmd.exe requires CRLF line endings; everything else stays LF.
+*.cmd text eol=crlf

--- a/tools/wpe-oracle/.gitignore
+++ b/tools/wpe-oracle/.gitignore
@@ -1,0 +1,9 @@
+# WPE Runtime Oracle — local-only capture artifacts. Never commit binary
+# dumps or captured WPE/workshop assets (see README "Notes").
+captures/
+jobs/
+*.rdc
+*.png
+*.dxbc.txt
+__pycache__/
+*.pyc

--- a/tools/wpe-oracle/README.md
+++ b/tools/wpe-oracle/README.md
@@ -1,15 +1,17 @@
-# WPE Runtime Oracle: Windows Shader-First Capture Kit
+# WPE Runtime Oracle: Windows ↔ Mac divergence kit
 
-This is the minimal first slice only:
+Cross-device pipeline that aligns Wallpaper Engine's real D3D11 frame (Windows
+ground truth) against our Metal renderer and pinpoints where they diverge:
 
-- shared `wpe.trace.v1` contract
-- Windows RenderDoc capture + headless `renderdoccmd convert`
-- Mac-side stdlib parser (`parse_capture.py`) for `frame.zip.xml` + blobs
-- no Mac Swift exporter
-- no diff engine
-- no HTML report
+- shared `wpe.trace.v1` contract (both producers)
+- **Windows producer**: RenderDoc capture + headless `renderdoccmd convert` + Mac-side stdlib parser (`parse_capture.py`) → `windows/trace.json`
+- **Mac producer** (Phase A): `WPECanonicalTraceRecorder.swift` emits `mac/trace.json` from the live Metal scene-debug path
+- **Diff engine** (Phase B): `diff_traces.py` DP-aligns the two pass lists, normalizes uniforms by name, and buckets the first real divergence → `diff/divergence-summary.json` (`wpe.diff.v1`)
+- not yet: corpus orchestration (Phase C), extra fidelity tools (Phase D), HTML report / in-app panel (Phase E)
 
-The stop-loss is intentional: first validate that RenderDoc can see Wallpaper Engine's WorkerW desktop-wallpaper D3D11 path.
+Scope is structure / uniform / topology / texture-binding / RT-lineage diffing.
+Per-pass perceptual (SSIM/ΔE) diff is deferred (the convert path has no WPE RT
+readback); Mac per-pass RT hashes are best-effort placeholders for it.
 
 ## Requirements
 
@@ -27,6 +29,7 @@ No scheduled task is used. No `-ExecutionPolicy Bypass` is used. `run_once.cmd` 
 - `run_once.cmd`: user-launched Windows capture entry → `renderdoccmd convert` → `frame.zip.xml` + `frame.zip`.
 - `parse_capture.py`: Mac stdlib parser; turns the convert output into `trace.json` + `shader-interface.md`.
 - `extract_renderdoc_trace.py`: retained ONLY as a qrenderdoc GUI Python-shell alternative. RenderDoc 1.44 has no standalone `renderdoc` module and no `renderdoccmd python`, so it cannot run headless.
+- `diff_traces.py`: Mac stdlib diff engine; aligns `windows/trace.json` ↔ `mac/trace.json` and writes `diff/divergence-summary.json` (`wpe.diff.v1`). The Mac trace is produced on-device by `WPECanonicalTraceRecorder` (DEBUG builds) into the scene-debug session folder.
 - `job.example.json`: seed job for scene `3526278753`.
 
 Artifacts are written under:
@@ -87,6 +90,35 @@ python3 tools/wpe-oracle/parse_capture.py \
 ```
 
 This emits `windows/trace.json` (wpe.trace.v1) + `windows/shader-interface.md`.
+
+## Divergence Diff (Phase B)
+
+The Mac producer runs on-device: a DEBUG build with scene-debug artifacts
+enabled (`defaults write Taijia.LiveWallpaper WPESceneDebugArtifactsEnabled -bool YES`,
+then relaunch) writes `trace.json` into each scene-debug session folder
+(`~/Library/Containers/Taijia.LiveWallpaper/Data/Library/Application Support/LiveWallpaper/scene-debug/<stamp>-<id>/`).
+Copy it next to the Windows trace as `mac/trace.json`, then diff:
+
+```bash
+python3 tools/wpe-oracle/diff_traces.py \
+  --windows tools/wpe-oracle/captures/<jobId>/windows/trace.json \
+  --mac     tools/wpe-oracle/captures/<jobId>/mac/trace.json \
+  --out     tools/wpe-oracle/captures/<jobId>/diff/divergence-summary.json
+```
+
+`divergence-summary.json` (`wpe.diff.v1`) carries: `status`, `primaryBucket`
+(transpiler / FBO / asset / puppet+particle), `firstDivergence` (with a
+`pinpoint` naming the exact pass / uniform / texture and a `responsibleSite`
+code path), the full pass `alignment` (deletions = passes only WPE drew, e.g.
+particle `POINTLIST`), per-pass `passes[].status` (matched / diverged /
+unverified-cascade / skipped_on_mac), and `bucketHistogram`. Uniform-packing
+differences (WPE `g_bufStatic`/`g_bufDynamic` split vs our flat slot array) are
+reconciled by name and reported in `normalizationNotes`, not as divergence.
+
+> Coverage note: the recorder traces custom-shader passes (the effect chain).
+> The base-image `genericimage4` draw goes through a non-custom path and is not
+> yet captured, so the diff reports it as a `missing-wpe-pass` (transpiler
+> bucket) rather than a real rendering divergence.
 
 ## Mac to Windows Bridge
 
@@ -159,5 +191,5 @@ If RenderDoc cannot hook WorkerW/WPE at all, validate the path with Nsight Graph
 
 - Missing HLSL source is expected — WPE ships only DXBC. RDEF reflection (cbuffer layouts, resource/sampler bindings) + ISGN/OSGN signatures are the baseline, parsed by `parse_capture.py`.
 - The convert path has no GPU replay readback, so per-RT PNGs are intentionally absent; `output.png` is `null` in `trace.json`. (Replayed images need the qrenderdoc GUI.)
-- This first slice intentionally does not classify divergences.
-- Do not commit `.rdc`, `.zip`, `frame.zip.xml`, shader blobs, or captured WPE/workshop assets.
+- Divergence classification lives in `diff_traces.py` (Phase B); see "Divergence Diff" above.
+- Do not commit `.rdc`, `.zip`, `frame.zip.xml`, shader blobs, captured WPE/workshop assets, or `mac/`+`diff/` outputs.

--- a/tools/wpe-oracle/README.md
+++ b/tools/wpe-oracle/README.md
@@ -1,0 +1,148 @@
+# WPE Runtime Oracle: Windows Shader-First Capture Kit
+
+This is the minimal first slice only:
+
+- shared `wpe.trace.v1` contract
+- Windows RenderDoc shader-first capture/export
+- no Mac Swift exporter
+- no diff engine
+- no HTML report
+
+The stop-loss is intentional: first validate that RenderDoc can see Wallpaper Engine's WorkerW desktop-wallpaper D3D11 path.
+
+## Requirements
+
+- Windows interactive logon session. Do not run capture from SSH.
+- Wallpaper Engine 2.8.26 (default path `D:\Steam\steamapps\common\wallpaper_engine\`, or set `wpeRoot` in the job).
+- Workshop scenes at `D:\Steam\steamapps\workshop\content\431960\<id>\` (or set `workshopRoot` / `projectJson` in the job).
+- RenderDoc for Windows (v1.31+ recommended) installed.
+- Python available through RenderDoc's Python environment (`renderdoccmd python`) or a Python environment where `renderdoc` is importable.
+
+No scheduled task is used. No `-ExecutionPolicy Bypass` is used. `run_once.cmd` is a plain command script the user launches manually.
+
+## Files
+
+- `wpe-trace.schema.json`: JSON Schema draft 2020-12 for `wpe.trace.v1`.
+- `extract_renderdoc_trace.py`: RenderDoc replay exporter for `.rdc` files.
+- `run_once.cmd`: user-launched one-shot capture entry.
+- `job.example.json`: seed job for scene `3526278753`.
+
+Artifacts are written under:
+
+```text
+tools\wpe-oracle\captures\<jobId>\windows\
+  frame.rdc
+  trace.json
+  rt\*.png
+  shaders\*.dxbc.txt
+tools\wpe-oracle\captures\<jobId>\done.json
+```
+
+`captures/` can contain WPE assets, shader disassembly, and large `.rdc` files. Keep it gitignored and local.
+
+## Operator Flow
+
+1. Install RenderDoc on Windows.
+
+2. Copy a job, then edit the Steam paths inside it if Steam is not on `D:\`:
+
+```cmd
+cd tools\wpe-oracle
+mkdir jobs 2>nul
+copy job.example.json jobs\seed-3526278753-shader-first.json
+:: edit jobs\seed-3526278753-shader-first.json: wpeRoot / workshopRoot / projectJson
+```
+
+3. Launch from the Windows interactive desktop session:
+
+```cmd
+run_once.cmd jobs\seed-3526278753-shader-first.json
+```
+
+4. The script:
+
+- sets the process to per-monitor DPI aware v2 before reading screen geometry
+- centers the pointer
+- switches WPE to the scene via:
+
+```cmd
+wallpaper64.exe -control openWallpaper -file <project.json>
+```
+
+- warms up
+- tries RenderDoc capture
+- exports `windows\trace.json`, `rt\*.png`, and `shaders\*.dxbc.txt`
+- writes `done.json`
+
+## Mac to Windows Bridge
+
+SSH is only for job delivery and artifact retrieval. It must not attempt interactive capture.
+
+Example delivery (forward slashes parse most reliably over OpenSSH on Windows):
+
+```bash
+ssh Taijia@100.117.237.66 "mkdir D:/path/to/tools/wpe-oracle/jobs" 2>/dev/null
+scp tools/wpe-oracle/job.example.json Taijia@100.117.237.66:D:/path/to/tools/wpe-oracle/jobs/seed-3526278753-shader-first.json
+```
+
+Then the user manually runs `run_once.cmd` on Windows.
+
+Example retrieval:
+
+```bash
+scp -r Taijia@100.117.237.66:D:/path/to/tools/wpe-oracle/captures/seed-3526278753-shader-first ./captures/
+```
+
+## Feasibility Signal
+
+The key signal is in `done.json`:
+
+- `status=succeeded`, `hookMethod=launch-under`: RenderDoc saw WPE when launched under RenderDoc.
+- `status=succeeded`, `hookMethod=inject`: RenderDoc saw an already-running `wallpaper64.exe`.
+- `status=needs-ui`: CLI automation did not capture WPE. Use RenderDoc UI injection next.
+- `status=failed`: capture or extraction failed; inspect the console stdout/stderr and the `error` field in `done.json`. (Per-texture save failures additionally drop a `*.error.txt` beside the affected PNG.)
+
+The minimum useful success is:
+
+- `windows\trace.json` exists
+- `passes[]` is non-empty
+- `resources.shaders` contains DXBC disassembly paths
+- `constantBuffers[]` contains runtime values such as `g_Time` when reflection exposes them
+- `rt\*.png` contains at least one render target dump
+
+## Fallback Ladder
+
+1. **Launch-under-RenderDoc**
+
+Use when WPE is not already running or the job sets `"captureMethod": "launch-under"`.
+
+2. **Inject**
+
+Use when WPE is already running. The script tries `renderdoccmd inject` against the newest `wallpaper64.exe` PID.
+
+3. **RenderDoc UI**
+
+If CLI capture fails:
+
+- open RenderDoc in the interactive session
+- **File > Inject into Process**, search `wallpaper64.exe`, click **Inject**
+- once the wallpaper is visible, click **Capture Frame(s) Immediately** in the
+  connection panel (the windowless wallpaper has no focus, so the F12 hotkey
+  usually will not fire — use the UI button)
+- select the capture, **File > Save Capture As**, save it as
+  `captures\<jobId>\windows\frame.rdc`
+- rerun:
+
+```cmd
+run_once.cmd jobs\<jobId>.json extract-only
+```
+
+4. **Nsight Graphics**
+
+If RenderDoc cannot hook WorkerW/WPE at all, validate the path with Nsight Graphics on the NVIDIA RTX PRO 6000 machine before building any Mac-side trace or diff code.
+
+## Notes
+
+- Missing HLSL source is expected. DXBC disassembly and reflection are the baseline.
+- This first slice intentionally does not classify divergences.
+- Do not commit `.rdc`, PNGs, shader dumps, or captured WPE/workshop assets.

--- a/tools/wpe-oracle/README.md
+++ b/tools/wpe-oracle/README.md
@@ -3,7 +3,8 @@
 This is the minimal first slice only:
 
 - shared `wpe.trace.v1` contract
-- Windows RenderDoc shader-first capture/export
+- Windows RenderDoc capture + headless `renderdoccmd convert`
+- Mac-side stdlib parser (`parse_capture.py`) for `frame.zip.xml` + blobs
 - no Mac Swift exporter
 - no diff engine
 - no HTML report
@@ -15,30 +16,32 @@ The stop-loss is intentional: first validate that RenderDoc can see Wallpaper En
 - Windows interactive logon session. Do not run capture from SSH.
 - Wallpaper Engine 2.8.26 (default path `D:\Steam\steamapps\common\wallpaper_engine\`, or set `wpeRoot` in the job).
 - Workshop scenes at `D:\Steam\steamapps\workshop\content\431960\<id>\` (or set `workshopRoot` / `projectJson` in the job).
-- RenderDoc for Windows (v1.31+ recommended) installed.
-- Python available through RenderDoc's Python environment (`renderdoccmd python`) or a Python environment where `renderdoc` is importable.
+- RenderDoc for Windows (validated on v1.44) installed.
+- Python 3 on the Mac for `parse_capture.py` (stdlib only).
 
 No scheduled task is used. No `-ExecutionPolicy Bypass` is used. `run_once.cmd` is a plain command script the user launches manually.
 
 ## Files
 
 - `wpe-trace.schema.json`: JSON Schema draft 2020-12 for `wpe.trace.v1`.
-- `extract_renderdoc_trace.py`: RenderDoc replay exporter for `.rdc` files.
-- `run_once.cmd`: user-launched one-shot capture entry.
+- `run_once.cmd`: user-launched Windows capture entry → `renderdoccmd convert` → `frame.zip.xml` + `frame.zip`.
+- `parse_capture.py`: Mac stdlib parser; turns the convert output into `trace.json` + `shader-interface.md`.
+- `extract_renderdoc_trace.py`: retained ONLY as a qrenderdoc GUI Python-shell alternative. RenderDoc 1.44 has no standalone `renderdoc` module and no `renderdoccmd python`, so it cannot run headless.
 - `job.example.json`: seed job for scene `3526278753`.
 
 Artifacts are written under:
 
 ```text
 tools\wpe-oracle\captures\<jobId>\windows\
-  frame.rdc
-  trace.json
-  rt\*.png
-  shaders\*.dxbc.txt
+  frame.rdc            (Windows; the raw capture)
+  frame.zip.xml        (Windows; renderdoccmd convert structure)
+  frame.zip            (Windows; convert blob payloads)
+  trace.json           (Mac; parse_capture.py → wpe.trace.v1)
+  shader-interface.md  (Mac; per-shader RDEF + signatures)
 tools\wpe-oracle\captures\<jobId>\done.json
 ```
 
-`captures/` can contain WPE assets, shader disassembly, and large `.rdc` files. Keep it gitignored and local.
+`captures/` holds WPE assets, shader bytecode, and large `.rdc`/`.zip` files. Keep it gitignored and local.
 
 ## Operator Flow
 
@@ -70,9 +73,20 @@ wallpaper64.exe -control openWallpaper -file <project.json>
 ```
 
 - warms up
-- tries RenderDoc capture
-- exports `windows\trace.json`, `rt\*.png`, and `shaders\*.dxbc.txt`
+- tries RenderDoc capture (auto launch-under / inject)
+- runs `renderdoccmd convert -f <frame.rdc> -o windows\frame.zip.xml -c zip.xml`
 - writes `done.json`
+
+> **Reality check (validated on RenderDoc 1.44 + WPE 2.8.26):** WPE is a single-instance, windowless wallpaper, so CLI auto-capture rarely triggers. The reliable capture is the RenderDoc **GUI → "Launch Application"** tab: kill the running `wallpaper64.exe` first, then Launch `wallpaper64.exe` (working dir = the WPE folder, "Capture Child Processes" on) so RenderDoc owns the sole instance, then "Capture Frame(s) Immediately" and **Save Capture As** `frame.rdc`. `renderdoccmd convert` and `parse_capture.py` then run headlessly over SSH.
+
+5. Copy the capture dir to the Mac and parse it (headless, stdlib only):
+
+```bash
+python3 tools/wpe-oracle/parse_capture.py \
+  --capture-dir tools/wpe-oracle/captures/<jobId>/windows --scene-id <id>
+```
+
+This emits `windows/trace.json` (wpe.trace.v1) + `windows/shader-interface.md`.
 
 ## Mac to Windows Bridge
 
@@ -100,15 +114,15 @@ The key signal is in `done.json`:
 - `status=succeeded`, `hookMethod=launch-under`: RenderDoc saw WPE when launched under RenderDoc.
 - `status=succeeded`, `hookMethod=inject`: RenderDoc saw an already-running `wallpaper64.exe`.
 - `status=needs-ui`: CLI automation did not capture WPE. Use RenderDoc UI injection next.
-- `status=failed`: capture or extraction failed; inspect the console stdout/stderr and the `error` field in `done.json`. (Per-texture save failures additionally drop a `*.error.txt` beside the affected PNG.)
+- `status=failed`: convert failed; inspect the console stdout/stderr and the `error` field in `done.json`.
 
 The minimum useful success is:
 
-- `windows\trace.json` exists
-- `passes[]` is non-empty
-- `resources.shaders` contains DXBC disassembly paths
-- `constantBuffers[]` contains runtime values such as `g_Time` when reflection exposes them
-- `rt\*.png` contains at least one render target dump
+- Windows: `windows\frame.zip.xml` exists and `done.json.status` is `succeeded`.
+- Mac (after `parse_capture.py`): `windows/trace.json` exists and validates against `wpe.trace.v1`.
+- Mac: `passes[]` is non-empty.
+- Mac: `resources.shaders` carries DXBC shader records + RDEF reflection (`shader-interface.md`).
+- Mac: `constantBuffers[]` carries decoded runtime values (matrices like `g_ModelViewProjectionMatrix`) where RDEF layout + buffer contents allow.
 
 ## Fallback Ladder
 
@@ -143,6 +157,7 @@ If RenderDoc cannot hook WorkerW/WPE at all, validate the path with Nsight Graph
 
 ## Notes
 
-- Missing HLSL source is expected. DXBC disassembly and reflection are the baseline.
+- Missing HLSL source is expected — WPE ships only DXBC. RDEF reflection (cbuffer layouts, resource/sampler bindings) + ISGN/OSGN signatures are the baseline, parsed by `parse_capture.py`.
+- The convert path has no GPU replay readback, so per-RT PNGs are intentionally absent; `output.png` is `null` in `trace.json`. (Replayed images need the qrenderdoc GUI.)
 - This first slice intentionally does not classify divergences.
-- Do not commit `.rdc`, PNGs, shader dumps, or captured WPE/workshop assets.
+- Do not commit `.rdc`, `.zip`, `frame.zip.xml`, shader blobs, or captured WPE/workshop assets.

--- a/tools/wpe-oracle/diff_traces.py
+++ b/tools/wpe-oracle/diff_traces.py
@@ -1,0 +1,752 @@
+#!/usr/bin/env python3
+"""Diff a Windows WPE trace against a Mac Metal trace (both wpe.trace.v1).
+
+Phase B of the divergence pipeline: structure / uniform-by-name / topology /
+texture-binding / RT-lineage diffing with DP pass alignment and bucketed
+first-divergence pinpointing. No SSIM, no corpus orchestration, no HTML — those
+are later phases. Pure stdlib so it runs anywhere the Windows parser does.
+
+    python3 diff_traces.py --windows windows/trace.json --mac mac/trace.json \
+        --out diff/divergence-summary.json
+
+The contract emitted is `wpe.diff.v1` (see the plan's §四). Uniform packing
+differences (WPE g_bufStatic/g_bufDynamic split vs our flat slot array) are
+reconciled by NAME and are NOT reported as divergence.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+EPSILON = 1.0e-4
+BUCKETS = ("transpiler", "FBO", "asset", "puppet+particle")
+# Uniforms whose values legitimately differ between two captures (wall-clock time,
+# frame counters, RNG). Comparing them by value yields a guaranteed false-positive
+# that would mask real divergences, so they are skipped until Phase D-1 constant
+# replay feeds WPE's decoded values back into our packing. Names are lowercased.
+VOLATILE_UNIFORMS = {
+    "g_time", "time", "u_time", "utime", "itime", "g_daytime", "daytime",
+    "g_framecount", "framecount", "frametime", "g_frame", "random", "g_random",
+}
+# DP costs.
+DELETE_QUAD = 2.0          # deleting a WPE quad pass is expensive (real gap)
+DELETE_POINTLIST = 0.35    # deleting a WPE particle pass is cheap (expected gap)
+INSERT = 2.0               # inserting an unmatched Mac pass
+
+
+# --------------------------------------------------------------------------- #
+# Normalized model
+# --------------------------------------------------------------------------- #
+@dataclass
+class Uniform:
+    name: str
+    value: Any
+    stage: Optional[str] = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TextureBinding:
+    slot: int
+    name: Optional[str]
+    resource: Optional[str]
+    fallback: bool = False
+    width: Optional[int] = None
+    height: Optional[int] = None
+    fmt: Optional[str] = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class NormalizedPass:
+    side: str
+    ordinal: int
+    pass_id: Optional[str]
+    shader_name: Optional[str]
+    topology: str
+    draw: dict[str, Any]
+    uniforms: dict[str, Uniform]
+    textures: dict[int, TextureBinding]
+    shader_sig: dict[str, Any]
+    rt_lineage: list[str]
+    blend: Any
+    output_hash: Optional[str]
+    raw: dict[str, Any]
+
+    @property
+    def is_pointlist(self) -> bool:
+        return self.topology == "pointlist"
+
+
+# --------------------------------------------------------------------------- #
+# IO
+# --------------------------------------------------------------------------- #
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+# --------------------------------------------------------------------------- #
+# Normalization
+# --------------------------------------------------------------------------- #
+def normalize_trace(trace: dict[str, Any], side: str) -> list[NormalizedPass]:
+    resources = trace.get("resources", {}) or {}
+    shaders = resources.get("shaders", {}) or {}
+    textures = resources.get("textures", {}) or {}
+    out: list[NormalizedPass] = []
+    for raw_pass in trace.get("passes", []) or []:
+        if not isinstance(raw_pass, dict):
+            continue
+        draw = raw_pass.get("draw", {}) or {}
+        uniforms = normalize_uniforms(raw_pass)
+        texture_bindings = normalize_textures(raw_pass, textures)
+        out.append(NormalizedPass(
+            side=side,
+            ordinal=safe_int(raw_pass.get("ordinal"), len(out)),
+            pass_id=raw_pass.get("passId"),
+            shader_name=raw_pass.get("shaderName"),
+            topology=canonical_topology(draw),
+            draw=draw,
+            uniforms=uniforms,
+            textures=texture_bindings,
+            shader_sig=normalize_shader_sig(raw_pass, shaders, uniforms, texture_bindings),
+            rt_lineage=normalize_rt_lineage(raw_pass),
+            blend=(raw_pass.get("state") or {}).get("blend"),
+            output_hash=(raw_pass.get("output") or {}).get("sha256"),
+            raw=raw_pass,
+        ))
+    return out
+
+
+def safe_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def canonical_topology(draw: dict[str, Any]) -> str:
+    """Collapse to a small, comparable vocabulary.
+
+    Both WPE (D3D ``TRIANGLELIST`` 6-index quad / ``TRIANGLESTRIP`` 4-vertex) and
+    Mac (``fullscreen-quad`` / ``object-quad``) effect passes are screen quads, so
+    they all canonicalize to ``"quad"`` and align. The only non-quad WPE passes in
+    the effect corpus are the particle ``POINTLIST`` draws, which stay distinct so
+    they fall out of the alignment into the puppet+particle bucket.
+    """
+    topology = str(draw.get("topology") or "").lower()
+    if "pointlist" in topology:
+        return "pointlist"
+    if "linelist" in topology or "linestrip" in topology:
+        return "line"
+    if any(token in topology for token in ("quad", "triangle")):
+        return "quad"
+    if not topology:
+        return "unknown"
+    return topology
+
+
+def normalize_uniforms(raw_pass: dict[str, Any]) -> dict[str, Uniform]:
+    uniforms: dict[str, Uniform] = {}
+    for cbuffer in raw_pass.get("constantBuffers", []) or []:
+        stage = cbuffer.get("stage")
+        for variable in cbuffer.get("variables", []) or []:
+            name = variable.get("name")
+            if not name:
+                continue
+            uniforms[name] = Uniform(
+                name=name,
+                value=preferred_uniform_value(variable),
+                stage=stage,
+                raw=variable,
+            )
+    return uniforms
+
+
+def preferred_uniform_value(variable: dict[str, Any]) -> Any:
+    for key in ("matrix4x4RowMajor", "matrix4x4"):
+        if key in variable and variable[key] is not None:
+            return variable[key]
+    if "value" in variable:
+        return variable["value"]
+    return variable.get("rawSlotFloats")
+
+
+def normalize_textures(raw_pass: dict[str, Any], texture_resources: dict[str, Any]) -> dict[int, TextureBinding]:
+    out: dict[int, TextureBinding] = {}
+    for item in raw_pass.get("textures", []) or []:
+        try:
+            slot = int(item.get("slot", len(out)))
+        except (TypeError, ValueError):
+            slot = len(out)
+        resource = item.get("resource")
+        desc = texture_resources.get(resource or "", {}) or {}
+        out[slot] = TextureBinding(
+            slot=slot,
+            name=item.get("name"),
+            resource=resource,
+            fallback=bool(item.get("fallback")),
+            width=item.get("width") or desc.get("width"),
+            height=item.get("height") or desc.get("height"),
+            fmt=item.get("format") or item.get("pixelFormat") or desc.get("format"),
+            raw=item,
+        )
+    return out
+
+
+def normalize_shader_sig(
+    raw_pass: dict[str, Any],
+    shader_resources: dict[str, Any],
+    uniforms: dict[str, Uniform],
+    textures: dict[int, TextureBinding],
+) -> dict[str, Any]:
+    refs = raw_pass.get("shaders", {}) or {}
+    reflected_uniforms: set[str] = set()
+    samplers: set[str] = set()
+    varyings: set[str] = set()
+    shader_ids: list[str] = []
+    for shader_id in (refs.get("vs"), refs.get("fs")):
+        if not shader_id:
+            continue
+        shader_ids.append(shader_id)
+        reflection = (shader_resources.get(shader_id) or {}).get("reflection") or {}
+        for uniform in reflection.get("uniforms", []) or []:
+            if uniform.get("name"):
+                reflected_uniforms.add(uniform["name"])
+        for sampler in reflection.get("samplers", []) or []:
+            if sampler.get("name"):
+                samplers.add(sampler["name"])
+        for key in ("inputSignature", "outputSignature"):
+            for param in reflection.get(key, []) or []:
+                semantic = param.get("semanticName")
+                if semantic:
+                    varyings.add(f"{semantic}{param.get('semanticIndex', 0)}")
+    if not reflected_uniforms:
+        reflected_uniforms = set(uniforms)
+    if not samplers:
+        samplers = {b.name for b in textures.values() if b.name}
+    return {
+        "shaderIds": shader_ids,
+        "uniformNames": sorted(reflected_uniforms),
+        "samplers": sorted(samplers),
+        "varyings": sorted(varyings),
+    }
+
+
+def normalize_rt_lineage(raw_pass: dict[str, Any]) -> list[str]:
+    color = (raw_pass.get("targets", {}) or {}).get("color") or []
+    return [str(item.get("resource")) for item in color if item.get("resource")]
+
+
+# --------------------------------------------------------------------------- #
+# DP alignment
+# --------------------------------------------------------------------------- #
+def align_passes(wpe: list[NormalizedPass], mac: list[NormalizedPass]) -> list[dict[str, Any]]:
+    rows, cols = len(wpe) + 1, len(mac) + 1
+    dp = [[0.0] * cols for _ in range(rows)]
+    back: list[list[Optional[tuple[str, int, int]]]] = [[None] * cols for _ in range(rows)]
+    for i in range(1, rows):
+        dp[i][0] = dp[i - 1][0] + delete_cost(wpe[i - 1])
+        back[i][0] = ("delete", i - 1, -1)
+    for j in range(1, cols):
+        dp[0][j] = dp[0][j - 1] + INSERT
+        back[0][j] = ("insert", -1, j - 1)
+    for i in range(1, rows):
+        for j in range(1, cols):
+            cost, choice = min(
+                (
+                    (dp[i - 1][j - 1] + substitute_cost(wpe[i - 1], mac[j - 1]), ("match", i - 1, j - 1)),
+                    (dp[i - 1][j] + delete_cost(wpe[i - 1]), ("delete", i - 1, -1)),
+                    (dp[i][j - 1] + INSERT, ("insert", -1, j - 1)),
+                ),
+                key=lambda item: item[0],
+            )
+            dp[i][j] = cost
+            back[i][j] = choice
+
+    i, j = len(wpe), len(mac)
+    alignment: list[dict[str, Any]] = []
+    while i > 0 or j > 0:
+        choice = back[i][j]
+        if choice is None:
+            break
+        op, wi, mj = choice
+        if op == "match":
+            alignment.append({"wpe": wi, "mac": mj, "status": "aligned", "cost": round(substitute_cost(wpe[wi], mac[mj]), 4)})
+            i, j = i - 1, j - 1
+        elif op == "delete":
+            entry = {"wpe": wi, "mac": None, "status": "deleted", "cost": round(delete_cost(wpe[wi]), 4)}
+            if wpe[wi].is_pointlist:
+                entry["bucket"] = "puppet+particle"
+            alignment.append(entry)
+            i -= 1
+        else:
+            alignment.append({"wpe": None, "mac": mj, "status": "inserted", "cost": INSERT})
+            j -= 1
+    alignment.reverse()
+    return alignment
+
+
+def delete_cost(pass_: NormalizedPass) -> float:
+    return DELETE_POINTLIST if pass_.is_pointlist else DELETE_QUAD
+
+
+def substitute_cost(wpe: NormalizedPass, mac: NormalizedPass) -> float:
+    cost = 0.0
+    if wpe.topology != mac.topology:
+        cost += 3.0 if (wpe.is_pointlist or mac.is_pointlist) else 1.0
+    cost += 1.0 - jaccard(set(wpe.uniforms), set(mac.uniforms))
+    cost += 0.75 * (1.0 - jaccard(set(texture_names(wpe)), set(texture_names(mac))))
+    cost += 0.75 * (1.0 - jaccard(set(wpe.shader_sig.get("samplers", [])), set(mac.shader_sig.get("samplers", []))))
+    if len(wpe.rt_lineage) != len(mac.rt_lineage):
+        cost += 0.25
+    return cost
+
+
+def texture_names(pass_: NormalizedPass) -> list[str]:
+    return [b.name or f"slot{slot}" for slot, b in sorted(pass_.textures.items())]
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    if not a and not b:
+        return 1.0
+    union = a | b
+    return len(a & b) / len(union) if union else 1.0
+
+
+# --------------------------------------------------------------------------- #
+# Ordered comparison + bucketing
+# --------------------------------------------------------------------------- #
+def compare_alignment(
+    wpe: list[NormalizedPass],
+    mac: list[NormalizedPass],
+    alignment: list[dict[str, Any]],
+    mac_trace: dict[str, Any],
+) -> tuple[list[dict[str, Any]], Optional[dict[str, Any]], dict[str, int], list[dict[str, Any]], list[str]]:
+    pass_summaries: list[dict[str, Any]] = []
+    first: Optional[dict[str, Any]] = None
+    findings: list[dict[str, Any]] = []
+    histogram = {bucket: 0 for bucket in BUCKETS}
+    notes: list[str] = []
+
+    if has_static_dynamic_split(wpe) and has_mac_flat_slots(mac):
+        notes.append(
+            "WPE g_bufStatic/g_bufDynamic and Mac mac_flat_slots reconciled by uniform name; "
+            "packing-layout differences are not treated as divergence."
+        )
+
+    # Resolution failures are a structural asset signal independent of alignment.
+    unresolved = resolution_missing_count(mac_trace)
+    if unresolved:
+        findings.append({
+            "macPassIndex": None,
+            "wpePassOrdinal": None,
+            "bucket": "asset",
+            "suppressed": False,
+            "pinpoint": {
+                "type": "texture",
+                "name": "resolutionSummary.missing",
+                "wpe": None,
+                "metal": unresolved,
+                "varianceType": "missing",
+            },
+            "responsibleSite": "LiveWallpaper/Infrastructure/SceneResourceResolver.swift",
+        })
+        histogram["asset"] += 1
+
+    # Cascade model: only an ALIGNED-PAIR divergence corrupts the downstream RT
+    # chain, so only those set `after_first`. A deleted/inserted pass is a
+    # structural coverage gap (Mac never traced/rendered it) — reported and
+    # bucketed, but it does NOT suppress the independent pair comparisons.
+    after_first = False
+    for index, entry in enumerate(alignment):
+        wi, mj = entry.get("wpe"), entry.get("mac")
+        if wi is not None and mj is not None:
+            divergence = compare_pair(wpe[wi], mac[mj])
+            if divergence is None:
+                pass_summaries.append({"index": index, "wpe": wi, "mac": mj, "status": "matched", "ssim": None, "reason": ""})
+                continue
+            suppressed = after_first
+            divergence["suppressed"] = suppressed
+            findings.append(divergence)
+            if suppressed:
+                status = "unverified"          # downstream cascade — reported, not counted
+            else:
+                status = "diverged"
+                histogram[divergence["bucket"]] += 1
+                first, after_first = divergence, True
+            pass_summaries.append({
+                "index": index, "wpe": wi, "mac": mj, "status": status, "ssim": None,
+                "reason": divergence["pinpoint"]["varianceType"],
+            })
+        elif wi is not None:
+            divergence = deleted_wpe_pass(wpe[wi])
+            divergence["suppressed"] = False
+            findings.append(divergence)
+            histogram[divergence["bucket"]] += 1
+            pass_summaries.append({
+                "index": index, "wpe": wi, "mac": None, "status": "skipped_on_mac",
+                "ssim": None, "reason": divergence["pinpoint"]["varianceType"],
+            })
+        else:
+            divergence = inserted_mac_pass(mac[mj])
+            divergence["suppressed"] = False
+            findings.append(divergence)
+            histogram["transpiler"] += 1
+            pass_summaries.append({
+                "index": index, "wpe": None, "mac": mj, "status": "inserted",
+                "ssim": None, "reason": "extra-mac-pass",
+            })
+    return pass_summaries, first, histogram, findings, notes
+
+
+def compare_pair(wpe: NormalizedPass, mac: NormalizedPass) -> Optional[dict[str, Any]]:
+    if wpe.topology != mac.topology:
+        bucket = "puppet+particle" if "pointlist" in (wpe.topology, mac.topology) else "transpiler"
+        return divergence(wpe, mac, bucket, "topology", "draw.topology", wpe.topology, mac.topology, "mismatch")
+
+    shader_delta = compare_shader_interface(wpe, mac)
+    if shader_delta is not None:
+        return divergence(wpe, mac, "transpiler", "shader-interface",
+                          shader_delta["name"], shader_delta["wpe"], shader_delta["metal"], shader_delta["varianceType"])
+
+    rt_delta = compare_rt_lineage(wpe, mac)
+    if rt_delta is not None:
+        return divergence(wpe, mac, "FBO", "rt", "targets.color", rt_delta["wpe"], rt_delta["metal"], rt_delta["varianceType"])
+
+    texture_delta = compare_textures(wpe, mac)
+    if texture_delta is not None:
+        return divergence(wpe, mac, texture_delta["bucket"], "texture",
+                          texture_delta["name"], texture_delta["wpe"], texture_delta["metal"], texture_delta["varianceType"])
+
+    uniform_delta = compare_uniforms(wpe, mac)
+    if uniform_delta is not None:
+        bucket = "puppet+particle" if looks_like_matrix_or_bone(uniform_delta["name"]) else "transpiler"
+        return divergence(wpe, mac, bucket, "uniform",
+                          uniform_delta["name"], uniform_delta["wpe"], uniform_delta["metal"], uniform_delta["varianceType"])
+
+    if wpe.output_hash and mac.output_hash and wpe.output_hash != mac.output_hash:
+        return divergence(wpe, mac, "FBO", "rt", "output.sha256", wpe.output_hash, mac.output_hash, "hash")
+
+    return None
+
+
+def compare_shader_interface(wpe: NormalizedPass, mac: NormalizedPass) -> Optional[dict[str, Any]]:
+    # Compare the logical uniform-name set only. Sampler *names* are NOT compared:
+    # D3D RDEF names samplers separately (g_Sampler*) from textures, while our MSL
+    # uses a combined g_Texture* sampler convention — comparing them is apples to
+    # oranges. Texture-binding divergences are caught per-slot in compare_textures.
+    w_uniforms = set(wpe.shader_sig.get("uniformNames", [])) or set(wpe.uniforms)
+    m_uniforms = set(mac.shader_sig.get("uniformNames", [])) or set(mac.uniforms)
+    if w_uniforms and m_uniforms and jaccard(w_uniforms, m_uniforms) < 0.15:
+        return {"name": "uniform-name-set", "wpe": sorted(w_uniforms), "metal": sorted(m_uniforms), "varianceType": "name-set"}
+    return None
+
+
+def compare_rt_lineage(wpe: NormalizedPass, mac: NormalizedPass) -> Optional[dict[str, Any]]:
+    if not wpe.rt_lineage or not mac.rt_lineage:
+        return None
+    if len(wpe.rt_lineage) != len(mac.rt_lineage):
+        return {"wpe": wpe.rt_lineage, "metal": mac.rt_lineage, "varianceType": "target-count"}
+    return None
+
+
+def compare_textures(wpe: NormalizedPass, mac: NormalizedPass) -> Optional[dict[str, Any]]:
+    for slot, metal in sorted(mac.textures.items()):
+        # Only a fallback on a *declared* sampler slot (the shader actually reads
+        # it) is a real under-binding. Beyond-declared slots that fall back to the
+        # primary texture are benign — the shader never samples them.
+        if metal.fallback and metal.name:
+            return {
+                "bucket": "asset", "name": metal.name or f"slot{slot}",
+                "wpe": texture_to_json(wpe.textures.get(slot)), "metal": texture_to_json(metal),
+                "varianceType": "fallback",
+            }
+    for slot in sorted(set(wpe.textures) & set(mac.textures)):
+        wt, mt = wpe.textures[slot], mac.textures[slot]
+        if wt.name and mt.name and normalize_texture_name(wt.name) != normalize_texture_name(mt.name):
+            return {"bucket": "asset", "name": f"slot{slot}", "wpe": texture_to_json(wt), "metal": texture_to_json(mt), "varianceType": "name"}
+        if wt.width and mt.width and wt.height and mt.height and (wt.width, wt.height) != (mt.width, mt.height):
+            return {"bucket": "asset", "name": wt.name or mt.name or f"slot{slot}", "wpe": texture_to_json(wt), "metal": texture_to_json(mt), "varianceType": "dimensions"}
+    missing = sorted(set(wpe.textures) - set(mac.textures))
+    if missing:
+        slot = missing[0]
+        return {"bucket": "asset", "name": wpe.textures[slot].name or f"slot{slot}", "wpe": texture_to_json(wpe.textures[slot]), "metal": None, "varianceType": "missing"}
+    return None
+
+
+def compare_uniforms(wpe: NormalizedPass, mac: NormalizedPass) -> Optional[dict[str, Any]]:
+    for name in sorted(set(wpe.uniforms) & set(mac.uniforms)):
+        if name.lower() in VOLATILE_UNIFORMS:
+            continue
+        wv, mv = wpe.uniforms[name].value, mac.uniforms[name].value
+        if wv is None or mv is None:
+            continue
+        if not values_close(wv, mv):
+            return {
+                "name": name,
+                "wpe": value_summary(wv, wpe.uniforms[name].raw),
+                "metal": value_summary(mv, mac.uniforms[name].raw),
+                "varianceType": matrix_variance_type(name, wv, mv),
+            }
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Value helpers
+# --------------------------------------------------------------------------- #
+def values_close(a: Any, b: Any, eps: float = EPSILON) -> bool:
+    av, bv = flatten_numbers(a), flatten_numbers(b)
+    if not av or not bv:
+        return a == b
+    if len(av) != len(bv):
+        return False
+    return all(abs(x - y) <= eps for x, y in zip(av, bv))
+
+
+def flatten_numbers(value: Any) -> list[float]:
+    if isinstance(value, bool):
+        return [1.0 if value else 0.0]
+    if isinstance(value, (int, float)):
+        return [float(value)]
+    if isinstance(value, list):
+        out: list[float] = []
+        for item in value:
+            out.extend(flatten_numbers(item))
+        return out
+    return []
+
+
+def matrix_variance_type(name: str, wv: Any, mv: Any) -> str:
+    if looks_like_matrix_or_bone(name):
+        wf, mf = flatten_numbers(wv), flatten_numbers(mv)
+        if len(wf) == len(mf) == 16 and values_close(transpose4(wf), mf):
+            return "transpose"
+        return "matrix"
+    return "value"
+
+
+def transpose4(values: list[float]) -> list[float]:
+    return [values[c * 4 + r] for r in range(4) for c in range(4)]
+
+
+def looks_like_matrix_or_bone(name: str) -> bool:
+    lowered = name.lower()
+    return "matrix" in lowered or "bone" in lowered
+
+
+def value_summary(value: Any, raw: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "value": value,
+        "slot": raw.get("slot"),
+        "offsetBytes": raw.get("startOffset") or raw.get("offsetBytes"),
+        "matrixMajor": raw.get("matrixMajor"),
+    }
+
+
+def texture_to_json(binding: Optional[TextureBinding]) -> Optional[dict[str, Any]]:
+    if binding is None:
+        return None
+    return {
+        "slot": binding.slot, "name": binding.name, "resource": binding.resource,
+        "fallback": binding.fallback, "width": binding.width, "height": binding.height, "format": binding.fmt,
+    }
+
+
+def normalize_texture_name(name: str) -> str:
+    lowered = name.lower()
+    if lowered.startswith("g_texture"):
+        return lowered
+    if lowered.startswith("texture"):
+        return "g_" + lowered
+    return lowered
+
+
+def deleted_wpe_pass(pass_: NormalizedPass) -> dict[str, Any]:
+    is_particle = pass_.is_pointlist
+    return {
+        "macPassIndex": None,
+        "wpePassOrdinal": pass_.ordinal,
+        "passId": pass_.pass_id,
+        "shaderName": pass_.shader_name,
+        "bucket": "puppet+particle" if is_particle else "transpiler",
+        "pinpoint": {
+            "type": "topology",
+            "name": pass_.topology,
+            "wpe": {"ordinal": pass_.ordinal, "topology": pass_.topology, "draw": pass_.draw},
+            "metal": None,
+            "varianceType": "missing-pointlist-particle-pass" if is_particle else "missing-wpe-pass",
+        },
+        "responsibleSite": "LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift (fragment-only: no particle/pointlist path)"
+        if is_particle else "LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift",
+    }
+
+
+def inserted_mac_pass(pass_: NormalizedPass) -> dict[str, Any]:
+    return {
+        "macPassIndex": pass_.ordinal,
+        "wpePassOrdinal": None,
+        "passId": pass_.pass_id,
+        "shaderName": pass_.shader_name,
+        "bucket": "transpiler",
+        "pinpoint": {"type": "topology", "name": pass_.topology, "wpe": None, "metal": pass_.topology, "varianceType": "extra-mac-pass"},
+        "responsibleSite": "LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift",
+    }
+
+
+def divergence(wpe: NormalizedPass, mac: NormalizedPass, bucket: str, type_: str,
+               name: str, wpe_value: Any, metal_value: Any, variance_type: str) -> dict[str, Any]:
+    return {
+        "macPassIndex": mac.ordinal,
+        "wpePassOrdinal": wpe.ordinal,
+        "passId": mac.pass_id or wpe.pass_id,
+        "shaderName": mac.shader_name or wpe.shader_name,
+        "bucket": bucket,
+        "pinpoint": {"type": type_, "name": name, "wpe": wpe_value, "metal": metal_value, "varianceType": variance_type},
+        "responsibleSite": responsible_site(bucket, type_),
+    }
+
+
+def responsible_site(bucket: str, type_: str) -> str:
+    if bucket == "asset":
+        return "LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift"
+    if bucket == "FBO":
+        return "LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift"
+    if bucket == "puppet+particle":
+        return "LiveWallpaper/Runtime/WPEMetalShaderDispatcher.swift"
+    return "LiveWallpaper/Runtime/WPEShaderTranspiler.swift"
+
+
+def has_static_dynamic_split(passes: list[NormalizedPass]) -> bool:
+    names = {cb.get("name") for p in passes for cb in (p.raw.get("constantBuffers") or [])}
+    return "g_bufStatic" in names and "g_bufDynamic" in names
+
+
+def has_mac_flat_slots(passes: list[NormalizedPass]) -> bool:
+    return any(cb.get("name") == "mac_flat_slots" for p in passes for cb in (p.raw.get("constantBuffers") or []))
+
+
+def resolution_missing_count(trace: dict[str, Any]) -> int:
+    summary = (trace.get("capture") or {}).get("resolutionSummary") or {}
+    try:
+        return int(summary.get("missing") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+# --------------------------------------------------------------------------- #
+# Summary assembly
+# --------------------------------------------------------------------------- #
+def build_summary(windows_trace: dict[str, Any], mac_trace: dict[str, Any],
+                  windows_path: Path, mac_path: Path, out_path: Path) -> dict[str, Any]:
+    wpe = normalize_trace(windows_trace, "windows-wpe")
+    mac = normalize_trace(mac_trace, "mac-metal")
+    alignment = align_passes(wpe, mac)
+    passes, first, histogram, findings, notes = compare_alignment(wpe, mac, alignment, mac_trace)
+
+    status = "matched" if (first is None and not findings) else "diverged"
+    primary_bucket = first.get("bucket") if first else primary_from_findings(findings)
+
+    alignment_json: list[dict[str, Any]] = []
+    for item in alignment:
+        entry = dict(item)
+        if entry.get("wpe") is not None:
+            entry["wpePassOrdinal"] = wpe[entry["wpe"]].ordinal
+            entry["wpeTopology"] = wpe[entry["wpe"]].topology
+        if entry.get("mac") is not None:
+            entry["macPassIndex"] = mac[entry["mac"]].ordinal
+            entry["macTopology"] = mac[entry["mac"]].topology
+        alignment_json.append(entry)
+
+    pointlist_deletions = sum(
+        1 for item in alignment_json
+        if item.get("status") == "deleted" and item.get("bucket") == "puppet+particle"
+    )
+    histogram["puppet+particle"] = max(histogram["puppet+particle"], pointlist_deletions)
+
+    scene = windows_trace.get("scene") or mac_trace.get("scene") or {}
+    return {
+        "schema": "wpe.diff.v1",
+        "sceneId": str(scene.get("workshopId") or ""),
+        "status": status,
+        "confidence": confidence_score(alignment_json, first, findings),
+        "primaryBucket": primary_bucket,
+        "ssimFinal": None,
+        "firstDivergence": first,
+        "alignment": alignment_json,
+        "passes": passes,
+        "bucketHistogram": histogram,
+        "findings": findings,
+        "normalizationNotes": notes,
+        "artifactRefs": {
+            "windowsTrace": str(windows_path),
+            "macTrace": str(mac_path),
+            "diffSummary": str(out_path),
+            "report": None,
+            "gputrace": None,
+        },
+    }
+
+
+def primary_from_findings(findings: list[dict[str, Any]]) -> Optional[str]:
+    """When no aligned-pair divergence is the cascade source, pick the most
+    fundamental structural bucket: asset (resources never loaded) dominates."""
+    priority = ("asset", "puppet+particle", "FBO", "transpiler")
+    present = {f["bucket"] for f in findings if not f.get("suppressed")}
+    for bucket in priority:
+        if bucket in present:
+            return bucket
+    return None
+
+
+def confidence_score(alignment: list[dict[str, Any]], first: Optional[dict[str, Any]], findings: list[dict[str, Any]]) -> float:
+    if not alignment:
+        return 0.0
+    aligned = sum(1 for item in alignment if item.get("status") == "aligned")
+    base = aligned / len(alignment)
+    if first and first.get("bucket") == "puppet+particle":
+        base = max(base, 0.9)
+    if any(f.get("pinpoint", {}).get("varianceType") == "fallback" for f in findings):
+        base = max(base, 0.75)
+    return round(min(max(base, 0.0), 1.0), 3)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--windows", type=Path, required=True, help="Windows WPE wpe.trace.v1 JSON.")
+    parser.add_argument("--mac", type=Path, required=True, help="Mac Metal wpe.trace.v1 JSON.")
+    parser.add_argument("--out", type=Path, required=True, help="Output divergence-summary.json (wpe.diff.v1).")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    summary = build_summary(load_json(args.windows), load_json(args.mac), args.windows, args.mac, args.out)
+    write_json(args.out, summary)
+    fd = summary["firstDivergence"]
+    print(f"wrote {args.out}")
+    print(f"  status={summary['status']} primaryBucket={summary['primaryBucket']} "
+          f"confidence={summary['confidence']}")
+    if fd:
+        pp = fd["pinpoint"]
+        print(f"  firstDivergence: pass mac#{fd['macPassIndex']}/wpe#{fd['wpePassOrdinal']} "
+              f"shader={fd.get('shaderName')} passId={fd.get('passId')}")
+        print(f"    {fd['bucket']} :: {pp['type']}/{pp['name']} ({pp['varianceType']}) -> {fd['responsibleSite']}")
+    else:
+        print("  firstDivergence: none")
+    print(f"  buckets={summary['bucketHistogram']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/wpe-oracle/extract_renderdoc_trace.py
+++ b/tools/wpe-oracle/extract_renderdoc_trace.py
@@ -1,0 +1,963 @@
+#!/usr/bin/env python3
+"""Export a shader-first WPE RenderDoc capture as wpe.trace.v1.
+
+Runs in RenderDoc's Python environment (`renderdoccmd python` or the
+RenderDoc UI Python shell). Dependencies are stdlib + `renderdoc` only.
+
+This tool is intentionally best-effort across RenderDoc versions: all API
+access is wrapped, missing HLSL source is accepted, and DXBC disassembly plus
+reflection are treated as the minimum shader oracle.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    import renderdoc as rd
+except Exception as exc:  # pragma: no cover - only meaningful inside RenderDoc.
+    rd = None
+    RENDERDOC_IMPORT_ERROR = exc
+else:
+    RENDERDOC_IMPORT_ERROR = None
+
+
+STAGE_DEFS = (
+    ("vs", "vertex", "Vertex"),
+    ("fs", "fragment", "Pixel"),
+)
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return sha256_bytes(text.encode("utf-8", errors="replace"))
+
+
+def sha256_file(path: Path) -> str | None:
+    try:
+        h = hashlib.sha256()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8", newline="\n") as f:
+        json.dump(value, f, indent=2, sort_keys=True)
+        f.write("\n")
+    tmp.replace(path)
+
+
+def write_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8", errors="replace")
+
+
+def safe_name(value: str | None, fallback: str = "unnamed") -> str:
+    if not value:
+        value = fallback
+    value = value.replace("\\", "/").split("/")[-1]
+    value = re.sub(r"[^A-Za-z0-9_.-]+", "_", value)
+    return value[:96] or fallback
+
+
+def enum_name(value: Any) -> str | None:
+    if value is None:
+        return None
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    try:
+        return str(value)
+    except Exception:
+        return type(value).__name__
+
+
+def get_attr(obj: Any, *names: str, default: Any = None) -> Any:
+    for name in names:
+        try:
+            if hasattr(obj, name):
+                value = getattr(obj, name)
+                if value is not None:
+                    return value
+        except Exception:
+            continue
+    return default
+
+
+def call(obj: Any, name: str, *args: Any) -> Any:
+    fn = getattr(obj, name, None)
+    if fn is None:
+        return None
+    try:
+        return fn(*args)
+    except Exception:
+        return None
+
+
+def call_any(obj: Any, names: Iterable[str], *args: Any) -> Any:
+    for name in names:
+        value = call(obj, name, *args)
+        if value is not None:
+            return value
+    return None
+
+
+def rid_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        return str(value)
+    except Exception:
+        return None
+
+
+def is_null_rid(value: Any) -> bool:
+    text = (rid_text(value) or "").strip().lower()
+    return text in ("", "0", "null", "resourceid()", "resourceid::null()")
+
+
+def extract_rid(obj: Any) -> Any:
+    if obj is None:
+        return None
+    for name in ("resourceId", "resource", "id"):
+        value = get_attr(obj, name)
+        if value is not None and not is_null_rid(value):
+            return value
+    descriptor = get_attr(obj, "descriptor")
+    if descriptor is not None:
+        return extract_rid(descriptor)
+    return None
+
+
+def resource_key(prefix: str, rid: Any) -> str:
+    text = rid_text(rid) or "unknown"
+    digest = sha256_text(text)[:16]
+    return f"{prefix}-{digest}"
+
+
+def simple_value(value: Any, depth: int = 0) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if depth > 3:
+        return enum_name(value)
+    if isinstance(value, (list, tuple)):
+        return [simple_value(v, depth + 1) for v in list(value)[:64]]
+    if isinstance(value, dict):
+        return {str(k): simple_value(v, depth + 1) for k, v in value.items()}
+    if hasattr(value, "__iter__") and not isinstance(value, (bytes, bytearray)):
+        try:
+            return [simple_value(v, depth + 1) for v in list(value)[:64]]
+        except Exception:
+            pass
+    return enum_name(value)
+
+
+def public_fields(obj: Any, *, max_fields: int = 64) -> dict[str, Any] | None:
+    if obj is None:
+        return None
+    out: dict[str, Any] = {}
+    for name in dir(obj):
+        if name.startswith("_"):
+            continue
+        if name[0].isupper():
+            continue
+        try:
+            value = getattr(obj, name)
+        except Exception:
+            continue
+        if callable(value):
+            continue
+        if len(out) >= max_fields:
+            out["_truncated"] = True
+            break
+        out[name] = simple_value(value)
+    return out
+
+
+def renderdoc_version() -> str | None:
+    if rd is None:
+        return None
+    for name in ("GetVersionString", "GetVersion"):
+        fn = getattr(rd, name, None)
+        if fn is None:
+            continue
+        try:
+            return str(fn())
+        except Exception:
+            continue
+    return None
+
+
+def stage_enum(stage_key: str) -> Any:
+    if rd is None:
+        return None
+    shader_stage = getattr(rd, "ShaderStage", None)
+    if shader_stage is None:
+        return None
+    candidates = {
+        "vs": ("Vertex", "VS"),
+        "fs": ("Pixel", "Fragment", "PS"),
+    }[stage_key]
+    for name in candidates:
+        if hasattr(shader_stage, name):
+            return getattr(shader_stage, name)
+    return None
+
+
+def draw_flags_enum(name: str) -> Any:
+    if rd is None:
+        return None
+    flags = getattr(rd, "DrawFlags", None)
+    if flags is None:
+        return None
+    return getattr(flags, name, None)
+
+
+def open_capture(path: Path) -> tuple[Any, Any]:
+    if rd is None:
+        raise RuntimeError(f"RenderDoc Python module unavailable: {RENDERDOC_IMPORT_ERROR}")
+    try:
+        rd.InitialiseReplay(rd.GlobalEnvironment(), [])
+    except Exception:
+        pass
+
+    cap = rd.OpenCaptureFile()
+    result = cap.OpenFile(str(path), "", None)
+    succeeded = getattr(rd.ResultCode, "Succeeded", None)
+    if succeeded is not None and result != succeeded:
+        raise RuntimeError(f"RenderDoc OpenFile failed for {path}: {result}")
+    if hasattr(cap, "LocalReplaySupport") and not cap.LocalReplaySupport():
+        raise RuntimeError(f"RenderDoc local replay unsupported for {path}")
+    result, controller = cap.OpenCapture(rd.ReplayOptions(), None)
+    if succeeded is not None and result != succeeded:
+        raise RuntimeError(f"RenderDoc OpenCapture failed for {path}: {result}")
+    return cap, controller
+
+
+def shutdown_capture(cap: Any, controller: Any) -> None:
+    try:
+        controller.Shutdown()
+    except Exception:
+        pass
+    try:
+        cap.Shutdown()
+    except Exception:
+        pass
+    try:
+        rd.ShutdownReplay()
+    except Exception:
+        pass
+
+
+def capture_with_renderdoccmd(renderdoccmd: Path, target: Path, rdc: Path, working_dir: Path | None) -> None:
+    rdc.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        str(renderdoccmd),
+        "capture",
+        "--capture-file",
+        str(rdc),
+    ]
+    if working_dir is not None:
+        cmd.extend(["--working-dir", str(working_dir)])
+    cmd.append(str(target))
+    subprocess.run(cmd, check=True)
+
+
+def root_actions(controller: Any) -> list[Any]:
+    actions = call(controller, "GetRootActions")
+    if actions is None:
+        actions = call(controller, "GetDrawcalls")
+    return list(actions or [])
+
+
+def walk_actions(actions: Iterable[Any]) -> Iterable[Any]:
+    for action in actions:
+        yield action
+        children = get_attr(action, "children", default=[]) or []
+        yield from walk_actions(children)
+
+
+def action_name(controller: Any, action: Any) -> str | None:
+    structured = call(controller, "GetStructuredFile")
+    name_fn = getattr(action, "GetName", None)
+    if name_fn is not None:
+        try:
+            return name_fn(structured)
+        except Exception:
+            pass
+    return get_attr(action, "customName", "name")
+
+
+def is_draw_action(action: Any) -> bool:
+    flags_value = get_attr(action, "flags")
+    drawcall_flag = draw_flags_enum("Drawcall")
+    if flags_value is not None and drawcall_flag is not None:
+        try:
+            return bool(flags_value & drawcall_flag)
+        except Exception:
+            pass
+    num_indices = get_attr(action, "numIndices", default=0) or 0
+    num_vertices = get_attr(action, "numVertices", default=0) or 0
+    return bool(num_indices or num_vertices)
+
+
+def texture_description(controller: Any, rid: Any) -> dict[str, Any]:
+    desc = call(controller, "GetTexture", rid)
+    if desc is None:
+        return {"width": None, "height": None, "format": None, "mips": None}
+    fmt = get_attr(desc, "format")
+    fmt_name = call(fmt, "Name") if fmt is not None else None
+    return {
+        "width": get_attr(desc, "width", "Width"),
+        "height": get_attr(desc, "height", "Height"),
+        "format": fmt_name or enum_name(fmt),
+        "mips": get_attr(desc, "mips", "mipLevels", "mipCount"),
+    }
+
+
+def resource_names(controller: Any) -> dict[str, str]:
+    out: dict[str, str] = {}
+    resources = call(controller, "GetResources") or []
+    for resource in resources:
+        rid = extract_rid(resource)
+        if is_null_rid(rid):
+            continue
+        name = get_attr(resource, "name")
+        if name:
+            out[rid_text(rid) or ""] = str(name)
+    return out
+
+
+def record_texture(resources: dict[str, Any], controller: Any, names: dict[str, str], rid: Any, png: str | None = None) -> str:
+    key = resource_key("tex", rid)
+    desc = texture_description(controller, rid)
+    resources["textures"].setdefault(key, {
+        "label": names.get(rid_text(rid) or "", rid_text(rid)),
+        "sourcePath": None,
+        "width": desc["width"],
+        "height": desc["height"],
+        "format": desc["format"],
+        "mips": desc["mips"],
+        "sha256": None,
+        "png": png,
+    })
+    if png and not resources["textures"][key].get("png"):
+        resources["textures"][key]["png"] = png
+    return key
+
+
+def record_render_target(resources: dict[str, Any], controller: Any, names: dict[str, str], rid: Any, event_label: str) -> str:
+    key = resource_key("rt", rid)
+    desc = texture_description(controller, rid)
+    existing = resources["renderTargets"].setdefault(key, {
+        "label": names.get(rid_text(rid) or "", rid_text(rid)),
+        "width": desc["width"],
+        "height": desc["height"],
+        "format": desc["format"],
+        "lineage": [],
+    })
+    if event_label not in existing["lineage"]:
+        existing["lineage"].append(event_label)
+    return key
+
+
+def record_buffer(resources: dict[str, Any], rid: Any, label: str | None, byte_length: int | None = None) -> str:
+    key = resource_key("buf", rid)
+    resources["buffers"].setdefault(key, {
+        "label": label or rid_text(rid),
+        "byteLength": byte_length,
+        "sha256": None,
+    })
+    return key
+
+
+def save_texture_png(controller: Any, rid: Any, path: Path) -> str | None:
+    if rd is None or is_null_rid(rid):
+        return None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    texsave = rd.TextureSave()
+    texsave.resourceId = rid
+    texsave.mip = 0
+    try:
+        texsave.slice.sliceIndex = 0
+    except Exception:
+        pass
+    try:
+        texsave.alpha = rd.AlphaMapping.Preserve
+    except Exception:
+        pass
+    try:
+        texsave.destType = rd.FileType.PNG
+    except Exception:
+        pass
+    try:
+        controller.SaveTexture(texsave, str(path))
+    except Exception as exc:
+        write_text(path.with_suffix(".error.txt"), f"SaveTexture failed: {exc}\n")
+        return None
+    return str(path.as_posix())
+
+
+def reflect_binding(item: Any, fallback_slot: int | None = None) -> dict[str, Any]:
+    return {
+        "name": str(get_attr(item, "name", default="")),
+        "slot": get_attr(item, "fixedBindNumber", "bindPoint", "reg", default=fallback_slot),
+        "type": enum_name(get_attr(item, "type", "resType", "variableType")),
+    }
+
+
+def reflect_list(items: Iterable[Any] | None) -> list[dict[str, Any]]:
+    return [reflect_binding(item, i) for i, item in enumerate(list(items or []))]
+
+
+def variable_shape(var: Any) -> tuple[Any, Any]:
+    # Modern RenderDoc exposes rows/columns on the ShaderVariable itself;
+    # older builds carry them on var.type. Prefer the variable, fall back to type.
+    typ = get_attr(var, "type")
+    rows = get_attr(var, "rows", default=get_attr(typ, "rows") if typ is not None else None)
+    cols = get_attr(
+        var,
+        "columns",
+        "cols",
+        default=get_attr(typ, "columns", "cols") if typ is not None else None,
+    )
+    return rows, cols
+
+
+def shader_type_name(var: Any) -> str | None:
+    typ = get_attr(var, "type")
+    if typ is None:
+        return None
+    base = get_attr(typ, "name", "baseType", "type")
+    rows, cols = variable_shape(var)
+    elements = get_attr(typ, "elements")
+    suffix = ""
+    if rows and cols:
+        suffix = f"{rows}x{cols}"
+    if elements and elements != 1:
+        suffix = f"{suffix}[{elements}]" if suffix else f"[{elements}]"
+    return f"{enum_name(base)}{suffix}" if base is not None else suffix or enum_name(typ)
+
+
+def numeric_values_from_shader_variable(var: Any) -> list[float | int]:
+    value = get_attr(var, "value")
+    if value is None:
+        return []
+    for attr in ("f32v", "f64v", "s32v", "u32v", "fv", "dv", "iv", "uv"):
+        raw = get_attr(value, attr)
+        if raw is None:
+            continue
+        try:
+            values = list(raw)
+        except Exception:
+            continue
+        if values:
+            return [v for v in values if isinstance(v, (int, float))]
+    return []
+
+
+def variable_to_json(var: Any, prefix: str | None = None) -> list[dict[str, Any]]:
+    raw_name = str(get_attr(var, "name", default=""))
+    name = raw_name
+    if prefix:
+        if raw_name.startswith("["):
+            name = prefix + raw_name
+        elif raw_name:
+            name = prefix + "." + raw_name
+        else:
+            name = prefix
+    if not name:
+        name = "unnamed"
+
+    members = list(get_attr(var, "members", default=[]) or [])
+    values = numeric_values_from_shader_variable(var)
+    if members and not values:
+        flattened: list[dict[str, Any]] = []
+        for member in members:
+            flattened.extend(variable_to_json(member, name))
+        return flattened
+
+    out: dict[str, Any] = {
+        "name": name,
+        "type": shader_type_name(var),
+    }
+    if values:
+        out["value"] = values[0] if len(values) == 1 else values
+        rows, cols = variable_shape(var)
+        if len(values) >= 16 and (rows == 4 and cols == 4 or "bone" in name.lower() or "bones" in name.lower()):
+            out["matrix4x4"] = [float(v) for v in values[:16]]
+    if members:
+        child_members: list[dict[str, Any]] = []
+        for member in members:
+            child_members.extend(variable_to_json(member, name))
+        out["members"] = child_members
+    return [out]
+
+
+def collect_constant_buffers(
+    controller: Any,
+    pipe: Any,
+    resources: dict[str, Any],
+    stage_key: str,
+    stage_label: str,
+    stage: Any,
+    reflection: Any,
+) -> list[dict[str, Any]]:
+    if reflection is None:
+        return []
+    pso = call(pipe, "GetGraphicsPipelineObject")
+    entry = call(pipe, "GetShaderEntryPoint", stage) or ""
+    shader_rid = get_attr(reflection, "resourceId")
+    blocks = list(get_attr(reflection, "constantBlocks", default=[]) or [])
+    out: list[dict[str, Any]] = []
+
+    for index, block_reflection in enumerate(blocks):
+        slot = get_attr(block_reflection, "fixedBindNumber", "bindPoint", default=index)
+        bound = call(pipe, "GetConstantBlock", stage, slot, 0)
+        descriptor = get_attr(bound, "descriptor", default=bound)
+        rid = extract_rid(descriptor)
+        label = get_attr(block_reflection, "name", default=f"{stage_key}_cbuffer_{slot}")
+        byte_length = get_attr(descriptor, "byteSize", "byteLength", "size")
+        buffer_key = record_buffer(resources, rid or f"{stage_key}:{slot}:{label}", label, byte_length)
+
+        variables: list[dict[str, Any]] = []
+        error = None
+        if rid is not None and shader_rid is not None:
+            try:
+                raw_variables = controller.GetCBufferVariableContents(
+                    pso,
+                    shader_rid,
+                    stage,
+                    entry,
+                    slot,
+                    rid,
+                    0,
+                    0,
+                )
+                for variable in raw_variables:
+                    variables.extend(variable_to_json(variable))
+            except Exception as exc:
+                error = str(exc)
+
+        cbuffer = {
+            "name": str(label) if label is not None else None,
+            "stage": stage_label,
+            "slot": slot,
+            "resource": buffer_key,
+            "rawBytesSha256": None,
+            "variables": variables,
+        }
+        if error:
+            cbuffer["extractionError"] = error
+        out.append(cbuffer)
+    return out
+
+
+def disassemble_shader(controller: Any, pipe: Any, reflection: Any) -> str:
+    if reflection is None:
+        return ""
+    targets = call(controller, "GetDisassemblyTargets", True) or call(controller, "GetDisassemblyTargets", False) or []
+    targets = list(targets)
+    target = None
+    for candidate in targets:
+        if "dxbc" in str(candidate).lower():
+            target = candidate
+            break
+    if target is None and targets:
+        target = targets[0]
+    if target is None:
+        target = "dxbc"
+    pso = call(pipe, "GetGraphicsPipelineObject")
+    try:
+        return controller.DisassembleShader(pso, reflection, target) or ""
+    except Exception as exc:
+        return f"; DisassembleShader failed: {exc}\n"
+
+
+def collect_shader(
+    controller: Any,
+    pipe: Any,
+    resources: dict[str, Any],
+    out_dir: Path,
+    ordinal: int,
+    stage_key: str,
+    stage_label: str,
+) -> tuple[str | None, list[dict[str, Any]]]:
+    stage = stage_enum(stage_key)
+    if stage is None:
+        return None, []
+    reflection = call(pipe, "GetShaderReflection", stage)
+    if reflection is None:
+        return None, []
+    shader_rid = get_attr(reflection, "resourceId")
+    if is_null_rid(shader_rid):
+        return None, []
+
+    entry = call(pipe, "GetShaderEntryPoint", stage)
+    disasm = disassemble_shader(controller, pipe, reflection)
+    disasm_hash = sha256_text(disasm)
+    shader_id = f"shader-{stage_key}-{disasm_hash[:16]}"
+    disasm_path = out_dir / "shaders" / f"{ordinal:04d}-{stage_key}-{safe_name(entry, 'main')}-{disasm_hash[:12]}.dxbc.txt"
+    write_text(disasm_path, disasm)
+
+    constant_buffers = collect_constant_buffers(controller, pipe, resources, stage_key, stage_label, stage, reflection)
+    reflection_json = {
+        "samplers": reflect_list(get_attr(reflection, "samplers")),
+        "textures": reflect_list(get_attr(reflection, "readOnlyResources", "readOnlyResourceBindings")),
+        "constantBlocks": reflect_list(get_attr(reflection, "constantBlocks")),
+        "uniforms": [v for cb in constant_buffers for v in cb.get("variables", [])],
+    }
+    resources["shaders"].setdefault(shader_id, {
+        "stage": stage_label,
+        "sourceLanguage": "DXBC",
+        "entryPoint": str(entry) if entry is not None else None,
+        "sourcePath": None,
+        "sourceSha256": None,
+        "disassembly": {
+            "path": str(disasm_path.as_posix()),
+            "sha256": disasm_hash,
+        },
+        "reflection": reflection_json,
+        "renderdocResourceId": rid_text(shader_rid),
+    })
+    return shader_id, constant_buffers
+
+
+def collect_texture_bindings(controller: Any, pipe: Any, resources: dict[str, Any], names: dict[str, str]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for stage_key, stage_label, _ in STAGE_DEFS:
+        stage = stage_enum(stage_key)
+        if stage is None:
+            continue
+        bindings = call(pipe, "GetReadOnlyResources", stage) or []
+        for slot, binding in enumerate(list(bindings)):
+            rid = extract_rid(binding)
+            if is_null_rid(rid):
+                continue
+            tex_key = record_texture(resources, controller, names, rid)
+            out.append({
+                "stage": stage_label,
+                "slot": slot,
+                "name": get_attr(binding, "name"),
+                "resource": tex_key,
+                "renderdocResourceId": rid_text(rid),
+            })
+    return out
+
+
+def collect_samplers(pipe: Any) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for stage_key, stage_label, _ in STAGE_DEFS:
+        stage = stage_enum(stage_key)
+        if stage is None:
+            continue
+        samplers = call(pipe, "GetSamplers", stage) or []
+        for slot, sampler in enumerate(list(samplers)):
+            data = public_fields(sampler) or {}
+            data.update({"stage": stage_label, "slot": slot})
+            out.append(data)
+    return out
+
+
+def collect_targets(
+    controller: Any,
+    pipe: Any,
+    resources: dict[str, Any],
+    names: dict[str, str],
+    out_dir: Path,
+    ordinal: int,
+    event_id: int | None,
+    action: Any,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    color_targets: list[dict[str, Any]] = []
+    output = {"resource": None, "png": None, "sha256": None, "visualStats": {"note": "PNG saved via RenderDoc SaveTexture; pixel statistics intentionally deferred."}}
+
+    # Prefer the bound output-merger targets; fall back to the action's own
+    # output list (stable across RenderDoc builds) so a missing PipeState helper
+    # does not silently drop the pass and yield an empty trace.
+    output_entries: list[tuple[int, Any, Any]] = []
+    for slot, target in enumerate(list(call(pipe, "GetOutputTargets") or [])):
+        rid = extract_rid(target)
+        if not is_null_rid(rid):
+            output_entries.append((slot, target, rid))
+    if not output_entries:
+        for slot, rid in enumerate(list(get_attr(action, "outputs", default=[]) or [])):
+            if not is_null_rid(rid):
+                output_entries.append((slot, None, rid))
+
+    for slot, target, rid in output_entries:
+        label = f"draw-{ordinal:04d}-event-{event_id}"
+        rt_key = record_render_target(resources, controller, names, rid, label)
+        png = out_dir / "rt" / f"pass-{ordinal:04d}-event-{event_id}-color{slot}.png"
+        saved = save_texture_png(controller, rid, png)
+        color_targets.append({
+            "slot": slot,
+            "resource": rt_key,
+            "load": enum_name(get_attr(target, "loadOp", "loadAction")) if target is not None else None,
+            "store": enum_name(get_attr(target, "storeOp", "storeAction")) if target is not None else None,
+            "renderdocResourceId": rid_text(rid),
+            "png": saved,
+        })
+        if output["resource"] is None:
+            output = {
+                "resource": rt_key,
+                "png": saved,
+                "sha256": sha256_file(Path(saved)) if saved else None,
+                "visualStats": {"note": "PNG saved via RenderDoc SaveTexture; pixel statistics intentionally deferred."},
+            }
+
+    depth_target = call(pipe, "GetDepthTarget")
+    depth = None
+    depth_rid = extract_rid(depth_target)
+    if not is_null_rid(depth_rid):
+        depth = {
+            "resource": record_render_target(resources, controller, names, depth_rid, f"depth-draw-{ordinal:04d}"),
+            "load": enum_name(get_attr(depth_target, "loadOp", "loadAction")),
+            "store": enum_name(get_attr(depth_target, "storeOp", "storeAction")),
+            "renderdocResourceId": rid_text(depth_rid),
+        }
+    return {"color": color_targets, "depth": depth}, output
+
+
+def viewport_to_json(viewport: Any) -> list[float]:
+    if viewport is None:
+        return []
+    values = []
+    for name in ("x", "y", "width", "height", "minDepth", "maxDepth"):
+        value = get_attr(viewport, name)
+        if value is not None:
+            try:
+                values.append(float(value))
+            except Exception:
+                pass
+    return values
+
+
+def first_viewport(pipe: Any) -> list[float]:
+    viewport = call(pipe, "GetViewport", 0)
+    if viewport is None:
+        viewports = call(pipe, "GetViewports") or []
+        viewport = list(viewports)[0] if viewports else None
+    return viewport_to_json(viewport)
+
+
+def first_scissor(pipe: Any) -> list[float]:
+    scissor = call(pipe, "GetScissor", 0)
+    if scissor is None:
+        scissors = call(pipe, "GetScissors") or []
+        scissor = list(scissors)[0] if scissors else None
+    return viewport_to_json(scissor)
+
+
+def collect_pipeline_state(pipe: Any) -> dict[str, Any]:
+    return {
+        "blend": public_fields(call_any(pipe, ("GetBlendState", "GetOutputMergerState"))),
+        "depth": public_fields(call_any(pipe, ("GetDepthState", "GetDepthStencilState"))),
+        "raster": public_fields(call_any(pipe, ("GetRasterizerState", "GetRasterState"))),
+        "samplers": collect_samplers(pipe),
+    }
+
+
+def collect_pass(controller: Any, resources: dict[str, Any], names: dict[str, str], out_dir: Path, ordinal: int, action: Any) -> dict[str, Any] | None:
+    event_id = get_attr(action, "eventId")
+    if event_id is None:
+        return None
+    try:
+        controller.SetFrameEvent(event_id, True)
+    except Exception:
+        return None
+    pipe = controller.GetPipelineState()
+    targets, output = collect_targets(controller, pipe, resources, names, out_dir, ordinal, event_id, action)
+    if not targets["color"]:
+        return None
+
+    shaders: dict[str, str | None] = {"vs": None, "fs": None}
+    constant_buffers: list[dict[str, Any]] = []
+    for stage_key, stage_label, _ in STAGE_DEFS:
+        shader_id, cbuffers = collect_shader(controller, pipe, resources, out_dir, ordinal, stage_key, stage_label)
+        shaders[stage_key] = shader_id
+        constant_buffers.extend(cbuffers)
+
+    return {
+        "ordinal": ordinal,
+        "eventId": int(event_id),
+        "layerId": None,
+        "passId": None,
+        "shaderName": action_name(controller, action),
+        "draw": {
+            "topology": enum_name(get_attr(action, "topology", default=call(pipe, "GetPrimitiveTopology"))),
+            "vertexCount": get_attr(action, "numVertices", default=None),
+            "indexCount": get_attr(action, "numIndices", default=None),
+            "instanceCount": get_attr(action, "numInstances", default=None),
+            "viewport": first_viewport(pipe),
+            "scissor": first_scissor(pipe),
+        },
+        "targets": targets,
+        "textures": collect_texture_bindings(controller, pipe, resources, names),
+        "shaders": shaders,
+        "constantBuffers": constant_buffers,
+        "state": collect_pipeline_state(pipe),
+        "output": output,
+    }
+
+
+def infer_resolution(resources: dict[str, Any], job: dict[str, Any]) -> dict[str, int]:
+    explicit = job.get("resolution") or job.get("preferredResolution")
+    if isinstance(explicit, dict) and explicit.get("width") and explicit.get("height"):
+        return {"width": int(explicit["width"]), "height": int(explicit["height"])}
+    best = (1, 1)
+    for rt in resources["renderTargets"].values():
+        w, h = rt.get("width"), rt.get("height")
+        if isinstance(w, int) and isinstance(h, int) and w * h > best[0] * best[1]:
+            best = (w, h)
+    return {"width": best[0], "height": best[1]}
+
+
+def build_trace(args: argparse.Namespace, controller: Any, job: dict[str, Any]) -> dict[str, Any]:
+    out_dir = Path(args.out)
+    resources = {
+        "textures": {},
+        "renderTargets": {},
+        "buffers": {},
+        "shaders": {},
+    }
+    names = resource_names(controller)
+    passes: list[dict[str, Any]] = []
+    for action in walk_actions(root_actions(controller)):
+        if not is_draw_action(action):
+            continue
+        captured = collect_pass(controller, resources, names, out_dir, len(passes), action)
+        if captured is not None:
+            passes.append(captured)
+
+    final = {"resource": None, "png": None, "sha256": None}
+    if passes:
+        last_output = passes[-1]["output"]
+        final = {
+            "resource": last_output.get("resource"),
+            "png": last_output.get("png"),
+            "sha256": last_output.get("sha256"),
+        }
+
+    project_json = args.project_json or job.get("projectJson") or ""
+    project_sha = sha256_file(Path(project_json)) if project_json else None
+    scene_id = args.scene_id or str(job.get("sceneId") or job.get("workshopId") or "")
+    mode = args.mode or job.get("mode") or "shader-first"
+    warmup_ms = int(args.warmup_ms if args.warmup_ms is not None else job.get("warmupMs", 0) or 0)
+    pointer = job.get("pointer") or [0.5, 0.5]
+
+    return {
+        "schema": "wpe.trace.v1",
+        "producer": {
+            "side": "windows-wpe",
+            "tool": "RenderDoc",
+            "toolVersion": renderdoc_version(),
+            "wpeVersion": args.wpe_version,
+            "appBuild": None,
+        },
+        "scene": {
+            "workshopId": scene_id,
+            "projectJson": project_json,
+            "projectJsonSha256": project_sha,
+            "scenePkgSha256": sha256_file(Path(project_json).with_name("scene.pkg")) if project_json else None,
+            "entryFile": "project.json",
+            "assetRoots": [str(Path(project_json).parent)] if project_json else [],
+        },
+        "capture": {
+            "jobId": str(job.get("jobId") or args.job_id or ""),
+            "mode": mode,
+            "frameOrdinal": int(args.frame_ordinal),
+            "warmupMs": warmup_ms,
+            "resolution": infer_resolution(resources, job),
+            "wallpaperWindow": {
+                "class": "WorkerW",
+                "hwnd": job.get("workerWHwnd"),
+                "pid": job.get("wallpaperPid"),
+            },
+            "determinism": {
+                "time": None,
+                "daytime": None,
+                "pointer": pointer,
+                "audioMode": job.get("audioMode", "muted"),
+                "mouseParallax": job.get("mouseParallax", "centered"),
+            },
+        },
+        "resources": resources,
+        "passes": passes,
+        "final": final,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rdc", type=Path, help="Input .rdc capture to replay.")
+    parser.add_argument("--target", type=Path, help="Optional target exe to capture before extraction.")
+    parser.add_argument("--renderdoccmd", type=Path, help="renderdoccmd.exe path when --target is used.")
+    parser.add_argument("--capture-file", type=Path, help="Output .rdc path when --target is used.")
+    parser.add_argument("--working-dir", type=Path, help="Target working directory when --target is used.")
+    parser.add_argument("--out", type=Path, required=True, help="Output windows artifact directory.")
+    parser.add_argument("--job", type=Path, help="Job descriptor JSON.")
+    parser.add_argument("--job-id", default="", help="Job id override.")
+    parser.add_argument("--scene-id", default="", help="Workshop scene id override.")
+    parser.add_argument("--project-json", default="", help="project.json path override.")
+    parser.add_argument("--mode", choices=("shader-first", "state", "full"), default=None)
+    parser.add_argument("--warmup-ms", type=int, default=None)
+    parser.add_argument("--frame-ordinal", type=int, default=0)
+    parser.add_argument("--wpe-version", default="2.8.26")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    args.out.mkdir(parents=True, exist_ok=True)
+    (args.out / "rt").mkdir(parents=True, exist_ok=True)
+    (args.out / "shaders").mkdir(parents=True, exist_ok=True)
+
+    job = read_json(args.job) if args.job else {}
+    rdc = args.rdc
+    if rdc is None and args.target is not None:
+        if args.renderdoccmd is None:
+            raise SystemExit("--renderdoccmd is required with --target")
+        rdc = args.capture_file or args.out / "frame.rdc"
+        capture_with_renderdoccmd(args.renderdoccmd, args.target, rdc, args.working_dir)
+    if rdc is None:
+        raise SystemExit("Either --rdc or --target is required")
+    if not rdc.is_file():
+        raise SystemExit(f"Capture file does not exist: {rdc}")
+
+    cap = controller = None
+    try:
+        cap, controller = open_capture(rdc)
+        trace = build_trace(args, controller, job)
+        write_json(args.out / "trace.json", trace)
+        return 0
+    finally:
+        if cap is not None and controller is not None:
+            shutdown_capture(cap, controller)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/wpe-oracle/extract_replay.py
+++ b/tools/wpe-oracle/extract_replay.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Extract WPE's per-frame GLOBAL conditions from a windows wpe.trace.v1 into a
+compact `replay.json` (wpe.replay.v1) that the Mac renderer's constant-replay
+override (Phase D-1) feeds back into its uniform packing for a controlled
+re-render.
+
+The goal is to eliminate the dynamic NOISE that otherwise dominates a diff —
+capture time, pointer, render resolution — so a re-rendered Mac frame differs
+from WPE only by genuine shader/texture/RT logic. Scope is the frame globals our
+fragment path actually consumes: g_Time, render resolution (drives both the
+render size and g_Texture*Resolution), pointer anchors (g_Point0..3), daytime.
+Per-material statics (g_Speed, g_Strength, ...) come from scene.pkg and are NOT
+replayed here; MVP is moot for our fragment-only fixed-fullscreen-vertex path.
+
+    python3 extract_replay.py --windows windows/trace.json --out replay.json
+
+Only D3D_SVF_USED variables with decoded values are read (the parser marks
+unused reflection slots, which carry no real value).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+# Names that vary per capture (time/pointer) — the whole point of replay is to
+# pin these. Resolution is handled separately (it also drives the render size).
+FRAME_TIME_NAMES = {"g_time", "time", "u_time", "itime"}
+DAYTIME_NAMES = {"g_daytime", "daytime"}
+POINT_PREFIX = "g_point"  # g_Point0..3 — pointer/parallax anchors
+
+
+def load(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def used_variables(trace: dict[str, Any]):
+    """Yield (pass_ordinal, shader_name, var) for every USED, decoded variable."""
+    for p in trace.get("passes", []) or []:
+        shader = p.get("shaderName")
+        ordinal = p.get("ordinal")
+        for cb in p.get("constantBuffers", []) or []:
+            for var in cb.get("variables", []) or []:
+                if var.get("value") is None:
+                    continue
+                if var.get("usedByShader") is False:
+                    continue
+                yield ordinal, shader, var
+
+
+def first_value(trace: dict[str, Any], predicate) -> Optional[Any]:
+    for _, _, var in used_variables(trace):
+        if predicate(var.get("name", "")):
+            return var.get("value")
+    return None
+
+
+def extract_resolution(trace: dict[str, Any]) -> dict[str, int]:
+    cap = (trace.get("capture") or {}).get("resolution") or {}
+    width, height = cap.get("width"), cap.get("height")
+    if width and height:
+        return {"width": int(width), "height": int(height)}
+    # Fall back to g_Texture0Resolution (xy = render-target dimensions).
+    res = first_value(trace, lambda n: n.lower() == "g_texture0resolution")
+    if isinstance(res, list) and len(res) >= 2 and res[0] and res[1]:
+        return {"width": int(res[0]), "height": int(res[1])}
+    return {}
+
+
+def build_replay(trace: dict[str, Any]) -> dict[str, Any]:
+    scene = trace.get("scene") or {}
+    determinism = (trace.get("capture") or {}).get("determinism") or {}
+
+    time_value = first_value(trace, lambda n: n.lower() in FRAME_TIME_NAMES)
+    daytime_value = first_value(trace, lambda n: n.lower() in DAYTIME_NAMES)
+    if daytime_value is None:
+        daytime_value = determinism.get("daytime")
+
+    # Pointer anchors (g_Point0..3) if WPE decoded them; the override applies them
+    # by name, falling back to the capture pointer for the cursor position.
+    points: dict[str, Any] = {}
+    for _, _, var in used_variables(trace):
+        name = var.get("name", "")
+        if name.lower().startswith(POINT_PREFIX):
+            points.setdefault(name, var.get("value"))
+
+    return {
+        "schema": "wpe.replay.v1",
+        "sceneId": str(scene.get("workshopId") or ""),
+        "resolution": extract_resolution(trace),
+        "frame": {
+            "time": time_value,
+            "daytime": daytime_value,
+            "pointer": determinism.get("pointer") or [0.5, 0.5],
+            "points": points or None,
+        },
+        "source": {
+            "producer": (trace.get("producer") or {}).get("side"),
+            "wpeVersion": (trace.get("producer") or {}).get("wpeVersion"),
+        },
+    }
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--windows", type=Path, required=True, help="Windows WPE wpe.trace.v1 JSON.")
+    parser.add_argument("--out", type=Path, required=True, help="Output replay.json (wpe.replay.v1).")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    replay = build_replay(load(args.windows))
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8", newline="\n") as handle:
+        json.dump(replay, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    frame = replay["frame"]
+    res = replay["resolution"]
+    print(f"wrote {args.out}")
+    print(f"  scene={replay['sceneId']} resolution={res.get('width')}x{res.get('height')} "
+          f"time={frame['time']} daytime={frame['daytime']} pointer={frame['pointer']}")
+    print(f"  point anchors: {sorted((frame.get('points') or {}).keys()) or 'none'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/wpe-oracle/job.example.json
+++ b/tools/wpe-oracle/job.example.json
@@ -1,0 +1,23 @@
+{
+  "jobId": "seed-3526278753-shader-first",
+  "sceneId": "3526278753",
+  "mode": "shader-first",
+  "captureMethod": "auto",
+  "wpeVersion": "2.8.26",
+  "wpeRoot": "D:\\Steam\\steamapps\\common\\wallpaper_engine",
+  "workshopRoot": "D:\\Steam\\steamapps\\workshop\\content\\431960",
+  "projectJson": "D:\\Steam\\steamapps\\workshop\\content\\431960\\3526278753\\project.json",
+  "renderDocCmd": "C:\\Program Files\\RenderDoc\\renderdoccmd.exe",
+  "warmupMs": 1500,
+  "frameOrdinal": 0,
+  "preferredResolution": {
+    "width": 3840,
+    "height": 2160
+  },
+  "pointer": [
+    0.5,
+    0.5
+  ],
+  "audioMode": "muted",
+  "mouseParallax": "centered"
+}

--- a/tools/wpe-oracle/parse_capture.py
+++ b/tools/wpe-oracle/parse_capture.py
@@ -26,6 +26,9 @@ from typing import Any, BinaryIO, Iterable
 
 SCHEMA_VERSION = "wpe.trace.v1"
 DEFAULT_WPE_VERSION = "2.8.26"
+D3D11_MAP_WRITE_DISCARD = 4
+D3D11_MAP_WRITE_NO_OVERWRITE = 5
+D3D_SVF_USED = 0x2
 
 RESOURCE_BIND_TYPES = {
     0: "CBUFFER",
@@ -552,6 +555,14 @@ class TraceState:
     samplers: dict[str, dict[int, str]] = field(default_factory=lambda: {"vertex": {}, "fragment": {}})
 
 
+@dataclass
+class PendingMap:
+    resource_id: str
+    subresource: int
+    map_type: int
+    map_type_label: str | None
+
+
 class CaptureParser:
     def __init__(self, capture_dir: Path, out_dir: Path, scene_id: str, project_json: str, wpe_version: str) -> None:
         self.capture_dir = capture_dir
@@ -565,6 +576,8 @@ class CaptureParser:
         self.textures: dict[str, dict[str, Any]] = {}
         self.buffers: dict[str, dict[str, Any]] = {}
         self.buffer_data: dict[str, bytes] = {}
+        self.buffer_backing: dict[str, bytearray] = {}
+        self.pending_maps: dict[tuple[str, int], PendingMap] = {}
         self.rtv_to_texture: dict[str, str] = {}
         self.srv_to_texture: dict[str, str] = {}
         self.dsv_to_texture: dict[str, str] = {}
@@ -634,11 +647,14 @@ class CaptureParser:
         key = self.buffer_key(rid)
         desc = self.buffers.get(rid, {})
         data = self.buffer_data.get(rid, b"")
-        self.resources["buffers"].setdefault(key, {
+        byte_length = desc.get("byteLength") or len(data) or None
+        entry = self.resources["buffers"].setdefault(key, {
             "label": desc.get("label") or f"Buffer {rid}",
-            "byteLength": desc.get("byteLength") or len(data) or None,
-            "sha256": sha256_bytes(data) if data else None,
+            "byteLength": byte_length,
+            "sha256": None,
         })
+        entry["byteLength"] = byte_length
+        entry["sha256"] = sha256_bytes(data) if data else None
         return key
 
     def shader_id_for_resource(self, rid: str | None) -> str | None:
@@ -707,9 +723,11 @@ class CaptureParser:
             self.handle_set_shader_resources(chunk, "vertex" if "::VS" in name else "fragment")
         elif name in ("ID3D11DeviceContext::VSSetSamplers", "ID3D11DeviceContext::PSSetSamplers"):
             self.handle_set_samplers(chunk, "vertex" if "::VS" in name else "fragment")
+        elif name == "ID3D11DeviceContext::Map":
+            self.handle_map(chunk)
         elif name == "ID3D11DeviceContext::Unmap":
             self.handle_unmap(chunk)
-        elif name == "ID3D11DeviceContext::UpdateSubresource":
+        elif name in ("ID3D11DeviceContext::UpdateSubresource", "ID3D11DeviceContext::UpdateSubresource1"):
             self.handle_update_subresource(chunk)
         elif name == "ID3D11DeviceContext::DrawIndexed":
             self.emit_draw(chunk, indexed=True)
@@ -756,9 +774,62 @@ class CaptureParser:
             "bindFlags": bind_flags,
         }
         blob_index, _ = buffer_ref(chunk, "InitialData")
+        self.ensure_buffer_backing(rid, byte_width)
         data = self.blobs.read_blob(blob_index)
         if data:
-            self.buffer_data[rid] = data
+            self.write_buffer_data(rid, data, offset=0, discard=True)
+        else:
+            self.publish_buffer_data(rid)
+
+    def buffer_byte_width(self, rid: str) -> int:
+        desc = self.buffers.get(rid, {})
+        width = desc.get("byteLength")
+        if isinstance(width, int) and width > 0:
+            return width
+        return max(len(self.buffer_backing.get(rid, b"")), len(self.buffer_data.get(rid, b"")))
+
+    def ensure_buffer_backing(self, rid: str, min_size: int = 0) -> bytearray:
+        size = max(min_size, self.buffer_byte_width(rid))
+        backing = self.buffer_backing.get(rid)
+        if backing is None:
+            old = self.buffer_data.get(rid, b"")
+            size = max(size, len(old))
+            backing = bytearray(size)
+            backing[:min(len(old), size)] = old[:size]
+            self.buffer_backing[rid] = backing
+        elif len(backing) < size:
+            backing.extend(b"\x00" * (size - len(backing)))
+        return backing
+
+    def publish_buffer_data(self, rid: str) -> None:
+        backing = self.buffer_backing.get(rid)
+        if backing is not None:
+            self.buffer_data[rid] = bytes(backing)
+
+    def write_buffer_data(self, rid: str, data: bytes, offset: int = 0, discard: bool = False) -> None:
+        if not rid:
+            return
+        offset = max(offset, 0)
+        byte_width = self.buffer_byte_width(rid)
+        needed = max(byte_width, offset + len(data))
+        if discard:
+            self.buffer_backing[rid] = bytearray(needed)
+        backing = self.ensure_buffer_backing(rid, needed)
+        backing[offset:offset + len(data)] = data
+        self.publish_buffer_data(rid)
+
+    def handle_map(self, chunk: ET.Element) -> None:
+        rid = rid_child(chunk, "pResource")
+        if rid is None:
+            return
+        subresource = int_child(chunk, "Subresource")
+        map_type = int_child(chunk, "MapType")
+        self.pending_maps[(rid, subresource)] = PendingMap(
+            resource_id=rid,
+            subresource=subresource,
+            map_type=map_type,
+            map_type_label=enum_value(direct(chunk, "MapType")),
+        )
 
     def handle_create_shader(self, chunk: ET.Element, stage: str) -> None:
         rid = rid_child(chunk, "pShader")
@@ -855,19 +926,51 @@ class CaptureParser:
 
     def handle_unmap(self, chunk: ET.Element) -> None:
         rid = rid_child(chunk, "pResource")
-        blob_index, _ = buffer_ref(chunk, "MapWrittenData")
+        if rid is None:
+            return
+        subresource = int_child(chunk, "Subresource")
+        pending = self.pending_maps.pop((rid, subresource), None)
+        map_type = int_child(chunk, "MapType", pending.map_type if pending is not None else 0)
+        start = int_child(chunk, "Byte offset to start of written data")
+        end = int_child(chunk, "Byte offset to end of written data")
+        blob_index, byte_length = buffer_ref(chunk, "MapWrittenData")
         data = self.blobs.read_blob(blob_index)
-        if rid and data:
-            self.buffer_data[rid] = data
-            self.record_buffer_resource(rid)
+        if not data:
+            return
+        expected = max(end - start, 0)
+        if expected and len(data) > expected:
+            data = data[:expected]
+        elif byte_length is not None and byte_length > 0 and len(data) > byte_length:
+            data = data[:byte_length]
+        discard = map_type == D3D11_MAP_WRITE_DISCARD
+        self.write_buffer_data(rid, data, offset=start, discard=discard)
+        self.record_buffer_resource(rid)
 
     def handle_update_subresource(self, chunk: ET.Element) -> None:
         rid = rid_child(chunk, "pDstResource")
-        blob_index, _ = buffer_ref(chunk, "pSrcData")
+        if rid is None:
+            return
+        offset, limit = self.update_subresource_range(chunk)
+        blob_index, byte_length = buffer_ref(chunk, "pSrcData")
         data = self.blobs.read_blob(blob_index)
-        if rid and data:
-            self.buffer_data[rid] = data
-            self.record_buffer_resource(rid)
+        if not data:
+            return
+        if limit is not None and limit >= offset:
+            data = data[:limit - offset]
+        elif byte_length is not None and byte_length > 0 and len(data) > byte_length:
+            data = data[:byte_length]
+        self.write_buffer_data(rid, data, offset=offset, discard=False)
+        self.record_buffer_resource(rid)
+
+    def update_subresource_range(self, chunk: ET.Element) -> tuple[int, int | None]:
+        box = direct(chunk, "pDstBox") or direct(chunk, "DstBox")
+        if box is None:
+            return 0, None
+        left = int_child(box, "left", int_child(box, "Left"))
+        right = int_child(box, "right", int_child(box, "Right", -1))
+        if right < left:
+            right = None
+        return max(left, 0), right
 
     def emit_draw(self, chunk: ET.Element, indexed: bool) -> None:
         ordinal = len(self.passes)
@@ -1013,7 +1116,12 @@ class CaptureParser:
                 slot = cbuffer.get("bindPoint")
                 bound_rid = self.state.constant_buffers[stage].get(slot)
                 data = self.buffer_data.get(bound_rid or "", b"")
-                variables = [decode_variable_value(v, data) for v in cbuffer.get("variables", [])]
+                cb_vars = cbuffer.get("variables", [])
+                # Defensive fallback: if a compiler emitted ALL-zero variable flags
+                # (no D3D_SVF_USED on any), the used-gate would silently drop every
+                # value — decode them all instead of returning an empty cbuffer.
+                force_used = bool(cb_vars) and all((v.get("flags") or 0) == 0 for v in cb_vars)
+                variables = [decode_variable_value(v, data, force_used=force_used) for v in cb_vars]
                 out.append({
                     "name": cbuffer.get("name"),
                     "stage": stage,
@@ -1142,24 +1250,33 @@ def binding_md(binding: dict[str, Any]) -> dict[str, Any]:
 
 def variable_schema(var: dict[str, Any]) -> dict[str, Any]:
     typ = var.get("type", {})
+    flags = int(var.get("flags") or 0)
     return {
         "name": var.get("name", ""),
         "type": f"{typ.get('class')}<{typ.get('type')}>",
         "startOffset": var.get("startOffset"),
         "size": var.get("size"),
+        "flags": flags,
+        "usedByShader": bool(flags & D3D_SVF_USED),
         "rows": typ.get("rows"),
         "cols": typ.get("cols"),
         "elements": typ.get("elements"),
     }
 
 
-def decode_variable_value(var: dict[str, Any], data: bytes) -> dict[str, Any]:
+def decode_variable_value(var: dict[str, Any], data: bytes, force_used: bool = False) -> dict[str, Any]:
     out = variable_schema(var)
     start = int(var.get("startOffset") or 0)
     size = int(var.get("size") or 0)
     raw = data[start:start + size] if start < len(data) else b""
     typ = var.get("type", {})
     rows = int(typ.get("rows") or 0)
+    if not out["usedByShader"] and not force_used:
+        out["valueStatus"] = "unused-reflection-slot"
+        if raw:
+            out["rawBytesSha256"] = sha256_bytes(raw)
+        return out
+
     cols = int(typ.get("cols") or 0)
     elements = int(typ.get("elements") or 1)
     values = decode_scalar_values(raw, typ.get("type"))

--- a/tools/wpe-oracle/parse_capture.py
+++ b/tools/wpe-oracle/parse_capture.py
@@ -1,0 +1,1199 @@
+#!/usr/bin/env python3
+"""Parse RenderDoc zip.xml D3D11 captures into wpe.trace.v1.
+
+RenderDoc 1.44 does not expose a standalone `renderdoc` Python module outside
+qrenderdoc. The headless path is:
+
+  renderdoccmd convert -f frame.rdc -o frame.zip.xml -c zip.xml
+
+This script runs on macOS with stdlib only and parses the structured XML plus
+the companion `blobs/000000` files or `frame.zip` blob archive.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import struct
+import sys
+import zipfile
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, BinaryIO, Iterable
+
+
+SCHEMA_VERSION = "wpe.trace.v1"
+DEFAULT_WPE_VERSION = "2.8.26"
+
+RESOURCE_BIND_TYPES = {
+    0: "CBUFFER",
+    1: "TBUFFER",
+    2: "TEXTURE",
+    3: "SAMPLER",
+    4: "UAV_RWTYPED",
+    5: "STRUCTURED",
+    6: "UAV_RWSTRUCTURED",
+    7: "BYTEADDRESS",
+    8: "UAV_RWBYTEADDRESS",
+    9: "UAV_APPEND_STRUCTURED",
+    10: "UAV_CONSUME_STRUCTURED",
+    11: "UAV_RWSTRUCTURED_WITH_COUNTER",
+}
+
+SHADER_VARIABLE_CLASSES = {
+    0: "scalar",
+    1: "vector",
+    2: "matrix_rows",
+    3: "matrix_columns",
+    4: "object",
+    5: "struct",
+    6: "interface_class",
+    7: "interface_pointer",
+}
+
+SHADER_VARIABLE_TYPES = {
+    0: "void",
+    1: "bool",
+    2: "int",
+    3: "float",
+    4: "string",
+    5: "texture",
+    6: "texture1d",
+    7: "texture2d",
+    8: "texture3d",
+    9: "texturecube",
+    10: "sampler",
+    11: "sampler1d",
+    12: "sampler2d",
+    13: "sampler3d",
+    14: "samplercube",
+    15: "pixelshader",
+    16: "vertexshader",
+    17: "uint",
+    18: "uint8",
+    19: "geometryshader",
+    20: "rasterizer",
+    21: "depthstencil",
+    22: "blend",
+    23: "buffer",
+    24: "cbuffer",
+    25: "tbuffer",
+    26: "texture1darray",
+    27: "texture2darray",
+    28: "rendertargetview",
+    29: "depthstencilview",
+    30: "texture2dms",
+    31: "texture2dmsarray",
+    32: "texturecubearray",
+    33: "hullshader",
+    34: "domainshader",
+    35: "interface_pointer",
+    36: "compute_shader",
+    37: "double",
+    38: "rwttexture1d",
+    39: "rwtexture1darray",
+    40: "rwtexture2d",
+    41: "rwtexture2darray",
+    42: "rwtexture3d",
+    43: "rwbuffer",
+    44: "byteaddress_buffer",
+    45: "rwbyteaddress_buffer",
+    46: "structured_buffer",
+    47: "rwstructured_buffer",
+    48: "append_structured_buffer",
+    49: "consume_structured_buffer",
+}
+
+COMPONENT_TYPES = {
+    0: "unknown",
+    1: "uint32",
+    2: "sint32",
+    3: "float32",
+}
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str | None:
+    try:
+        h = hashlib.sha256()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8", newline="\n") as f:
+        json.dump(value, f, indent=2, sort_keys=True)
+        f.write("\n")
+    tmp.replace(path)
+
+
+def write_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8", newline="\n")
+
+
+def cstr(buf: bytes, offset: int | None) -> str:
+    if offset is None or offset == 0xFFFFFFFF or offset < 0 or offset >= len(buf):
+        return ""
+    end = buf.find(b"\x00", offset)
+    if end < 0:
+        end = len(buf)
+    return buf[offset:end].decode("utf-8", errors="replace")
+
+
+def valid_cstr(buf: bytes, offset: int | None) -> bool:
+    return bool(cstr(buf, offset))
+
+
+def u32(buf: bytes, offset: int) -> int:
+    return struct.unpack_from("<I", buf, offset)[0]
+
+
+def text(elem: ET.Element | None) -> str:
+    return (elem.text or "").strip() if elem is not None else ""
+
+
+def direct(elem: ET.Element, name: str | None = None, tag: str | None = None) -> ET.Element | None:
+    for child in list(elem):
+        if name is not None and child.get("name") != name:
+            continue
+        if tag is not None and child.tag != tag:
+            continue
+        return child
+    return None
+
+
+def find_named(elem: ET.Element, name: str) -> ET.Element | None:
+    for child in elem.iter():
+        if child.get("name") == name:
+            return child
+    return None
+
+
+def int_child(elem: ET.Element, name: str, default: int = 0) -> int:
+    child = direct(elem, name)
+    if child is None:
+        child = find_named(elem, name)
+    try:
+        return int(text(child), 0)
+    except ValueError:
+        return default
+
+
+def float_child(elem: ET.Element, name: str, default: float = 0.0) -> float:
+    child = direct(elem, name)
+    if child is None:
+        child = find_named(elem, name)
+    try:
+        return float(text(child))
+    except ValueError:
+        return default
+
+
+def rid_child(elem: ET.Element, name: str) -> str | None:
+    child = direct(elem, name, "ResourceId")
+    if child is None:
+        child = find_named(elem, name)
+    value = text(child)
+    return None if value in ("", "0") else value
+
+
+def array_resource_ids(elem: ET.Element, name: str) -> list[str | None]:
+    arr = direct(elem, name, "array")
+    if arr is None:
+        return []
+    out: list[str | None] = []
+    for child in list(arr):
+        value = text(child)
+        out.append(None if value in ("", "0") else value)
+    return out
+
+
+def buffer_ref(elem: ET.Element, name: str | None = None) -> tuple[int | None, int | None]:
+    for child in elem.iter("buffer"):
+        if name is not None and child.get("name") != name:
+            continue
+        raw = text(child)
+        try:
+            index = int(raw)
+        except ValueError:
+            index = None
+        byte_length = child.get("byteLength")
+        return index, int(byte_length) if byte_length and byte_length.isdigit() else None
+    return None, None
+
+
+def enum_value(elem: ET.Element | None) -> str | None:
+    if elem is None:
+        return None
+    return elem.get("string") or text(elem) or None
+
+
+def xml_value(elem: ET.Element) -> Any:
+    if len(list(elem)) == 0:
+        raw = text(elem)
+        if elem.tag == "bool":
+            return raw.lower() == "true"
+        if elem.tag in ("uint", "int"):
+            try:
+                return int(raw, 0)
+            except ValueError:
+                return raw
+        if elem.tag == "float":
+            try:
+                return float(raw)
+            except ValueError:
+                return raw
+        if elem.tag == "enum":
+            return elem.get("string") or raw
+        return raw
+    values: dict[str, Any] = {}
+    for child in list(elem):
+        key = child.get("name") or child.get("typename") or child.tag
+        child_value = xml_value(child)
+        if key in values:
+            existing = values[key]
+            if not isinstance(existing, list):
+                values[key] = [existing]
+            values[key].append(child_value)
+        else:
+            values[key] = child_value
+    return values
+
+
+class BlobStore:
+    def __init__(self, capture_dir: Path) -> None:
+        self.capture_dir = capture_dir
+        self.blob_dir = capture_dir / "blobs"
+        self.zip_path = capture_dir / "frame.zip"
+        self._zip: zipfile.ZipFile | None = None
+
+    def close(self) -> None:
+        if self._zip is not None:
+            self._zip.close()
+            self._zip = None
+
+    @property
+    def zip(self) -> zipfile.ZipFile | None:
+        if self._zip is None and self.zip_path.is_file():
+            self._zip = zipfile.ZipFile(self.zip_path)
+        return self._zip
+
+    def open_xml(self) -> BinaryIO:
+        xml_path = self.capture_dir / "frame.zip.xml"
+        if xml_path.is_file():
+            return xml_path.open("rb")
+        archive = self.zip
+        if archive is not None:
+            for name in archive.namelist():
+                if name.endswith(".xml"):
+                    return archive.open(name)
+        raise FileNotFoundError(f"no frame.zip.xml found in {self.capture_dir}")
+
+    def read_blob(self, index: int | None) -> bytes:
+        if index is None:
+            return b""
+        name = f"{index:06d}"
+        disk_path = self.blob_dir / name
+        if disk_path.is_file():
+            return disk_path.read_bytes()
+        archive = self.zip
+        if archive is not None:
+            try:
+                return archive.read(name)
+            except KeyError:
+                pass
+        return b""
+
+
+def parse_signature(data: bytes, fourcc: str) -> list[dict[str, Any]]:
+    if len(data) < 8:
+        return []
+    count = u32(data, 0)
+    prefer = (28, 24) if fourcc.endswith("1") else (24, 28)
+    stride = prefer[-1]
+    for candidate in prefer:
+        if 8 + count * candidate <= len(data):
+            offsets = []
+            for i in range(count):
+                rec_off = 8 + i * candidate
+                name_off = u32(data, rec_off + (4 if candidate >= 28 else 0))
+                offsets.append(name_off)
+            if all(valid_cstr(data, offset) for offset in offsets):
+                stride = candidate
+                break
+
+    out: list[dict[str, Any]] = []
+    for i in range(count):
+        rec_off = 8 + i * stride
+        if rec_off + stride > len(data):
+            break
+        if stride >= 28:
+            stream, name_off, semantic_index, system_value, component_type, register, packed = struct.unpack_from("<IIIIIII", data, rec_off)
+        else:
+            stream = None
+            name_off, semantic_index, system_value, component_type, register, packed = struct.unpack_from("<IIIIII", data, rec_off)
+        out.append({
+            "semanticName": cstr(data, name_off),
+            "semanticIndex": semantic_index,
+            "stream": stream,
+            "systemValueType": system_value,
+            "componentType": COMPONENT_TYPES.get(component_type, str(component_type)),
+            "register": register,
+            "mask": packed & 0xFF,
+            "readWriteMask": (packed >> 8) & 0xFF,
+        })
+    return out
+
+
+def choose_resource_stride(data: bytes, offset: int, count: int) -> int:
+    for stride in (32, 40, 48):
+        if offset + count * stride > len(data):
+            continue
+        if all(valid_cstr(data, u32(data, offset + i * stride)) for i in range(count)):
+            return stride
+    return 32
+
+
+def choose_variable_stride(data: bytes, offset: int, count: int) -> int:
+    for stride in (40, 24):
+        if offset + count * stride > len(data):
+            continue
+        if all(valid_cstr(data, u32(data, offset + i * stride)) for i in range(count)):
+            return stride
+    return 40
+
+
+def parse_type_desc(data: bytes, offset: int) -> dict[str, Any]:
+    if offset <= 0 or offset + 12 > len(data):
+        return {"class": None, "type": None, "rows": None, "cols": None, "elements": None}
+    class_id, type_id, rows, cols, elements, members = struct.unpack_from("<HHHHHH", data, offset)
+    return {
+        "class": SHADER_VARIABLE_CLASSES.get(class_id, str(class_id)),
+        "type": SHADER_VARIABLE_TYPES.get(type_id, str(type_id)),
+        "rows": rows,
+        "cols": cols,
+        "elements": elements or None,
+        "members": members or None,
+    }
+
+
+def parse_rdef(data: bytes) -> dict[str, Any]:
+    if len(data) < 28:
+        return {"constantBuffers": [], "resourceBindings": [], "creator": ""}
+    cb_count, cb_offset, binding_count, binding_offset, shader_version, flags, creator_offset = struct.unpack_from("<IIIIIII", data, 0)
+    binding_stride = choose_resource_stride(data, binding_offset, binding_count)
+
+    bindings: list[dict[str, Any]] = []
+    for i in range(binding_count):
+        rec_off = binding_offset + i * binding_stride
+        if rec_off + 32 > len(data):
+            break
+        name_off, type_id, return_type, dimension, sample_count, bind_point, bind_count, bind_flags = struct.unpack_from("<IIIIIIII", data, rec_off)
+        extra: list[int] = []
+        if binding_stride > 32 and rec_off + binding_stride <= len(data):
+            extra = list(struct.unpack_from("<" + "I" * ((binding_stride - 32) // 4), data, rec_off + 32))
+        bindings.append({
+            "name": cstr(data, name_off),
+            "type": RESOURCE_BIND_TYPES.get(type_id, str(type_id)),
+            "returnType": return_type,
+            "dimension": dimension,
+            "sampleCount": sample_count,
+            "bindPoint": bind_point,
+            "bindCount": bind_count,
+            "flags": bind_flags,
+            "extra": extra,
+        })
+
+    binding_by_name = {b["name"]: b for b in bindings}
+    cbuffers: list[dict[str, Any]] = []
+    for i in range(cb_count):
+        rec_off = cb_offset + i * 24
+        if rec_off + 24 > len(data):
+            break
+        name_off, var_count, var_offset, size, cb_flags, cb_type = struct.unpack_from("<IIIIII", data, rec_off)
+        name = cstr(data, name_off)
+        var_stride = choose_variable_stride(data, var_offset, var_count)
+        variables: list[dict[str, Any]] = []
+        for j in range(var_count):
+            var_off = var_offset + j * var_stride
+            if var_off + 24 > len(data):
+                break
+            fields = list(struct.unpack_from("<IIIIII", data, var_off))
+            start_texture = texture_size = start_sampler = sampler_size = None
+            if var_stride >= 40 and var_off + 40 <= len(data):
+                fields = list(struct.unpack_from("<IIIIIIIIII", data, var_off))
+                start_texture, texture_size, start_sampler, sampler_size = fields[6], fields[7], fields[8], fields[9]
+            var_name_off, start_offset, var_size, var_flags, type_offset, default_offset = fields[:6]
+            type_desc = parse_type_desc(data, type_offset)
+            variable = {
+                "name": cstr(data, var_name_off),
+                "startOffset": start_offset,
+                "size": var_size,
+                "flags": var_flags,
+                "type": type_desc,
+            }
+            if default_offset not in (0, 0xFFFFFFFF):
+                variable["defaultValueOffset"] = default_offset
+            if start_texture not in (None, 0xFFFFFFFF):
+                variable["startTexture"] = start_texture
+                variable["textureSize"] = texture_size
+            if start_sampler not in (None, 0xFFFFFFFF):
+                variable["startSampler"] = start_sampler
+                variable["samplerSize"] = sampler_size
+            variables.append(variable)
+        binding = binding_by_name.get(name, {})
+        cbuffers.append({
+            "name": name,
+            "size": size,
+            "flags": cb_flags,
+            "type": cb_type,
+            "bindPoint": binding.get("bindPoint", i),
+            "bindCount": binding.get("bindCount", 1),
+            "variables": variables,
+        })
+    return {
+        "constantBuffers": cbuffers,
+        "resourceBindings": bindings,
+        "shaderVersion": shader_version,
+        "flags": flags,
+        "creator": cstr(data, creator_offset),
+    }
+
+
+def parse_dxbc(data: bytes) -> dict[str, Any]:
+    if len(data) < 32 or data[:4] != b"DXBC":
+        return {
+            "valid": False,
+            "sha256": sha256_bytes(data),
+            "chunks": [],
+            "rdef": {"constantBuffers": [], "resourceBindings": [], "creator": ""},
+            "signatures": {},
+        }
+    version, total_size, chunk_count = struct.unpack_from("<III", data, 20)
+    chunk_offsets = struct.unpack_from("<" + "I" * chunk_count, data, 32)
+    chunks: list[dict[str, Any]] = []
+    signatures: dict[str, list[dict[str, Any]]] = {}
+    rdef = {"constantBuffers": [], "resourceBindings": [], "creator": ""}
+    shex_payload = b""
+    for offset in chunk_offsets:
+        if offset + 8 > len(data):
+            continue
+        fourcc = data[offset:offset + 4].decode("ascii", errors="replace")
+        size = u32(data, offset + 4)
+        payload = data[offset + 8: offset + 8 + size]
+        chunks.append({"fourcc": fourcc, "offset": offset, "size": size})
+        if fourcc == "RDEF":
+            rdef = parse_rdef(payload)
+        elif fourcc in ("ISGN", "OSGN", "ISG1", "OSG1", "PCSG"):
+            signatures[fourcc] = parse_signature(payload, fourcc)
+        elif fourcc in ("SHEX", "SHDR"):
+            shex_payload = payload
+    stable_payload = shex_payload or data
+    return {
+        "valid": True,
+        "version": version,
+        "totalSize": total_size,
+        "sha256": sha256_bytes(data),
+        "stableShaderSha256": sha256_bytes(stable_payload),
+        "chunks": chunks,
+        "rdef": rdef,
+        "signatures": signatures,
+    }
+
+
+@dataclass
+class ShaderRecord:
+    stage: str
+    resource_id: str
+    blob_index: int
+    shader_id: str
+    dxbc: dict[str, Any]
+
+
+@dataclass
+class TraceState:
+    vertex_shader: str | None = None
+    fragment_shader: str | None = None
+    topology: str | None = None
+    input_layout: str | None = None
+    vertex_buffers: dict[int, str] = field(default_factory=dict)
+    index_buffer: str | None = None
+    render_targets: list[str | None] = field(default_factory=list)
+    depth_target: str | None = None
+    viewport: list[float] = field(default_factory=list)
+    blend_state: str | None = None
+    constant_buffers: dict[str, dict[int, str]] = field(default_factory=lambda: {"vertex": {}, "fragment": {}})
+    shader_resources: dict[str, dict[int, str]] = field(default_factory=lambda: {"vertex": {}, "fragment": {}})
+    samplers: dict[str, dict[int, str]] = field(default_factory=lambda: {"vertex": {}, "fragment": {}})
+
+
+class CaptureParser:
+    def __init__(self, capture_dir: Path, out_dir: Path, scene_id: str, project_json: str, wpe_version: str) -> None:
+        self.capture_dir = capture_dir
+        self.out_dir = out_dir
+        self.scene_id = scene_id
+        self.project_json = project_json
+        self.wpe_version = wpe_version
+        self.blobs = BlobStore(capture_dir)
+        self.state = TraceState()
+
+        self.textures: dict[str, dict[str, Any]] = {}
+        self.buffers: dict[str, dict[str, Any]] = {}
+        self.buffer_data: dict[str, bytes] = {}
+        self.rtv_to_texture: dict[str, str] = {}
+        self.srv_to_texture: dict[str, str] = {}
+        self.dsv_to_texture: dict[str, str] = {}
+        self.samplers: dict[str, dict[str, Any]] = {}
+        self.blend_states: dict[str, dict[str, Any]] = {}
+        self.shaders_by_resource: dict[str, ShaderRecord] = {}
+        self.shader_interfaces: dict[str, ShaderRecord] = {}
+
+        self.resources: dict[str, dict[str, Any]] = {
+            "textures": {},
+            "renderTargets": {},
+            "buffers": {},
+            "shaders": {},
+        }
+        self.passes: list[dict[str, Any]] = []
+
+    def close(self) -> None:
+        self.blobs.close()
+
+    def texture_key(self, rid: str) -> str:
+        return f"tex-{rid}"
+
+    def rt_key(self, rid: str) -> str:
+        return f"rt-{rid}"
+
+    def buffer_key(self, rid: str) -> str:
+        return f"buf-{rid}"
+
+    def record_texture_resource(self, texture_rid: str | None) -> str | None:
+        if texture_rid is None:
+            return None
+        key = self.texture_key(texture_rid)
+        desc = self.textures.get(texture_rid, {})
+        self.resources["textures"].setdefault(key, {
+            "label": desc.get("label") or f"Texture {texture_rid}",
+            "sourcePath": None,
+            "width": desc.get("width"),
+            "height": desc.get("height"),
+            "format": desc.get("format"),
+            "mips": desc.get("mips"),
+            "sha256": None,
+            "png": None,
+        })
+        return key
+
+    def record_render_target_resource(self, view_rid: str | None, ordinal: int) -> str | None:
+        if view_rid is None:
+            return None
+        texture_rid = self.rtv_to_texture.get(view_rid) or self.dsv_to_texture.get(view_rid) or view_rid
+        desc = self.textures.get(texture_rid, {})
+        key = self.rt_key(texture_rid)
+        entry = self.resources["renderTargets"].setdefault(key, {
+            "label": desc.get("label") or f"RT {texture_rid}",
+            "width": desc.get("width"),
+            "height": desc.get("height"),
+            "format": desc.get("format"),
+            "lineage": [],
+        })
+        marker = f"pass-{ordinal:04d}"
+        if marker not in entry["lineage"]:
+            entry["lineage"].append(marker)
+        return key
+
+    def record_buffer_resource(self, rid: str | None) -> str | None:
+        if rid is None:
+            return None
+        key = self.buffer_key(rid)
+        desc = self.buffers.get(rid, {})
+        data = self.buffer_data.get(rid, b"")
+        self.resources["buffers"].setdefault(key, {
+            "label": desc.get("label") or f"Buffer {rid}",
+            "byteLength": desc.get("byteLength") or len(data) or None,
+            "sha256": sha256_bytes(data) if data else None,
+        })
+        return key
+
+    def shader_id_for_resource(self, rid: str | None) -> str | None:
+        if rid is None:
+            return None
+        record = self.shaders_by_resource.get(rid)
+        return record.shader_id if record is not None else None
+
+    def parse(self) -> dict[str, Any]:
+        with self.blobs.open_xml() as xml_stream:
+            for _, elem in ET.iterparse(xml_stream, events=("end",)):
+                if elem.tag == "chunk":
+                    self.handle_chunk(elem)
+                    elem.clear()
+        trace = self.build_trace()
+        write_json(self.out_dir / "trace.json", trace)
+        write_text(self.out_dir / "shader-interface.md", self.shader_interface_markdown())
+        return trace
+
+    def handle_chunk(self, chunk: ET.Element) -> None:
+        name = chunk.get("name") or ""
+        if name == "IDXGISwapChain::GetBuffer":
+            self.handle_swapchain_get_buffer(chunk)
+        elif name == "ID3D11Device::CreateTexture2D":
+            self.handle_create_texture2d(chunk)
+        elif name == "ID3D11Device::CreateBuffer":
+            self.handle_create_buffer(chunk)
+        elif name == "ID3D11Device::CreateRenderTargetView":
+            self.rtv_to_texture[rid_child(chunk, "pView") or ""] = rid_child(chunk, "pResource") or ""
+        elif name == "ID3D11Device::CreateDepthStencilView":
+            self.dsv_to_texture[rid_child(chunk, "pView") or ""] = rid_child(chunk, "pResource") or ""
+        elif name == "ID3D11Device::CreateShaderResourceView":
+            self.srv_to_texture[rid_child(chunk, "pView") or ""] = rid_child(chunk, "pResource") or ""
+        elif name == "ID3D11Device::CreateSamplerState":
+            desc = direct(chunk, "Descriptor")
+            self.samplers[rid_child(chunk, "pSamplerState") or rid_child(chunk, "pState") or ""] = xml_value(desc if desc is not None else chunk)
+        elif name == "ID3D11Device::CreateBlendState":
+            desc = direct(chunk, "Descriptor")
+            self.blend_states[rid_child(chunk, "pState") or ""] = xml_value(desc if desc is not None else chunk)
+        elif name == "ID3D11Device::CreateVertexShader":
+            self.handle_create_shader(chunk, "vertex")
+        elif name == "ID3D11Device::CreatePixelShader":
+            self.handle_create_shader(chunk, "fragment")
+        elif name == "ID3D11DeviceContext::VSSetShader":
+            self.state.vertex_shader = rid_child(chunk, "pVertexShader") or rid_child(chunk, "pShader")
+        elif name == "ID3D11DeviceContext::PSSetShader":
+            self.state.fragment_shader = rid_child(chunk, "pPixelShader") or rid_child(chunk, "pShader")
+        elif name == "ID3D11DeviceContext::IASetPrimitiveTopology":
+            self.state.topology = enum_value(direct(chunk, "Topology"))
+        elif name == "ID3D11DeviceContext::IASetInputLayout":
+            self.state.input_layout = rid_child(chunk, "pInputLayout")
+        elif name == "ID3D11DeviceContext::IASetVertexBuffers":
+            self.handle_set_vertex_buffers(chunk)
+        elif name == "ID3D11DeviceContext::IASetIndexBuffer":
+            self.state.index_buffer = rid_child(chunk, "pIndexBuffer")
+        elif name == "ID3D11DeviceContext::RSSetViewports":
+            self.handle_set_viewports(chunk)
+        elif name == "ID3D11DeviceContext::OMSetBlendState":
+            self.state.blend_state = rid_child(chunk, "pBlendState")
+        elif name == "ID3D11DeviceContext::OMSetRenderTargets":
+            self.state.render_targets = array_resource_ids(chunk, "ppRenderTargetViews")
+            self.state.depth_target = rid_child(chunk, "pDepthStencilView")
+        elif name in ("ID3D11DeviceContext::VSSetConstantBuffers", "ID3D11DeviceContext::PSSetConstantBuffers"):
+            self.handle_set_constant_buffers(chunk, "vertex" if "::VS" in name else "fragment")
+        elif name in ("ID3D11DeviceContext::VSSetShaderResources", "ID3D11DeviceContext::PSSetShaderResources"):
+            self.handle_set_shader_resources(chunk, "vertex" if "::VS" in name else "fragment")
+        elif name in ("ID3D11DeviceContext::VSSetSamplers", "ID3D11DeviceContext::PSSetSamplers"):
+            self.handle_set_samplers(chunk, "vertex" if "::VS" in name else "fragment")
+        elif name == "ID3D11DeviceContext::Unmap":
+            self.handle_unmap(chunk)
+        elif name == "ID3D11DeviceContext::UpdateSubresource":
+            self.handle_update_subresource(chunk)
+        elif name == "ID3D11DeviceContext::DrawIndexed":
+            self.emit_draw(chunk, indexed=True)
+        elif name == "ID3D11DeviceContext::Draw":
+            self.emit_draw(chunk, indexed=False)
+
+    def handle_swapchain_get_buffer(self, chunk: ET.Element) -> None:
+        rid = rid_child(chunk, "SwapbufferID")
+        desc = direct(chunk, "BackbufferDescriptor")
+        if rid is None or desc is None:
+            return
+        self.textures[rid] = {
+            "label": "Swap Chain Backbuffer",
+            "width": int_child(desc, "Width"),
+            "height": int_child(desc, "Height"),
+            "mips": 1,
+            "format": enum_value(find_named(desc, "Format")),
+        }
+
+    def handle_create_texture2d(self, chunk: ET.Element) -> None:
+        rid = rid_child(chunk, "pTexture")
+        desc = direct(chunk, "Descriptor")
+        if rid is None or desc is None:
+            return
+        self.textures[rid] = {
+            "label": f"Texture2D {rid}",
+            "width": int_child(desc, "Width"),
+            "height": int_child(desc, "Height"),
+            "mips": int_child(desc, "MipLevels", 1),
+            "format": enum_value(find_named(desc, "Format")),
+            "bindFlags": enum_value(find_named(desc, "BindFlags")),
+        }
+
+    def handle_create_buffer(self, chunk: ET.Element) -> None:
+        rid = rid_child(chunk, "pBuffer")
+        desc = direct(chunk, "pDesc")
+        if rid is None:
+            return
+        byte_width = int_child(desc, "ByteWidth") if desc is not None else 0
+        bind_flags = enum_value(find_named(desc, "BindFlags")) if desc is not None else None
+        self.buffers[rid] = {
+            "label": f"Buffer {rid}",
+            "byteLength": byte_width or None,
+            "bindFlags": bind_flags,
+        }
+        blob_index, _ = buffer_ref(chunk, "InitialData")
+        data = self.blobs.read_blob(blob_index)
+        if data:
+            self.buffer_data[rid] = data
+
+    def handle_create_shader(self, chunk: ET.Element, stage: str) -> None:
+        rid = rid_child(chunk, "pShader")
+        blob_index, _ = buffer_ref(chunk, "pShaderBytecode")
+        if rid is None or blob_index is None:
+            return
+        data = self.blobs.read_blob(blob_index)
+        dxbc = parse_dxbc(data)
+        stable = dxbc.get("stableShaderSha256") or dxbc.get("sha256") or sha256_bytes(data)
+        shader_id = f"shader-{'vs' if stage == 'vertex' else 'fs'}-{stable[:16]}"
+        record = ShaderRecord(stage=stage, resource_id=rid, blob_index=blob_index, shader_id=shader_id, dxbc=dxbc)
+        self.shaders_by_resource[rid] = record
+        self.shader_interfaces[shader_id] = record
+        rdef = dxbc.get("rdef", {})
+        bindings = rdef.get("resourceBindings", [])
+        cbuffers = rdef.get("constantBuffers", [])
+        reflection = {
+            "samplers": [binding_md(b) for b in bindings if b.get("type") == "SAMPLER"],
+            "textures": [binding_md(b) for b in bindings if b.get("type") == "TEXTURE"],
+            "constantBlocks": [binding_md(b) for b in bindings if b.get("type") == "CBUFFER"],
+            "uniforms": [variable_schema(v) for cb in cbuffers for v in cb.get("variables", [])],
+            "inputSignature": dxbc.get("signatures", {}).get("ISGN") or dxbc.get("signatures", {}).get("ISG1") or [],
+            "outputSignature": dxbc.get("signatures", {}).get("OSGN") or dxbc.get("signatures", {}).get("OSG1") or [],
+            "dxbcChunks": dxbc.get("chunks", []),
+            "creator": rdef.get("creator", ""),
+        }
+        self.resources["shaders"][shader_id] = {
+            "stage": stage,
+            "sourceLanguage": "DXBC",
+            "entryPoint": None,
+            "sourcePath": f"blobs/{blob_index:06d}",
+            "sourceSha256": dxbc.get("sha256"),
+            "disassembly": {
+                "path": None,
+                "sha256": stable,
+            },
+            "reflection": reflection,
+            "renderdocResourceId": rid,
+        }
+
+    def handle_set_vertex_buffers(self, chunk: ET.Element) -> None:
+        start = int_child(chunk, "StartSlot")
+        buffers = array_resource_ids(chunk, "ppVertexBuffers")
+        for i, rid in enumerate(buffers):
+            if rid is None:
+                self.state.vertex_buffers.pop(start + i, None)
+            else:
+                self.state.vertex_buffers[start + i] = rid
+
+    def handle_set_viewports(self, chunk: ET.Element) -> None:
+        arr = direct(chunk, "pViewports", "array")
+        if arr is None or not list(arr):
+            self.state.viewport = []
+            return
+        vp = list(arr)[0]
+        self.state.viewport = [
+            float_child(vp, "TopLeftX"),
+            float_child(vp, "TopLeftY"),
+            float_child(vp, "Width"),
+            float_child(vp, "Height"),
+            float_child(vp, "MinDepth"),
+            float_child(vp, "MaxDepth"),
+        ]
+
+    def handle_set_constant_buffers(self, chunk: ET.Element, stage: str) -> None:
+        start = int_child(chunk, "StartSlot")
+        buffers = array_resource_ids(chunk, "ppConstantBuffers")
+        for i, rid in enumerate(buffers):
+            slot = start + i
+            if rid is None:
+                self.state.constant_buffers[stage].pop(slot, None)
+            else:
+                self.state.constant_buffers[stage][slot] = rid
+
+    def handle_set_shader_resources(self, chunk: ET.Element, stage: str) -> None:
+        start = int_child(chunk, "StartSlot")
+        srvs = array_resource_ids(chunk, "ppShaderResourceViews")
+        for i, rid in enumerate(srvs):
+            slot = start + i
+            if rid is None:
+                self.state.shader_resources[stage].pop(slot, None)
+            else:
+                self.state.shader_resources[stage][slot] = rid
+
+    def handle_set_samplers(self, chunk: ET.Element, stage: str) -> None:
+        start = int_child(chunk, "StartSlot")
+        samplers = array_resource_ids(chunk, "ppSamplers")
+        for i, rid in enumerate(samplers):
+            slot = start + i
+            if rid is None:
+                self.state.samplers[stage].pop(slot, None)
+            else:
+                self.state.samplers[stage][slot] = rid
+
+    def handle_unmap(self, chunk: ET.Element) -> None:
+        rid = rid_child(chunk, "pResource")
+        blob_index, _ = buffer_ref(chunk, "MapWrittenData")
+        data = self.blobs.read_blob(blob_index)
+        if rid and data:
+            self.buffer_data[rid] = data
+            self.record_buffer_resource(rid)
+
+    def handle_update_subresource(self, chunk: ET.Element) -> None:
+        rid = rid_child(chunk, "pDstResource")
+        blob_index, _ = buffer_ref(chunk, "pSrcData")
+        data = self.blobs.read_blob(blob_index)
+        if rid and data:
+            self.buffer_data[rid] = data
+            self.record_buffer_resource(rid)
+
+    def emit_draw(self, chunk: ET.Element, indexed: bool) -> None:
+        ordinal = len(self.passes)
+        event_id = int(chunk.get("chunkIndex") or chunk.get("id") or ordinal)
+        color_targets: list[dict[str, Any]] = []
+        for slot, view_rid in enumerate(self.state.render_targets):
+            rt_key = self.record_render_target_resource(view_rid, ordinal)
+            if rt_key is None:
+                continue
+            color_targets.append({
+                "slot": slot,
+                "resource": rt_key,
+                "load": None,
+                "store": None,
+                "renderdocView": view_rid,
+            })
+        depth = None
+        if self.state.depth_target:
+            depth_key = self.record_render_target_resource(self.state.depth_target, ordinal)
+            if depth_key:
+                depth = {
+                    "resource": depth_key,
+                    "load": None,
+                    "store": None,
+                    "renderdocView": self.state.depth_target,
+                }
+
+        output_resource = color_targets[0]["resource"] if color_targets else None
+        pass_record = {
+            "ordinal": ordinal,
+            "eventId": event_id,
+            "layerId": None,
+            "passId": None,
+            "shaderName": None,
+            "draw": self.draw_record(chunk, indexed),
+            "targets": {
+                "color": color_targets,
+                "depth": depth,
+            },
+            "textures": self.texture_bindings_for_pass(),
+            "shaders": {
+                "vs": self.shader_id_for_resource(self.state.vertex_shader),
+                "fs": self.shader_id_for_resource(self.state.fragment_shader),
+            },
+            "constantBuffers": self.constant_buffers_for_pass(),
+            "state": {
+                "blend": {
+                    "resource": self.state.blend_state,
+                    "descriptor": self.blend_states.get(self.state.blend_state or ""),
+                },
+                "depth": None,
+                "raster": None,
+                "samplers": self.samplers_for_pass(),
+            },
+            "output": {
+                "resource": output_resource,
+                "png": None,
+                "sha256": None,
+                "visualStats": {"note": "RenderDoc convert path has no replay readback; PNG intentionally unavailable."},
+            },
+        }
+        self.passes.append(pass_record)
+
+    def draw_record(self, chunk: ET.Element, indexed: bool) -> dict[str, Any]:
+        if indexed:
+            vertex_count = None
+            index_count = int_child(chunk, "IndexCount")
+            start = int_child(chunk, "StartIndexLocation")
+        else:
+            vertex_count = int_child(chunk, "VertexCount")
+            index_count = None
+            start = int_child(chunk, "StartVertexLocation")
+        return {
+            "topology": self.state.topology,
+            "vertexCount": vertex_count,
+            "indexCount": index_count,
+            "instanceCount": 1,
+            "viewport": self.state.viewport,
+            "scissor": [],
+            "start": start,
+            "indexed": indexed,
+        }
+
+    def texture_bindings_for_pass(self) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for stage in ("vertex", "fragment"):
+            shader = self.shader_for_stage(stage)
+            bindings = shader.dxbc.get("rdef", {}).get("resourceBindings", []) if shader else []
+            names_by_slot = {
+                b.get("bindPoint"): b.get("name")
+                for b in bindings
+                if b.get("type") == "TEXTURE"
+            }
+            for slot, srv_rid in sorted(self.state.shader_resources[stage].items()):
+                texture_rid = self.srv_to_texture.get(srv_rid, srv_rid)
+                tex_key = self.record_texture_resource(texture_rid)
+                if tex_key is None:
+                    continue
+                out.append({
+                    "stage": stage,
+                    "slot": slot,
+                    "name": names_by_slot.get(slot),
+                    "resource": tex_key,
+                    "renderdocView": srv_rid,
+                })
+        return out
+
+    def samplers_for_pass(self) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for stage in ("vertex", "fragment"):
+            shader = self.shader_for_stage(stage)
+            bindings = shader.dxbc.get("rdef", {}).get("resourceBindings", []) if shader else []
+            names_by_slot = {
+                b.get("bindPoint"): b.get("name")
+                for b in bindings
+                if b.get("type") == "SAMPLER"
+            }
+            for slot, sampler_rid in sorted(self.state.samplers[stage].items()):
+                entry = {
+                    "stage": stage,
+                    "slot": slot,
+                    "name": names_by_slot.get(slot),
+                    "resource": sampler_rid,
+                }
+                descriptor = self.samplers.get(sampler_rid)
+                if descriptor is not None:
+                    entry["descriptor"] = descriptor
+                out.append(entry)
+        return out
+
+    def shader_for_stage(self, stage: str) -> ShaderRecord | None:
+        rid = self.state.vertex_shader if stage == "vertex" else self.state.fragment_shader
+        return self.shaders_by_resource.get(rid or "")
+
+    def constant_buffers_for_pass(self) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for stage in ("vertex", "fragment"):
+            shader = self.shader_for_stage(stage)
+            if shader is None:
+                continue
+            cbuffers = shader.dxbc.get("rdef", {}).get("constantBuffers", [])
+            for cbuffer in cbuffers:
+                slot = cbuffer.get("bindPoint")
+                bound_rid = self.state.constant_buffers[stage].get(slot)
+                data = self.buffer_data.get(bound_rid or "", b"")
+                variables = [decode_variable_value(v, data) for v in cbuffer.get("variables", [])]
+                out.append({
+                    "name": cbuffer.get("name"),
+                    "stage": stage,
+                    "slot": slot,
+                    "resource": self.record_buffer_resource(bound_rid),
+                    "rawBytesSha256": sha256_bytes(data) if data else None,
+                    "variables": variables,
+                    "byteLength": len(data) if data else None,
+                })
+        return out
+
+    def build_trace(self) -> dict[str, Any]:
+        width, height = self.infer_resolution()
+        final = {"resource": None, "png": None, "sha256": None}
+        if self.passes:
+            output = self.passes[-1]["output"]
+            final = {"resource": output.get("resource"), "png": None, "sha256": None}
+        return {
+            "schema": SCHEMA_VERSION,
+            "producer": {
+                "side": "windows-wpe",
+                "tool": "renderdoccmd convert",
+                "toolVersion": None,
+                "wpeVersion": self.wpe_version,
+                "appBuild": None,
+            },
+            "scene": {
+                "workshopId": self.scene_id,
+                "projectJson": self.project_json,
+                "projectJsonSha256": sha256_file(Path(self.project_json)) if self.project_json else None,
+                "scenePkgSha256": sha256_file(Path(self.project_json).with_name("scene.pkg")) if self.project_json else None,
+                "entryFile": "project.json",
+                "assetRoots": [str(Path(self.project_json).parent)] if self.project_json else [],
+            },
+            "capture": {
+                "jobId": self.capture_dir.parent.name if self.capture_dir.name == "windows" else self.capture_dir.name,
+                "mode": "shader-first",
+                "frameOrdinal": 0,
+                "resolution": {"width": width, "height": height},
+                "wallpaperWindow": {"class": "WorkerW", "hwnd": None, "pid": None},
+                "determinism": {"time": None, "daytime": None, "pointer": [0.5, 0.5], "audioMode": "muted", "mouseParallax": "centered"},
+            },
+            "resources": self.resources,
+            "passes": self.passes,
+            "final": final,
+        }
+
+    def infer_resolution(self) -> tuple[int, int]:
+        best = (1, 1)
+        for tex in self.textures.values():
+            width, height = tex.get("width") or 0, tex.get("height") or 0
+            if width * height > best[0] * best[1]:
+                best = (int(width), int(height))
+        return best
+
+    def shader_interface_markdown(self) -> str:
+        lines = [
+            "# WPE Shader Interface",
+            "",
+            f"Capture: `{self.capture_dir}`",
+            "",
+        ]
+        for shader_id in sorted(self.shader_interfaces):
+            record = self.shader_interfaces[shader_id]
+            rdef = record.dxbc.get("rdef", {})
+            sigs = record.dxbc.get("signatures", {})
+            lines.extend([
+                f"## {record.stage} `{shader_id}`",
+                "",
+                f"- RenderDoc resource: `{record.resource_id}`",
+                f"- Blob: `blobs/{record.blob_index:06d}`",
+                f"- SHA256: `{record.dxbc.get('stableShaderSha256') or record.dxbc.get('sha256')}`",
+                f"- DXBC chunks: {', '.join(c['fourcc'] for c in record.dxbc.get('chunks', []))}",
+                "",
+                "### Resource Bindings",
+                "",
+                "| name | type | bindPoint | bindCount |",
+                "| --- | --- | ---: | ---: |",
+            ])
+            for binding in rdef.get("resourceBindings", []):
+                lines.append(f"| {binding.get('name','')} | {binding.get('type','')} | {binding.get('bindPoint','')} | {binding.get('bindCount','')} |")
+            lines.extend(["", "### Constant Buffers", ""])
+            for cb in rdef.get("constantBuffers", []):
+                lines.extend([
+                    f"#### `{cb.get('name')}` slot {cb.get('bindPoint')} size {cb.get('size')}",
+                    "",
+                    "| variable | offset | size | class | type | rows | cols | elements |",
+                    "| --- | ---: | ---: | --- | --- | ---: | ---: | ---: |",
+                ])
+                for var in cb.get("variables", []):
+                    typ = var.get("type", {})
+                    lines.append(
+                        f"| {var.get('name','')} | {var.get('startOffset','')} | {var.get('size','')} | "
+                        f"{typ.get('class','')} | {typ.get('type','')} | {typ.get('rows','')} | {typ.get('cols','')} | {typ.get('elements','')} |"
+                    )
+                lines.append("")
+            for label, keys in (("Input Signature", ("ISGN", "ISG1")), ("Output Signature", ("OSGN", "OSG1"))):
+                params = []
+                for key in keys:
+                    params = sigs.get(key) or []
+                    if params:
+                        break
+                lines.extend([
+                    f"### {label}",
+                    "",
+                    "| semantic | index | register | mask | component |",
+                    "| --- | ---: | ---: | ---: | --- |",
+                ])
+                for param in params:
+                    lines.append(
+                        f"| {param.get('semanticName','')} | {param.get('semanticIndex','')} | "
+                        f"{param.get('register','')} | {param.get('mask','')} | {param.get('componentType','')} |"
+                    )
+                lines.append("")
+        return "\n".join(lines)
+
+
+def binding_md(binding: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": binding.get("name", ""),
+        "slot": binding.get("bindPoint"),
+        "type": binding.get("type"),
+        "bindCount": binding.get("bindCount"),
+    }
+
+
+def variable_schema(var: dict[str, Any]) -> dict[str, Any]:
+    typ = var.get("type", {})
+    return {
+        "name": var.get("name", ""),
+        "type": f"{typ.get('class')}<{typ.get('type')}>",
+        "startOffset": var.get("startOffset"),
+        "size": var.get("size"),
+        "rows": typ.get("rows"),
+        "cols": typ.get("cols"),
+        "elements": typ.get("elements"),
+    }
+
+
+def decode_variable_value(var: dict[str, Any], data: bytes) -> dict[str, Any]:
+    out = variable_schema(var)
+    start = int(var.get("startOffset") or 0)
+    size = int(var.get("size") or 0)
+    raw = data[start:start + size] if start < len(data) else b""
+    typ = var.get("type", {})
+    rows = int(typ.get("rows") or 0)
+    cols = int(typ.get("cols") or 0)
+    values: list[float | int] = []
+    if raw and typ.get("type") in ("float", "double"):
+        count = len(raw) // 4
+        if count:
+            values = list(struct.unpack_from("<" + "f" * count, raw, 0))
+    elif raw:
+        values = list(raw)
+    if values:
+        out["value"] = values[0] if len(values) == 1 else values
+        if rows == 4 and cols == 4 and len(values) >= 16:
+            out["matrix4x4"] = [float(v) for v in values[:16]]
+    if raw:
+        out["rawBytesSha256"] = sha256_bytes(raw)
+    return out
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture-dir", type=Path, required=True, help="Directory containing frame.zip.xml and blobs/ or frame.zip.")
+    parser.add_argument("--out", type=Path, help="Output directory. Defaults to --capture-dir.")
+    parser.add_argument("--scene-id", default="3526278753")
+    parser.add_argument("--project-json", default="")
+    parser.add_argument("--wpe-version", default=DEFAULT_WPE_VERSION)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    capture_dir = args.capture_dir
+    out_dir = args.out or capture_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    parser = CaptureParser(
+        capture_dir=capture_dir,
+        out_dir=out_dir,
+        scene_id=args.scene_id,
+        project_json=args.project_json,
+        wpe_version=args.wpe_version,
+    )
+    try:
+        trace = parser.parse()
+    finally:
+        parser.close()
+    print(f"wrote {out_dir / 'trace.json'} ({len(trace['passes'])} passes, {len(trace['resources']['shaders'])} shaders)")
+    print(f"wrote {out_dir / 'shader-interface.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/wpe-oracle/parse_capture.py
+++ b/tools/wpe-oracle/parse_capture.py
@@ -113,6 +113,8 @@ COMPONENT_TYPES = {
     3: "float32",
 }
 
+SIGNATURE_CHUNKS = {"ISGN", "OSGN", "ISG1", "OSG1", "ISG5", "OSG5", "PCSG"}
+
 
 def sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
@@ -481,8 +483,19 @@ def parse_dxbc(data: bytes) -> dict[str, Any]:
             "rdef": {"constantBuffers": [], "resourceBindings": [], "creator": ""},
             "signatures": {},
         }
-    version, total_size, chunk_count = struct.unpack_from("<III", data, 20)
-    chunk_offsets = struct.unpack_from("<" + "I" * chunk_count, data, 32)
+    try:
+        version, total_size, chunk_count = struct.unpack_from("<III", data, 20)
+        if 32 + 4 * chunk_count > len(data):
+            raise struct.error("DXBC chunk table exceeds blob length")
+        chunk_offsets = struct.unpack_from("<" + "I" * chunk_count, data, 32)
+    except struct.error:
+        return {
+            "valid": False,
+            "sha256": sha256_bytes(data),
+            "chunks": [],
+            "rdef": {"constantBuffers": [], "resourceBindings": [], "creator": ""},
+            "signatures": {},
+        }
     chunks: list[dict[str, Any]] = []
     signatures: dict[str, list[dict[str, Any]]] = {}
     rdef = {"constantBuffers": [], "resourceBindings": [], "creator": ""}
@@ -496,7 +509,7 @@ def parse_dxbc(data: bytes) -> dict[str, Any]:
         chunks.append({"fourcc": fourcc, "offset": offset, "size": size})
         if fourcc == "RDEF":
             rdef = parse_rdef(payload)
-        elif fourcc in ("ISGN", "OSGN", "ISG1", "OSG1", "PCSG"):
+        elif fourcc in SIGNATURE_CHUNKS:
             signatures[fourcc] = parse_signature(payload, fourcc)
         elif fourcc in ("SHEX", "SHDR"):
             shex_payload = payload
@@ -767,8 +780,8 @@ class CaptureParser:
             "textures": [binding_md(b) for b in bindings if b.get("type") == "TEXTURE"],
             "constantBlocks": [binding_md(b) for b in bindings if b.get("type") == "CBUFFER"],
             "uniforms": [variable_schema(v) for cb in cbuffers for v in cb.get("variables", [])],
-            "inputSignature": dxbc.get("signatures", {}).get("ISGN") or dxbc.get("signatures", {}).get("ISG1") or [],
-            "outputSignature": dxbc.get("signatures", {}).get("OSGN") or dxbc.get("signatures", {}).get("OSG1") or [],
+            "inputSignature": first_signature(dxbc, ("ISGN", "ISG1", "ISG5")),
+            "outputSignature": first_signature(dxbc, ("OSGN", "OSG1", "OSG5")),
             "dxbcChunks": dxbc.get("chunks", []),
             "creator": rdef.get("creator", ""),
         }
@@ -1097,7 +1110,7 @@ class CaptureParser:
                         f"{typ.get('class','')} | {typ.get('type','')} | {typ.get('rows','')} | {typ.get('cols','')} | {typ.get('elements','')} |"
                     )
                 lines.append("")
-            for label, keys in (("Input Signature", ("ISGN", "ISG1")), ("Output Signature", ("OSGN", "OSG1"))):
+            for label, keys in (("Input Signature", ("ISGN", "ISG1", "ISG5")), ("Output Signature", ("OSGN", "OSG1", "OSG5")), ("Patch Constant Signature", ("PCSG",))):
                 params = []
                 for key in keys:
                     params = sigs.get(key) or []
@@ -1148,20 +1161,62 @@ def decode_variable_value(var: dict[str, Any], data: bytes) -> dict[str, Any]:
     typ = var.get("type", {})
     rows = int(typ.get("rows") or 0)
     cols = int(typ.get("cols") or 0)
-    values: list[float | int] = []
-    if raw and typ.get("type") in ("float", "double"):
-        count = len(raw) // 4
-        if count:
-            values = list(struct.unpack_from("<" + "f" * count, raw, 0))
-    elif raw:
-        values = list(raw)
+    elements = int(typ.get("elements") or 1)
+    values = decode_scalar_values(raw, typ.get("type"))
     if values:
         out["value"] = values[0] if len(values) == 1 else values
         if rows == 4 and cols == 4 and len(values) >= 16:
-            out["matrix4x4"] = [float(v) for v in values[:16]]
+            # WPE/HLSL constant-buffer matrices are column-major; expose the raw
+            # 16 floats plus a row-major view for comparison against our
+            # column-major Metal matrices.
+            major = "row" if typ.get("class") == "matrix_rows" else "column"
+            out["matrixMajor"] = major
+            mats, row_major = [], []
+            for i in range(max(1, elements)):
+                chunk = values[i * 16:(i + 1) * 16]
+                if len(chunk) < 16:
+                    break
+                m = [float(v) for v in chunk]
+                mats.append(m)
+                row_major.append(m if major == "row" else transpose_square4(m))
+            if mats:
+                out["matrix4x4"] = mats[0]
+                out["matrix4x4RowMajor"] = row_major[0]
+            if len(mats) > 1:
+                out["matrix4x4Array"] = mats
+                out["matrix4x4RowMajorArray"] = row_major
     if raw:
         out["rawBytesSha256"] = sha256_bytes(raw)
     return out
+
+
+def decode_scalar_values(raw: bytes, value_type: str | None) -> list[float | int | bool]:
+    if not raw:
+        return []
+    if value_type == "double":
+        count = len(raw) // 8
+        return list(struct.unpack_from("<" + "d" * count, raw, 0)) if count else []
+    fmt = {"float": "f", "int": "i", "uint": "I", "bool": "I"}.get(value_type)
+    if fmt is None:
+        return list(raw)
+    count = len(raw) // 4
+    if not count:
+        return []
+    values = list(struct.unpack_from("<" + fmt * count, raw, 0))
+    return [bool(v) for v in values] if value_type == "bool" else values
+
+
+def transpose_square4(values: list[float | int | bool]) -> list[float]:
+    return [float(values[c * 4 + r]) for r in range(4) for c in range(4)]
+
+
+def first_signature(dxbc: dict[str, Any], keys: Iterable[str]) -> list[dict[str, Any]]:
+    signatures = dxbc.get("signatures", {})
+    for key in keys:
+        params = signatures.get(key)
+        if params:
+            return params
+    return []
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/tools/wpe-oracle/run_once.cmd
+++ b/tools/wpe-oracle/run_once.cmd
@@ -1,0 +1,352 @@
+@echo off
+setlocal EnableExtensions DisableDelayedExpansion
+
+rem WPE Runtime Oracle one-shot launcher.
+rem User-launched in the interactive Windows desktop session only.
+rem No scheduled task, no admin requirement, no -ExecutionPolicy Bypass.
+
+set "SCRIPT_DIR=%~dp0"
+set "ROOT=%SCRIPT_DIR%"
+set "DEFAULT_WPE_ROOT=D:\Steam\steamapps\common\wallpaper_engine"
+set "DEFAULT_WORKSHOP_ROOT=D:\Steam\steamapps\workshop\content\431960"
+set "DEFAULT_SCENE_ID=3526278753"
+set "STATUS=failed"
+set "HOOK_METHOD=none"
+set "ERROR_TEXT="
+
+if "%~1"=="" (
+  echo Usage:
+  echo   run_once.cmd job.example.json
+  echo   run_once.cmd jobs\my-job.json
+  echo   run_once.cmd my-job-id
+  echo   run_once.cmd jobs\my-job.json extract-only
+  exit /b 2
+)
+
+set "JOB_ARG=%~1"
+if exist "%JOB_ARG%" (
+  set "JOB_FILE=%JOB_ARG%"
+) else if exist "%ROOT%jobs\%JOB_ARG%.json" (
+  set "JOB_FILE=%ROOT%jobs\%JOB_ARG%.json"
+) else (
+  echo [wpe-oracle] job not found: %JOB_ARG%
+  exit /b 2
+)
+
+for %%I in ("%JOB_FILE%") do set "JOB_FILE=%%~fI"
+
+call :read_job
+if errorlevel 1 exit /b 2
+
+set "OUT_DIR=%ROOT%captures\%JOB_ID%\windows"
+rem renderdoccmd appends a frame suffix to --capture-file, so capture to a
+rem template (frame) and resolve the newest frame*.rdc afterwards. Manual UI
+rem saves to frame.rdc, which the same glob matches.
+set "RDC_TEMPLATE=%OUT_DIR%\frame"
+set "RDC_SAVE_AS=%OUT_DIR%\frame.rdc"
+set "RDC_FILE="
+set "DONE_JSON=%ROOT%captures\%JOB_ID%\done.json"
+set "EXTRACTOR=%ROOT%extract_renderdoc_trace.py"
+
+if not exist "%OUT_DIR%" mkdir "%OUT_DIR%" >nul 2>&1
+if not exist "%OUT_DIR%\rt" mkdir "%OUT_DIR%\rt" >nul 2>&1
+if not exist "%OUT_DIR%\shaders" mkdir "%OUT_DIR%\shaders" >nul 2>&1
+
+echo [wpe-oracle] job=%JOB_ID%
+echo [wpe-oracle] scene=%SCENE_ID%
+echo [wpe-oracle] project=%PROJECT_JSON%
+echo [wpe-oracle] mode=%MODE%
+echo [wpe-oracle] out=%OUT_DIR%
+
+call :find_renderdoc
+if errorlevel 1 goto fail
+
+call :set_dpi_and_center_pointer
+
+if /i "%~2"=="extract-only" (
+  call :find_newest_rdc
+  if errorlevel 1 (
+    set "ERROR_TEXT=extract-only requested but no %OUT_DIR%\frame*.rdc exists"
+    goto fail
+  )
+  set "HOOK_METHOD=manual-ui"
+  goto extract
+)
+
+if /i "%CAPTURE_METHOD%"=="launch-under" goto capture_launch_under
+if /i "%CAPTURE_METHOD%"=="inject" goto capture_inject
+if /i "%CAPTURE_METHOD%"=="ui" goto ui_fallback
+
+call :detect_wpe_pid
+if defined WPE_PID (
+  goto capture_inject
+) else (
+  goto capture_launch_under
+)
+
+:capture_launch_under
+set "HOOK_METHOD=launch-under"
+echo [wpe-oracle] hook=%HOOK_METHOD% starting wallpaper64.exe under RenderDoc
+echo [wpe-oracle] launch: "%RENDERDOCCMD%" capture --capture-file "%RDC_TEMPLATE%" --working-dir "%WPE_ROOT%" "%WPE_EXE%"
+
+rem Background the capture: renderdoccmd stays attached for the target's
+rem lifetime, and the wallpaper runs indefinitely, so a foreground call would
+rem never return.
+start "WPE RenderDoc capture" /min "%RENDERDOCCMD%" capture ^
+  --capture-file "%RDC_TEMPLATE%" ^
+  --working-dir "%WPE_ROOT%" ^
+  --opt-hook-children ^
+  "%WPE_EXE%"
+
+timeout /t 3 /nobreak >nul
+call :switch_scene
+call :set_dpi_and_center_pointer
+call :warmup
+call :prompt_renderdoc_trigger
+call :wait_for_rdc 120
+if errorlevel 1 (
+  echo [wpe-oracle] hook=launch-under did not produce an .rdc; trying inject if a WPE process is visible.
+  call :detect_wpe_pid
+  if defined WPE_PID goto capture_inject
+  goto ui_fallback
+)
+echo [wpe-oracle] hook=launch-under status=succeeded
+goto extract
+
+:capture_inject
+set "HOOK_METHOD=inject"
+echo [wpe-oracle] hook=%HOOK_METHOD% switching WPE scene before capture
+call :switch_scene
+call :set_dpi_and_center_pointer
+call :warmup
+call :detect_wpe_pid
+if not defined WPE_PID (
+  echo [wpe-oracle] no wallpaper64.exe PID found for inject
+  goto ui_fallback
+)
+
+echo [wpe-oracle] hook=inject pid=%WPE_PID%
+rem PID is positional for `renderdoccmd inject`; it returns a target-control
+rem ident (non-zero) on success, so we background it and watch for the .rdc
+rem instead of testing errorlevel.
+start "WPE RenderDoc inject" /min "%RENDERDOCCMD%" inject ^
+  --capture-file "%RDC_TEMPLATE%" ^
+  "%WPE_PID%"
+
+call :prompt_renderdoc_trigger
+call :wait_for_rdc 120
+if errorlevel 1 goto ui_fallback
+echo [wpe-oracle] hook=inject status=succeeded
+goto extract
+
+:ui_fallback
+set "HOOK_METHOD=needs-ui"
+echo.
+echo [wpe-oracle] AUTO HOOK DID NOT CAPTURE.
+echo [wpe-oracle] Feasibility signal: RenderDoc CLI alone did not produce a capture for WorkerW/WPE.
+echo [wpe-oracle] Manual fallback (RenderDoc UI, interactive session):
+echo   1. Open RenderDoc.
+echo   2. File ^> Inject into Process, search "wallpaper64.exe", click Inject.
+echo   3. Once the wallpaper is visible, click "Capture Frame(s) Immediately"
+echo      in the connection panel (or press F12 / PrintScreen).
+echo   4. Select the capture, File ^> Save Capture As, and save it as:
+echo      %RDC_SAVE_AS%
+echo   5. Re-run:
+echo      %~nx0 "%JOB_FILE%" extract-only
+set "STATUS=needs-ui"
+call :write_done
+exit /b 3
+
+:extract
+call :find_newest_rdc
+echo [wpe-oracle] extracting RenderDoc trace from %RDC_FILE%
+if not exist "%RDC_FILE%" (
+  set "ERROR_TEXT=missing capture under %OUT_DIR% (no frame*.rdc)"
+  goto fail
+)
+
+"%RENDERDOCCMD%" python "%EXTRACTOR%" ^
+  --rdc "%RDC_FILE%" ^
+  --out "%OUT_DIR%" ^
+  --job "%JOB_FILE%" ^
+  --job-id "%JOB_ID%" ^
+  --scene-id "%SCENE_ID%" ^
+  --project-json "%PROJECT_JSON%" ^
+  --mode "%MODE%" ^
+  --warmup-ms "%WARMUP_MS%" ^
+  --frame-ordinal "%FRAME_ORDINAL%" ^
+  --wpe-version "%WPE_VERSION%"
+
+if errorlevel 1 (
+  echo [wpe-oracle] renderdoccmd python failed; trying python from PATH for environments with renderdoc module installed.
+  python "%EXTRACTOR%" ^
+    --rdc "%RDC_FILE%" ^
+    --out "%OUT_DIR%" ^
+    --job "%JOB_FILE%" ^
+    --job-id "%JOB_ID%" ^
+    --scene-id "%SCENE_ID%" ^
+    --project-json "%PROJECT_JSON%" ^
+    --mode "%MODE%" ^
+    --warmup-ms "%WARMUP_MS%" ^
+    --frame-ordinal "%FRAME_ORDINAL%" ^
+    --wpe-version "%WPE_VERSION%"
+)
+
+if errorlevel 1 (
+  set "ERROR_TEXT=extract_renderdoc_trace.py failed (see console stdout/stderr)"
+  goto fail
+)
+
+if not exist "%OUT_DIR%\trace.json" (
+  set "ERROR_TEXT=extractor completed without trace.json"
+  goto fail
+)
+
+set "STATUS=succeeded"
+call :write_done
+echo [wpe-oracle] hook=%HOOK_METHOD% status=succeeded
+echo [wpe-oracle] trace=%OUT_DIR%\trace.json
+exit /b 0
+
+:fail
+if not defined ERROR_TEXT set "ERROR_TEXT=unknown failure"
+echo [wpe-oracle] ERROR: %ERROR_TEXT%
+set "STATUS=failed"
+call :write_done
+exit /b 1
+
+:read_job
+rem Parse the whole job JSON in ONE PowerShell call (11 sequential calls cost
+rem ~15s of shell startup) and emit `set` statements into a temp batch to load.
+echo [wpe-oracle] parsing job configuration...
+set "TEMP_JOB_BAT=%TEMP%\wpe_oracle_job_%RANDOM%.bat"
+powershell -NoProfile -Command ^
+  "try { $j = Get-Content -Raw $env:JOB_FILE | ConvertFrom-Json -ErrorAction Stop } catch { Write-Error 'Failed to parse job JSON'; exit 1 };" ^
+  "if (-not $j) { Write-Error 'Empty job JSON'; exit 1 };" ^
+  "$jobId = if($j.jobId){$j.jobId}else{'job-'+(Get-Date -Format yyyyMMdd-HHmmss)};" ^
+  "$sceneId = if($j.sceneId){$j.sceneId}else{'%DEFAULT_SCENE_ID%'};" ^
+  "$mode = if($j.mode){$j.mode}else{'shader-first'};" ^
+  "$wpeRoot = if($j.wpeRoot){$j.wpeRoot}else{'%DEFAULT_WPE_ROOT%'};" ^
+  "$workshopRoot = if($j.workshopRoot){$j.workshopRoot}else{'%DEFAULT_WORKSHOP_ROOT%'};" ^
+  "$projectJson = if($j.projectJson){$j.projectJson}else{Join-Path $workshopRoot ($sceneId + '\project.json')};" ^
+  "$renderDocCmd = if($j.renderDocCmd){$j.renderDocCmd}else{''};" ^
+  "$warmupMs = if($j.warmupMs -ne $null){[int]$j.warmupMs}else{1500};" ^
+  "$frameOrdinal = if($j.frameOrdinal -ne $null){[int]$j.frameOrdinal}else{0};" ^
+  "$captureMethod = if($j.captureMethod){$j.captureMethod}else{'auto'};" ^
+  "$wpeVersion = if($j.wpeVersion){$j.wpeVersion}else{'2.8.26'};" ^
+  "Write-Output ('set \"JOB_ID=' + $jobId + '\"');" ^
+  "Write-Output ('set \"SCENE_ID=' + $sceneId + '\"');" ^
+  "Write-Output ('set \"MODE=' + $mode + '\"');" ^
+  "Write-Output ('set \"WPE_ROOT=' + $wpeRoot + '\"');" ^
+  "Write-Output ('set \"WORKSHOP_ROOT=' + $workshopRoot + '\"');" ^
+  "Write-Output ('set \"PROJECT_JSON=' + $projectJson + '\"');" ^
+  "Write-Output ('set \"RENDERDOCCMD=' + $renderDocCmd + '\"');" ^
+  "Write-Output ('set \"WARMUP_MS=' + $warmupMs + '\"');" ^
+  "Write-Output ('set \"FRAME_ORDINAL=' + $frameOrdinal + '\"');" ^
+  "Write-Output ('set \"CAPTURE_METHOD=' + $captureMethod + '\"');" ^
+  "Write-Output ('set \"WPE_VERSION=' + $wpeVersion + '\"');" ^
+  > "%TEMP_JOB_BAT%"
+if errorlevel 1 (
+  echo [wpe-oracle] ERROR: failed to parse job JSON or file is corrupted.
+  if exist "%TEMP_JOB_BAT%" del "%TEMP_JOB_BAT%" >nul 2>&1
+  exit /b 1
+)
+call "%TEMP_JOB_BAT%"
+del "%TEMP_JOB_BAT%" >nul 2>&1
+
+set "WPE_EXE=%WPE_ROOT%\wallpaper64.exe"
+if not exist "%WPE_EXE%" (
+  echo [wpe-oracle] wallpaper64.exe not found: %WPE_EXE%
+  exit /b 1
+)
+if not exist "%PROJECT_JSON%" (
+  echo [wpe-oracle] project.json not found: %PROJECT_JSON%
+  exit /b 1
+)
+exit /b 0
+
+:find_renderdoc
+if defined RENDERDOCCMD if exist "%RENDERDOCCMD%" exit /b 0
+if exist "%ProgramFiles%\RenderDoc\renderdoccmd.exe" (
+  set "RENDERDOCCMD=%ProgramFiles%\RenderDoc\renderdoccmd.exe"
+  exit /b 0
+)
+if exist "%ProgramFiles(x86)%\RenderDoc\renderdoccmd.exe" (
+  set "RENDERDOCCMD=%ProgramFiles(x86)%\RenderDoc\renderdoccmd.exe"
+  exit /b 0
+)
+for /f "delims=" %%A in ('where renderdoccmd.exe 2^>nul') do (
+  set "RENDERDOCCMD=%%A"
+  exit /b 0
+)
+set "ERROR_TEXT=renderdoccmd.exe not found; install RenderDoc or set renderDocCmd in job.json"
+exit /b 1
+
+:switch_scene
+echo [wpe-oracle] WPE control openWallpaper
+"%WPE_EXE%" -control openWallpaper -file "%PROJECT_JSON%"
+exit /b 0
+
+:warmup
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -Command "[Math]::Max(1, [Math]::Ceiling([int]$env:WARMUP_MS / 1000.0))"`) do set "WARMUP_SECONDS=%%A"
+echo [wpe-oracle] warmup=%WARMUP_MS%ms
+timeout /t %WARMUP_SECONDS% /nobreak >nul
+exit /b 0
+
+:detect_wpe_pid
+set "WPE_PID="
+for /f "usebackq delims=" %%A in (`powershell -NoProfile -Command "$p=Get-Process wallpaper64 -ErrorAction SilentlyContinue | Sort-Object StartTime -Descending | Select-Object -First 1; if($p){$p.Id}"`) do set "WPE_PID=%%A"
+if defined WPE_PID echo [wpe-oracle] wallpaper64 pid=%WPE_PID%
+exit /b 0
+
+:set_dpi_and_center_pointer
+powershell -NoProfile -Command ^
+  "Add-Type 'using System; using System.Runtime.InteropServices; public static class W { [DllImport(\"user32.dll\")] public static extern bool SetProcessDpiAwarenessContext(IntPtr v); [DllImport(\"user32.dll\")] public static extern int GetSystemMetrics(int n); [DllImport(\"user32.dll\")] public static extern bool SetCursorPos(int x,int y); }';" ^
+  "[W]::SetProcessDpiAwarenessContext([IntPtr](-4)) | Out-Null;" ^
+  "$x=[W]::GetSystemMetrics(76)+[int]([W]::GetSystemMetrics(78)/2);" ^
+  "$y=[W]::GetSystemMetrics(77)+[int]([W]::GetSystemMetrics(79)/2);" ^
+  "[W]::SetCursorPos($x,$y) | Out-Null; Write-Host ('[wpe-oracle] pointer centered at {0},{1}' -f $x,$y)"
+exit /b 0
+
+:prompt_renderdoc_trigger
+echo [wpe-oracle] RenderDoc should now be attached to wallpaper64.exe.
+echo [wpe-oracle] If no capture appears, trigger ONE capture from the RenderDoc
+echo [wpe-oracle] connection panel ("Capture Frame(s) Immediately") while waiting.
+exit /b 0
+
+:find_newest_rdc
+set "RDC_FILE="
+for /f "delims=" %%F in ('dir /b /a:-d /o:-d "%OUT_DIR%\frame*.rdc" 2^>nul') do (
+  set "RDC_FILE=%OUT_DIR%\%%F"
+  exit /b 0
+)
+exit /b 1
+
+:wait_for_rdc
+set "WAIT_LIMIT=%~1"
+if not defined WAIT_LIMIT set "WAIT_LIMIT=60"
+set /a WAITED=0
+:wait_loop
+call :find_newest_rdc
+if not errorlevel 1 (
+  echo [wpe-oracle] capture file detected: %RDC_FILE%
+  exit /b 0
+)
+if %WAITED% GEQ %WAIT_LIMIT% (
+  echo [wpe-oracle] TIMEOUT: no frame*.rdc under %OUT_DIR% after %WAIT_LIMIT%s.
+  exit /b 1
+)
+set /a REMAINING=WAIT_LIMIT-WAITED
+set /a MOD=WAITED %% 5
+if %MOD%==0 echo [wpe-oracle] waiting for capture... %REMAINING%s remaining (watch %OUT_DIR%\frame*.rdc)
+timeout /t 1 /nobreak >nul
+set /a WAITED+=1
+goto wait_loop
+
+:write_done
+for %%D in ("%DONE_JSON%") do if not exist "%%~dpD" mkdir "%%~dpD" >nul 2>&1
+powershell -NoProfile -Command ^
+  "$done=[ordered]@{status=$env:STATUS; jobId=$env:JOB_ID; sceneId=$env:SCENE_ID; hookMethod=$env:HOOK_METHOD; error=$env:ERROR_TEXT; rdc=$env:RDC_FILE; trace=(Join-Path $env:OUT_DIR 'trace.json'); completedUtc=(Get-Date).ToUniversalTime().ToString('o')};" ^
+  "$done | ConvertTo-Json -Depth 6 | Set-Content -Encoding utf8 $env:DONE_JSON"
+echo [wpe-oracle] done=%DONE_JSON% status=%STATUS% hook=%HOOK_METHOD%
+exit /b 0

--- a/tools/wpe-oracle/run_once.cmd
+++ b/tools/wpe-oracle/run_once.cmd
@@ -46,7 +46,7 @@ set "RDC_TEMPLATE=%OUT_DIR%\frame"
 set "RDC_SAVE_AS=%OUT_DIR%\frame.rdc"
 set "RDC_FILE="
 set "DONE_JSON=%ROOT%captures\%JOB_ID%\done.json"
-set "EXTRACTOR=%ROOT%extract_renderdoc_trace.py"
+set "CONVERT_XML=%OUT_DIR%\frame.zip.xml"
 
 if not exist "%OUT_DIR%" mkdir "%OUT_DIR%" >nul 2>&1
 if not exist "%OUT_DIR%\rt" mkdir "%OUT_DIR%\rt" >nul 2>&1
@@ -159,53 +159,31 @@ exit /b 3
 
 :extract
 call :find_newest_rdc
-echo [wpe-oracle] extracting RenderDoc trace from %RDC_FILE%
+echo [wpe-oracle] converting RenderDoc capture to structured zip.xml from %RDC_FILE%
 if not exist "%RDC_FILE%" (
   set "ERROR_TEXT=missing capture under %OUT_DIR% (no frame*.rdc)"
   goto fail
 )
 
-"%RENDERDOCCMD%" python "%EXTRACTOR%" ^
-  --rdc "%RDC_FILE%" ^
-  --out "%OUT_DIR%" ^
-  --job "%JOB_FILE%" ^
-  --job-id "%JOB_ID%" ^
-  --scene-id "%SCENE_ID%" ^
-  --project-json "%PROJECT_JSON%" ^
-  --mode "%MODE%" ^
-  --warmup-ms "%WARMUP_MS%" ^
-  --frame-ordinal "%FRAME_ORDINAL%" ^
-  --wpe-version "%WPE_VERSION%"
-
+rem RenderDoc 1.x has no `renderdoccmd python` and no standalone renderdoc module;
+rem convert is headless/SSH-safe. The Mac parses frame.zip.xml via parse_capture.py.
+if exist "%CONVERT_XML%" del "%CONVERT_XML%" >nul 2>&1
+"%RENDERDOCCMD%" convert -f "%RDC_FILE%" -o "%CONVERT_XML%" -c zip.xml
 if errorlevel 1 (
-  echo [wpe-oracle] renderdoccmd python failed; trying python from PATH for environments with renderdoc module installed.
-  python "%EXTRACTOR%" ^
-    --rdc "%RDC_FILE%" ^
-    --out "%OUT_DIR%" ^
-    --job "%JOB_FILE%" ^
-    --job-id "%JOB_ID%" ^
-    --scene-id "%SCENE_ID%" ^
-    --project-json "%PROJECT_JSON%" ^
-    --mode "%MODE%" ^
-    --warmup-ms "%WARMUP_MS%" ^
-    --frame-ordinal "%FRAME_ORDINAL%" ^
-    --wpe-version "%WPE_VERSION%"
-)
-
-if errorlevel 1 (
-  set "ERROR_TEXT=extract_renderdoc_trace.py failed (see console stdout/stderr)"
+  set "ERROR_TEXT=renderdoccmd convert failed (see console stdout/stderr)"
   goto fail
 )
 
-if not exist "%OUT_DIR%\trace.json" (
-  set "ERROR_TEXT=extractor completed without trace.json"
+if not exist "%CONVERT_XML%" (
+  set "ERROR_TEXT=renderdoccmd convert completed without frame.zip.xml"
   goto fail
 )
 
 set "STATUS=succeeded"
 call :write_done
 echo [wpe-oracle] hook=%HOOK_METHOD% status=succeeded
-echo [wpe-oracle] trace=%OUT_DIR%\trace.json
+echo [wpe-oracle] structured capture=%CONVERT_XML%
+echo [wpe-oracle] next: copy this capture dir to Mac, run: python3 parse_capture.py --capture-dir "%OUT_DIR%"
 exit /b 0
 
 :fail
@@ -346,7 +324,7 @@ goto wait_loop
 :write_done
 for %%D in ("%DONE_JSON%") do if not exist "%%~dpD" mkdir "%%~dpD" >nul 2>&1
 powershell -NoProfile -Command ^
-  "$done=[ordered]@{status=$env:STATUS; jobId=$env:JOB_ID; sceneId=$env:SCENE_ID; hookMethod=$env:HOOK_METHOD; error=$env:ERROR_TEXT; rdc=$env:RDC_FILE; trace=(Join-Path $env:OUT_DIR 'trace.json'); completedUtc=(Get-Date).ToUniversalTime().ToString('o')};" ^
+  "$done=[ordered]@{status=$env:STATUS; jobId=$env:JOB_ID; sceneId=$env:SCENE_ID; hookMethod=$env:HOOK_METHOD; error=$env:ERROR_TEXT; rdc=$env:RDC_FILE; convertedXml=$env:CONVERT_XML; completedUtc=(Get-Date).ToUniversalTime().ToString('o')};" ^
   "$done | ConvertTo-Json -Depth 6 | Set-Content -Encoding utf8 $env:DONE_JSON"
 echo [wpe-oracle] done=%DONE_JSON% status=%STATUS% hook=%HOOK_METHOD%
 exit /b 0

--- a/tools/wpe-oracle/wpe-trace.schema.json
+++ b/tools/wpe-oracle/wpe-trace.schema.json
@@ -1,0 +1,923 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://loomscreen.local/schemas/wpe.trace.v1.json",
+  "title": "WPE Runtime Oracle Trace",
+  "description": "Canonical trace contract shared by Windows Wallpaper Engine D3D11 captures and macOS Metal captures.",
+  "type": "object",
+  "required": [
+    "schema",
+    "producer",
+    "scene",
+    "capture",
+    "resources",
+    "passes",
+    "final"
+  ],
+  "properties": {
+    "schema": {
+      "const": "wpe.trace.v1"
+    },
+    "producer": {
+      "$ref": "#/$defs/producer"
+    },
+    "scene": {
+      "$ref": "#/$defs/scene"
+    },
+    "capture": {
+      "$ref": "#/$defs/capture"
+    },
+    "resources": {
+      "$ref": "#/$defs/resources"
+    },
+    "passes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/pass"
+      }
+    },
+    "final": {
+      "$ref": "#/$defs/finalOutput"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "nullableString": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^([A-Fa-f0-9]{64})?$"
+    },
+    "resourceId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "vec2": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "number"
+      }
+    },
+    "vec4": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": {
+        "type": "number"
+      }
+    },
+    "matrix4x4": {
+      "type": "array",
+      "minItems": 16,
+      "maxItems": 16,
+      "items": {
+        "type": "number"
+      }
+    },
+    "producer": {
+      "type": "object",
+      "required": [
+        "side",
+        "tool",
+        "wpeVersion"
+      ],
+      "properties": {
+        "side": {
+          "enum": [
+            "windows-wpe",
+            "mac-metal"
+          ]
+        },
+        "tool": {
+          "type": "string"
+        },
+        "toolVersion": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "wpeVersion": {
+          "type": "string"
+        },
+        "appBuild": {
+          "$ref": "#/$defs/nullableString"
+        }
+      },
+      "additionalProperties": true
+    },
+    "scene": {
+      "type": "object",
+      "required": [
+        "workshopId",
+        "projectJson",
+        "projectJsonSha256"
+      ],
+      "properties": {
+        "workshopId": {
+          "type": "string",
+          "pattern": "^[0-9]+$"
+        },
+        "projectJson": {
+          "type": "string"
+        },
+        "projectJsonSha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "scenePkgSha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "entryFile": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "assetRoots": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "capture": {
+      "type": "object",
+      "required": [
+        "frameOrdinal",
+        "resolution",
+        "wallpaperWindow",
+        "determinism"
+      ],
+      "properties": {
+        "jobId": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "mode": {
+          "enum": [
+            "shader-first",
+            "state",
+            "full"
+          ]
+        },
+        "frameOrdinal": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warmupMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resolution": {
+          "type": "object",
+          "required": [
+            "width",
+            "height"
+          ],
+          "properties": {
+            "width": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "height": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "wallpaperWindow": {
+          "type": "object",
+          "required": [
+            "class",
+            "hwnd"
+          ],
+          "properties": {
+            "class": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "hwnd": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "pid": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": true
+        },
+        "determinism": {
+          "type": "object",
+          "required": [
+            "time",
+            "daytime",
+            "pointer",
+            "audioMode"
+          ],
+          "properties": {
+            "time": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "daytime": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "minimum": 0,
+              "maximum": 1
+            },
+            "pointer": {
+              "$ref": "#/$defs/vec2"
+            },
+            "audioMode": {
+              "enum": [
+                "muted",
+                "captured",
+                "zeroed",
+                "unknown"
+              ]
+            },
+            "mouseParallax": {
+              "enum": [
+                "disabled",
+                "centered",
+                "unknown"
+              ]
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "resources": {
+      "type": "object",
+      "required": [
+        "textures",
+        "renderTargets",
+        "buffers",
+        "shaders"
+      ],
+      "properties": {
+        "textures": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/textureResource"
+          }
+        },
+        "renderTargets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/renderTargetResource"
+          }
+        },
+        "buffers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/bufferResource"
+          }
+        },
+        "shaders": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/shaderResource"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "textureResource": {
+      "type": "object",
+      "required": [
+        "label",
+        "width",
+        "height",
+        "format"
+      ],
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "sourcePath": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "width": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "height": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "format": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "mips": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "png": {
+          "$ref": "#/$defs/nullableString"
+        }
+      },
+      "additionalProperties": true
+    },
+    "renderTargetResource": {
+      "type": "object",
+      "required": [
+        "label",
+        "width",
+        "height",
+        "format",
+        "lineage"
+      ],
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "width": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "height": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "format": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "lineage": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "bufferResource": {
+      "type": "object",
+      "required": [
+        "label",
+        "byteLength",
+        "sha256"
+      ],
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "byteLength": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      },
+      "additionalProperties": true
+    },
+    "shaderResource": {
+      "type": "object",
+      "required": [
+        "stage",
+        "sourceLanguage",
+        "entryPoint",
+        "disassembly",
+        "reflection"
+      ],
+      "properties": {
+        "stage": {
+          "enum": [
+            "vertex",
+            "fragment"
+          ]
+        },
+        "sourceLanguage": {
+          "enum": [
+            "HLSL",
+            "DXBC",
+            "MSL"
+          ]
+        },
+        "entryPoint": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "sourcePath": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "sourceSha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "disassembly": {
+          "type": "object",
+          "required": [
+            "path",
+            "sha256"
+          ],
+          "properties": {
+            "path": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "sha256": {
+              "$ref": "#/$defs/sha256"
+            }
+          },
+          "additionalProperties": true
+        },
+        "reflection": {
+          "$ref": "#/$defs/shaderReflection"
+        }
+      },
+      "additionalProperties": true
+    },
+    "shaderReflection": {
+      "type": "object",
+      "properties": {
+        "samplers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/reflectionBinding"
+          }
+        },
+        "textures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/reflectionBinding"
+          }
+        },
+        "constantBlocks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/reflectionBinding"
+          }
+        },
+        "uniforms": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/variable"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "reflectionBinding": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "slot": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "type": {
+          "$ref": "#/$defs/nullableString"
+        }
+      },
+      "additionalProperties": true
+    },
+    "pass": {
+      "type": "object",
+      "required": [
+        "ordinal",
+        "draw",
+        "targets",
+        "textures",
+        "shaders",
+        "constantBuffers",
+        "state",
+        "output"
+      ],
+      "properties": {
+        "ordinal": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "eventId": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "layerId": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "passId": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "shaderName": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "draw": {
+          "type": "object",
+          "required": [
+            "topology",
+            "vertexCount",
+            "indexCount",
+            "instanceCount",
+            "viewport"
+          ],
+          "properties": {
+            "topology": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "vertexCount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0
+            },
+            "indexCount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0
+            },
+            "instanceCount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0
+            },
+            "viewport": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "scissor": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "additionalProperties": true
+        },
+        "targets": {
+          "type": "object",
+          "required": [
+            "color",
+            "depth"
+          ],
+          "properties": {
+            "color": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "slot",
+                  "resource",
+                  "load",
+                  "store"
+                ],
+                "properties": {
+                  "slot": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "resource": {
+                    "$ref": "#/$defs/resourceId"
+                  },
+                  "load": {
+                    "$ref": "#/$defs/nullableString"
+                  },
+                  "store": {
+                    "$ref": "#/$defs/nullableString"
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "depth": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "resource": {
+                  "$ref": "#/$defs/resourceId"
+                },
+                "load": {
+                  "$ref": "#/$defs/nullableString"
+                },
+                "store": {
+                  "$ref": "#/$defs/nullableString"
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        },
+        "textures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "slot",
+              "resource"
+            ],
+            "properties": {
+              "stage": {
+                "enum": [
+                  "vertex",
+                  "fragment"
+                ]
+              },
+              "slot": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "name": {
+                "$ref": "#/$defs/nullableString"
+              },
+              "resource": {
+                "$ref": "#/$defs/resourceId"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "shaders": {
+          "type": "object",
+          "required": [
+            "vs",
+            "fs"
+          ],
+          "properties": {
+            "vs": {
+              "$ref": "#/$defs/nullableString"
+            },
+            "fs": {
+              "$ref": "#/$defs/nullableString"
+            }
+          },
+          "additionalProperties": true
+        },
+        "constantBuffers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/constantBuffer"
+          }
+        },
+        "state": {
+          "$ref": "#/$defs/pipelineState"
+        },
+        "output": {
+          "$ref": "#/$defs/passOutput"
+        }
+      },
+      "additionalProperties": true
+    },
+    "constantBuffer": {
+      "type": "object",
+      "required": [
+        "name",
+        "stage",
+        "slot",
+        "variables"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "stage": {
+          "enum": [
+            "vertex",
+            "fragment"
+          ]
+        },
+        "slot": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "resource": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "rawBytesSha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "variables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/variable"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "variable": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "value": {
+          "type": [
+            "number",
+            "integer",
+            "string",
+            "boolean",
+            "array",
+            "object",
+            "null"
+          ]
+        },
+        "matrix4x4": {
+          "$ref": "#/$defs/matrix4x4"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/variable"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "pipelineState": {
+      "type": "object",
+      "required": [
+        "blend",
+        "depth",
+        "raster",
+        "samplers"
+      ],
+      "properties": {
+        "blend": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "depth": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "raster": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true
+        },
+        "samplers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "slot"
+            ],
+            "properties": {
+              "stage": {
+                "enum": [
+                  "vertex",
+                  "fragment"
+                ]
+              },
+              "slot": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "filter": {
+                "$ref": "#/$defs/nullableString"
+              },
+              "addressU": {
+                "$ref": "#/$defs/nullableString"
+              },
+              "addressV": {
+                "$ref": "#/$defs/nullableString"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "passOutput": {
+      "type": "object",
+      "required": [
+        "png",
+        "sha256",
+        "visualStats"
+      ],
+      "properties": {
+        "resource": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "png": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "visualStats": {
+          "$ref": "#/$defs/visualStats"
+        }
+      },
+      "additionalProperties": true
+    },
+    "finalOutput": {
+      "type": "object",
+      "required": [
+        "png",
+        "sha256"
+      ],
+      "properties": {
+        "resource": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "png": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      },
+      "additionalProperties": true
+    },
+    "visualStats": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "coverage": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "meanRGBA": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {
+            "type": "number"
+          }
+        },
+        "note": {
+          "$ref": "#/$defs/nullableString"
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
Cross-device framework to find where our Metal renderer diverges from real Wallpaper Engine and drive it toward 1:1. Windows RenderDoc capture → headless parse → `windows/trace.json`; a DEBUG-only Mac `WPECanonicalTraceRecorder` emits the same `wpe.trace.v1` from the live Metal path; `diff_traces.py` DP-aligns the two and pinpoints the first divergence by bucket (transpiler/FBO/asset/puppet+particle).

Validated on saber (3526278753): auto-reproduces the 3 known findings (missing particle passes, uniform-packing normalized by name, asset/binding). Also fixes a D3D11 partial-Map cbuffer-decode bug (WPE uniforms were half-garbage → now real values) and adds the Phase D-1 constant-replay contract (`extract_replay.py`).

All app-side Swift is gated `#if !LITE_BUILD && DEBUG` — zero Release/Lite footprint. On-device recorder validation is the next step (build from this branch, capture a real `mac/trace.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)