### PR TITLE
WPE: in-place package-aware assets (cache write-dead) + UI polish

### DIFF
--- a/LiveWallpaper/Infrastructure/WPEAssetMount.swift
+++ b/LiveWallpaper/Infrastructure/WPEAssetMount.swift
@@ -1,13 +1,34 @@
 #if !LITE_BUILD
 import Foundation
 
+/// A dependency workshop item mounted for in-place asset resolution.
+///
+/// A dependency can be backed either by a real on-disk directory (an unpacked
+/// sibling Steam Workshop folder) or by a `scene.pkg` read in place — the latter
+/// lets packaged dependencies resolve without ever extracting them to a cache.
 struct WPEAssetMount: Equatable, Sendable {
+    enum Backing: Equatable, Sendable {
+        case directory(URL)
+        case package(URL)
+    }
+
     let workshopID: String
-    let rootURL: URL
+    let backing: Backing
 
     init(workshopID: String, rootURL: URL) {
         self.workshopID = workshopID
-        self.rootURL = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+        self.backing = .directory(rootURL.standardizedFileURL.resolvingSymlinksInPath())
+    }
+
+    init(workshopID: String, packageURL: URL) {
+        self.workshopID = workshopID
+        self.backing = .package(packageURL.standardizedFileURL.resolvingSymlinksInPath())
+    }
+
+    /// Directory root for a directory-backed mount; `nil` for a package mount.
+    var rootURL: URL? {
+        if case .directory(let url) = backing { return url }
+        return nil
     }
 }
 #endif

--- a/LiveWallpaper/Infrastructure/WPEDependencyMountResolver.swift
+++ b/LiveWallpaper/Infrastructure/WPEDependencyMountResolver.swift
@@ -37,12 +37,12 @@ struct WPEDependencyMountResolver {
             }
 
             if let workshopRoot,
-               let siblingRoot = validSourceSiblingRoot(
+               let siblingMount = validSourceSiblingMount(
                    workshopID: id,
                    workshopRootURL: workshopRoot,
                    fileManager: fileManager
                ) {
-                mounts.append(WPEAssetMount(workshopID: id, rootURL: siblingRoot))
+                mounts.append(siblingMount)
             }
         }
         return mounts
@@ -66,11 +66,11 @@ struct WPEDependencyMountResolver {
         return cacheRoot
     }
 
-    private func validSourceSiblingRoot(
+    private func validSourceSiblingMount(
         workshopID: String,
         workshopRootURL: URL,
         fileManager: FileManager
-    ) -> URL? {
+    ) -> WPEAssetMount? {
         let siblingRoot = workshopRootURL
             .appendingPathComponent(workshopID, isDirectory: true)
             .standardizedFileURL
@@ -80,9 +80,17 @@ struct WPEDependencyMountResolver {
             return nil
         }
 
+        // Packaged dependency: assets live inside scene.pkg → mount the package
+        // for in-place reading (no extraction). Prefer this over the loose folder.
+        let pkgURL = siblingRoot.appendingPathComponent("scene.pkg")
+        if fileManager.fileExists(atPath: pkgURL.path) {
+            return WPEAssetMount(workshopID: workshopID, packageURL: pkgURL)
+        }
+
+        // Unpacked dependency: mount the folder if it carries a project.json.
         let manifest = siblingRoot.appendingPathComponent("project.json")
         guard fileManager.fileExists(atPath: manifest.path) else { return nil }
-        return siblingRoot
+        return WPEAssetMount(workshopID: workshopID, rootURL: siblingRoot)
     }
 
     private static func isDirectory(_ url: URL, fileManager: FileManager) -> Bool {

--- a/LiveWallpaper/Infrastructure/WPEMultiRootResourceResolver.swift
+++ b/LiveWallpaper/Infrastructure/WPEMultiRootResourceResolver.swift
@@ -32,11 +32,7 @@ struct WPEMultiRootResourceResolver: Sendable {
                 cacheRootURL: $0.appendingPathComponent("assets", isDirectory: true)
             )
         }
-        var mounts: [String: SceneResourceResolver] = [:]
-        for mount in dependencyMounts {
-            mounts[mount.workshopID] = SceneResourceResolver(cacheRootURL: mount.rootURL)
-        }
-        self.dependencyMounts = mounts
+        self.dependencyMounts = Self.makeMountResolvers(dependencyMounts)
         self.tracer = tracer
     }
 
@@ -56,12 +52,27 @@ struct WPEMultiRootResourceResolver: Sendable {
                 cacheRootURL: $0.appendingPathComponent("assets", isDirectory: true)
             )
         }
+        self.dependencyMounts = Self.makeMountResolvers(dependencyMounts)
+        self.tracer = tracer
+    }
+
+    /// Builds a per-dependency resolver: a directory mount reads its on-disk
+    /// root; a package mount reads entries in place from `scene.pkg` via a
+    /// package provider (no extraction). A package that can't be opened is
+    /// dropped, so its references resolve as missing rather than crashing.
+    private static func makeMountResolvers(_ dependencyMounts: [WPEAssetMount]) -> [String: SceneResourceResolver] {
         var mounts: [String: SceneResourceResolver] = [:]
         for mount in dependencyMounts {
-            mounts[mount.workshopID] = SceneResourceResolver(cacheRootURL: mount.rootURL)
+            switch mount.backing {
+            case .directory(let rootURL):
+                mounts[mount.workshopID] = SceneResourceResolver(cacheRootURL: rootURL)
+            case .package(let packageURL):
+                if let provider = try? WPEPackageSceneAssetProvider(packageURL: packageURL) {
+                    mounts[mount.workshopID] = SceneResourceResolver(provider: provider)
+                }
+            }
         }
-        self.dependencyMounts = mounts
-        self.tracer = tracer
+        return mounts
     }
 
     /// Existence probe across the same cascade, without staging or reading

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -2,8 +2,9 @@
 import Foundation
 
 /// End-to-end Wallpaper Engine workshop import. Reads `project.json`, routes
-/// by `WPEType`, extracts `scene.pkg` via `WallpaperEngineCache` when present,
-/// and produces a `WallpaperContent` (.video / .html(.folder)) ready to apply.
+/// by `WPEType`, and produces a `WallpaperContent` (.video / .html(.folder) /
+/// .scene) that reads its assets in place from `scene.pkg` or the source folder
+/// — no extraction into `wpe-cache`.
 @MainActor
 final class WallpaperEngineImportService {
     enum ImportResult: Equatable, Sendable {
@@ -72,8 +73,8 @@ final class WallpaperEngineImportService {
     /// via a resource loader windowed into the entry's byte range (no
     /// extraction, no resting copy). The video entry is staged to a temp file
     /// once for a playability probe and reclaimed when the provider deinits.
-    /// Falls back to whole-package extraction only when the package can't be
-    /// opened or the entry is missing.
+    /// Rejected as unsupported when the package can't be opened or the entry is
+    /// missing from it.
     private func importPackagedVideo(
         project: WallpaperEngineProject,
         pkgURL: URL,
@@ -185,11 +186,11 @@ final class WallpaperEngineImportService {
     }
 
     /// Package-aware web import: serves the web payload in place from `scene.pkg`
-    /// via the render-time scheme handler (which reads pkg entries first, then
-    /// falls back to loose siblings like `project.json`). No whole-package
-    /// extraction, so no second on-disk copy in `wpe-cache`. Falls back to
-    /// extraction only when the package can't be opened or the index entry is
-    /// missing from it.
+    /// via the render-time scheme handler (which serves loose files first, then
+    /// falls back to package entries for what the folder doesn't have loose, e.g.
+    /// the index + bundle). No extraction, so no second on-disk copy in
+    /// `wpe-cache`. Rejected as unsupported when the package can't be opened or
+    /// its index entry is missing from it.
     private func importPackagedWeb(
         project: WallpaperEngineProject,
         folderURL: URL,
@@ -327,7 +328,7 @@ final class WallpaperEngineImportService {
 
     /// Imports a packaged scene to read in place from `scene.pkg` (no
     /// extraction). Returns `nil` when the package can't be opened/parsed for
-    /// in-place use, so the caller falls back to extracting into the cache.
+    /// in-place use, in which case the caller rejects it as unsupported.
     private func finishScenePackageBackedImport(
         project: WallpaperEngineProject,
         pkgURL: URL,
@@ -391,8 +392,8 @@ final class WallpaperEngineImportService {
     }
 
     /// Imports an unpacked folder scene to read in place from its source folder
-    /// (no mirror copy). Returns `nil` when the entry can't be read/parsed, so
-    /// the caller falls back to mirroring into the cache.
+    /// (no mirror copy). Returns `nil` when the entry can't be read/parsed, in
+    /// which case the caller rejects it as unsupported.
     private func finishSceneSourceDirectoryImport(
         project: WallpaperEngineProject,
         folderURL: URL,
@@ -536,10 +537,6 @@ final class WallpaperEngineImportService {
     }
 }
 
-private struct ExtractionFailure: Error, Sendable {
-    let reason: String
-}
-
 @MainActor
 struct WPECachedContentResolver {
     private let applicationSupportRootURL: URL
@@ -621,7 +618,7 @@ struct WPECachedContentResolver {
             return nil
         case .web:
             // Index may be loose or inside scene.pkg; the scheme handler serves
-            // from the package first, then loose siblings. Bookmark the folder.
+            // loose files first, then package entries. Bookmark the folder.
             guard looseEntryExists || packagedEntryExists,
                   let bookmark = makeBookmark(folderURL) else { return nil }
             return .html(
@@ -660,13 +657,17 @@ struct WPECachedContentResolver {
         let entryExistsInCache = entryURLCandidate.map { fileManager.fileExists(atPath: $0.path) } ?? false
 
         // Source-backed scene: scene.json lives in the source folder or source
-        // `scene.pkg`, not in the now-empty cache. Rebuild the in-place descriptor.
-        if origin.originalType == .scene, !entryExistsInCache {
-            return sourceBackedSceneContent(
-                for: origin,
-                cacheRelativePath: cacheRelativePath,
-                entryFile: entryFile
-            )
+        // `scene.pkg`. Prefer rebuilding in place from the source so a stale
+        // cache entry never shadows it (the extraction cache is being retired);
+        // only fall through to a cache-backed descriptor when the source can no
+        // longer be read.
+        if origin.originalType == .scene,
+           let sourceBacked = sourceBackedSceneContent(
+               for: origin,
+               cacheRelativePath: cacheRelativePath,
+               entryFile: entryFile
+           ) {
+            return sourceBacked
         }
 
         guard let entryURL = entryURLCandidate, entryExistsInCache else {

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -81,11 +81,7 @@ final class WallpaperEngineImportService {
     ) async -> ImportResult {
         guard let provider = try? WPEPackageSceneAssetProvider(packageURL: pkgURL),
               provider.exists(atRelativePath: project.entryFile) else {
-            return await importPackagedVideoViaExtraction(
-                project: project,
-                pkgURL: pkgURL,
-                sourceBookmark: sourceBookmark
-            )
+            return .rejected(reason: "Missing video entry \(project.entryFile) in package")
         }
 
         // One-time probe on a staged copy of just the video entry; the
@@ -115,44 +111,6 @@ final class WallpaperEngineImportService {
             .video(bookmarkData: videoBookmark, packageEntryName: project.entryFile),
             origin: origin
         )
-    }
-
-    /// Legacy fallback: extracts the whole `scene.pkg` into `wpe-cache` and
-    /// points the wallpaper at the extracted video file. Used only when the
-    /// package can't be opened for in-place reading.
-    private func importPackagedVideoViaExtraction(
-        project: WallpaperEngineProject,
-        pkgURL: URL,
-        sourceBookmark: Data
-    ) async -> ImportResult {
-        let cacheResult = await ensureExtracted(project: project, pkgURL: pkgURL)
-        guard case .success(let cacheURL) = cacheResult else {
-            if case .failure(let failure) = cacheResult { return .rejected(reason: failure.reason) }
-            return .rejected(reason: "Extraction failed")
-        }
-
-        guard let videoURL = resourceURL(root: cacheURL, relativePath: project.entryFile),
-              fileManager.fileExists(atPath: videoURL.path) else {
-            return .rejected(reason: "Missing video entry \(project.entryFile)")
-        }
-
-        do {
-            try await validateVideo(videoURL)
-        } catch {
-            return .rejected(reason: describe(error))
-        }
-
-        guard let videoBookmark = makeBookmark(videoURL) else {
-            return .rejected(reason: "Cannot create video bookmark")
-        }
-
-        let origin = makeOrigin(
-            project: project,
-            sourceBookmark: sourceBookmark,
-            cacheRelativePath: cacheRelativePath(for: project),
-            resourceLocation: .cache
-        )
-        return .ready(.video(bookmarkData: videoBookmark), origin: origin)
     }
 
     private func importUnpackagedVideo(
@@ -265,53 +223,9 @@ final class WallpaperEngineImportService {
             return .ready(content, origin: origin)
         }
 
-        return await importPackagedWebViaExtraction(
-            project: project,
-            pkgURL: pkgURL,
-            sourceBookmark: sourceBookmark
-        )
+        return .rejected(reason: "Missing web entry \(project.entryFile) in package")
     }
 
-    /// Legacy fallback: extracts the whole `scene.pkg` into `wpe-cache` and
-    /// points the wallpaper at the extracted folder. Used only when the package
-    /// can't be opened for in-place reading.
-    private func importPackagedWebViaExtraction(
-        project: WallpaperEngineProject,
-        pkgURL: URL,
-        sourceBookmark: Data
-    ) async -> ImportResult {
-        let cacheResult = await ensureExtracted(project: project, pkgURL: pkgURL)
-        guard case .success(let cacheURL) = cacheResult else {
-            if case .failure(let failure) = cacheResult { return .rejected(reason: failure.reason) }
-            return .rejected(reason: "Extraction failed")
-        }
-
-        guard let indexURL = resourceURL(root: cacheURL, relativePath: project.entryFile),
-              fileManager.fileExists(atPath: indexURL.path) else {
-            return .rejected(reason: "Missing web entry \(project.entryFile)")
-        }
-
-        guard let folderBookmark = makeBookmark(cacheURL) else {
-            return .rejected(reason: "Cannot create cached web folder bookmark")
-        }
-
-        let originKind = WallpaperEngineImportService.originKind(forSourceFolder: pkgURL.deletingLastPathComponent())
-        let origin = makeOrigin(
-            project: project,
-            sourceBookmark: sourceBookmark,
-            cacheRelativePath: cacheRelativePath(for: project),
-            resourceLocation: .cache,
-            originKind: originKind
-        )
-        let content = WallpaperContent.html(
-            source: .folder(bookmarkData: folderBookmark, indexFileName: project.entryFile),
-            config: HTMLConfig(
-                physicalPixelLayout: true,
-                originKind: originKind
-            )
-        )
-        return .ready(content, origin: origin)
-    }
 
     /// Marks an HTML wallpaper's `HTMLConfig` as Workshop-sourced when the
     /// source folder lives under a SteamCMD-managed
@@ -373,10 +287,10 @@ final class WallpaperEngineImportService {
 
         let pkgURL = folderURL.appendingPathComponent("scene.pkg")
         if fileManager.fileExists(atPath: pkgURL.path) {
-            // Default: read the packaged scene in place from scene.pkg — no
-            // extraction, so no second multi-GB copy in wpe-cache. Falls back to
-            // extracting into the cache only when the package can't be opened or
-            // parsed for in-place use.
+            // Read the packaged scene in place from scene.pkg — no extraction,
+            // so no second on-disk copy in wpe-cache. A package that can't be
+            // opened/parsed is unsupported (extraction used the same parser, so
+            // it could never have recovered what in-place reading can't).
             if let packageResult = await finishScenePackageBackedImport(
                 project: project,
                 pkgURL: pkgURL,
@@ -385,19 +299,7 @@ final class WallpaperEngineImportService {
             ) {
                 return packageResult
             }
-
-            let cacheResult = await ensureExtracted(project: project, pkgURL: pkgURL)
-            guard case .success(let cacheURL) = cacheResult else {
-                if case .failure(let failure) = cacheResult { return .rejected(reason: failure.reason) }
-                return .rejected(reason: "Extraction failed")
-            }
-
-            return finishSceneImport(
-                project: project,
-                cacheURL: cacheURL,
-                sourceFolderURL: folderURL,
-                sourceBookmark: sourceBookmark
-            )
+            return .rejected(reason: "Packaged scene \(project.entryFile) could not be read from the package")
         }
 
         guard let entryURL = resourceURL(root: folderURL, relativePath: project.entryFile),
@@ -410,9 +312,9 @@ final class WallpaperEngineImportService {
             ))
         }
 
-        // Default: read the unpacked folder scene in place from the source — no
-        // mirror copy in wpe-cache. Falls back to mirroring only if in-place
-        // reading fails (e.g. the entry can't be read/parsed).
+        // Read the unpacked folder scene in place from the source — no mirror
+        // copy in wpe-cache. If in-place reading fails it's unsupported (a
+        // mirror copies the same files, so it couldn't have recovered either).
         if let directoryResult = await finishSceneSourceDirectoryImport(
             project: project,
             folderURL: folderURL,
@@ -420,90 +322,7 @@ final class WallpaperEngineImportService {
         ) {
             return directoryResult
         }
-
-        let cacheResult = await ensureMirrored(project: project, folderURL: folderURL)
-        guard case .success(let cacheURL) = cacheResult else {
-            if case .failure(let failure) = cacheResult { return .rejected(reason: failure.reason) }
-            return .rejected(reason: "Directory mirror failed")
-        }
-
-        return finishSceneImport(
-            project: project,
-            cacheURL: cacheURL,
-            sourceFolderURL: folderURL,
-            sourceBookmark: sourceBookmark
-        )
-    }
-
-    private func finishSceneImport(
-        project: WallpaperEngineProject,
-        cacheURL: URL,
-        sourceFolderURL: URL,
-        sourceBookmark: Data
-    ) -> ImportResult {
-        // `scene.pkg` archives never carry `project.json` (it lives next to
-        // them in the workshop folder), so the .pkg extraction path leaves
-        // the cache without authoring metadata. Top it up here so the
-        // inspector schema loader and downstream readers find it without
-        // re-opening the source bookmark on every cold start.
-        copyProjectManifestIfNeeded(from: sourceFolderURL, to: cacheURL)
-
-
-        guard let entryURL = resourceURL(root: cacheURL, relativePath: project.entryFile),
-              fileManager.fileExists(atPath: entryURL.path) else {
-            return .rejected(reason: "Missing scene entry \(project.entryFile)")
-        }
-
-        let sceneData: Data
-        do {
-            sceneData = try Data(contentsOf: entryURL)
-        } catch {
-            return .rejected(reason: "Cannot read \(project.entryFile): \(describe(error))")
-        }
-
-        let document: WPESceneDocument
-        do {
-            document = try WPESceneDocumentParser.parse(data: sceneData)
-        } catch {
-            return .rejected(reason: describe(error))
-        }
-
-        let dependencyMounts = WPEDependencyMountResolver().mounts(
-            dependencyWorkshopIDs: project.dependencyWorkshopIDs,
-            origin: nil
-        )
-        let engineRoot = WPEEngineAssetsLibrary.shared.resolveAuthorizedRoot()
-        let tier = WPESceneCapabilityClassifier().capabilityTier(
-            for: document,
-            cacheURL: cacheURL,
-            dependencyMounts: dependencyMounts,
-            engineAssetsRootURL: engineRoot
-        )
-        let preflight = WPEScenePreflight.classify(
-            document: document,
-            project: project,
-            scenePackageEntries: scenePackageEntryNames(in: cacheURL, fileManager: fileManager)
-        )
-        let descriptor = SceneDescriptor(
-            workshopID: project.workshopID,
-            cacheRelativePath: cacheRelativePath(for: project),
-            entryFile: project.entryFile,
-            capabilityTier: tier,
-            dependencyWorkshopIDs: project.dependencyWorkshopIDs,
-            preflightTier: preflight.tier,
-            preflightFeatureFlags: sortedPreflightFeatureFlags(preflight.featureFlags)
-        )
-        let origin = makeOrigin(
-            project: project,
-            sourceBookmark: sourceBookmark,
-            cacheRelativePath: cacheRelativePath(for: project),
-            resourceLocation: .cache
-        )
-
-        if tier == .unsupported {
-            return .unsupported(origin: origin)
-        }
-        return .ready(.scene(descriptor), origin: origin)
+        return .rejected(reason: "Scene \(project.entryFile) could not be read from the source folder")
     }
 
     /// Imports a packaged scene to read in place from `scene.pkg` (no
@@ -647,27 +466,6 @@ final class WallpaperEngineImportService {
         }
     }
 
-    private func ensureExtracted(project: WallpaperEngineProject, pkgURL: URL) async -> Result<URL, ExtractionFailure> {
-        do {
-            let url = try await cache.ensureExtracted(workshopID: project.workshopID, sourcePkgURL: pkgURL)
-            return .success(url)
-        } catch {
-            return .failure(ExtractionFailure(reason: describe(error)))
-        }
-    }
-
-    private func ensureMirrored(project: WallpaperEngineProject, folderURL: URL) async -> Result<URL, ExtractionFailure> {
-        do {
-            let url = try await cache.ensureMirroredDirectory(
-                workshopID: project.workshopID,
-                sourceFolderURL: folderURL
-            )
-            return .success(url)
-        } catch {
-            return .failure(ExtractionFailure(reason: describe(error)))
-        }
-    }
-
     private func makeOrigin(
         project: WallpaperEngineProject,
         sourceBookmark: Data,
@@ -725,20 +523,6 @@ final class WallpaperEngineImportService {
         "wpe-cache/\(project.workshopID)"
     }
 
-    private func copyProjectManifestIfNeeded(from sourceFolder: URL, to cacheURL: URL) {
-        let destination = cacheURL.appendingPathComponent("project.json")
-        if fileManager.fileExists(atPath: destination.path) { return }
-        let source = sourceFolder.appendingPathComponent("project.json")
-        guard fileManager.fileExists(atPath: source.path) else { return }
-        do {
-            try fileManager.copyItem(at: source, to: destination)
-        } catch {
-            Logger.warning(
-                "WPE cache: failed to copy project.json into cache (\(error.localizedDescription))",
-                category: .screenManager
-            )
-        }
-    }
 
     private func resourceURL(root: URL, relativePath: String) -> URL? {
         WPEPathSafety.resourceURL(root: root, relativePath: relativePath)

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -68,7 +68,59 @@ final class WallpaperEngineImportService {
         return await importUnpackagedVideo(project: project, folderURL: folderURL, sourceBookmark: sourceBookmark)
     }
 
+    /// Package-aware video import: the video plays in place from `scene.pkg`
+    /// via a resource loader windowed into the entry's byte range (no
+    /// extraction, no resting copy). The video entry is staged to a temp file
+    /// once for a playability probe and reclaimed when the provider deinits.
+    /// Falls back to whole-package extraction only when the package can't be
+    /// opened or the entry is missing.
     private func importPackagedVideo(
+        project: WallpaperEngineProject,
+        pkgURL: URL,
+        sourceBookmark: Data
+    ) async -> ImportResult {
+        guard let provider = try? WPEPackageSceneAssetProvider(packageURL: pkgURL),
+              provider.exists(atRelativePath: project.entryFile) else {
+            return await importPackagedVideoViaExtraction(
+                project: project,
+                pkgURL: pkgURL,
+                sourceBookmark: sourceBookmark
+            )
+        }
+
+        // One-time probe on a staged copy of just the video entry; the
+        // provider's staging dir is removed on deinit (after this scope), so
+        // nothing persists. Playback reads the entry windowed, in place.
+        do {
+            let stagedURL = try provider.stagedURL(atRelativePath: project.entryFile)
+            try await validateVideo(stagedURL)
+        } catch {
+            return .rejected(reason: describe(error))
+        }
+
+        // Zero-cache: drop any stale prior extraction for this id.
+        await purgeStaleCache(workshopID: project.workshopID)
+
+        guard let videoBookmark = makeBookmark(pkgURL) else {
+            return .rejected(reason: "Cannot create video package bookmark")
+        }
+
+        let origin = makeOrigin(
+            project: project,
+            sourceBookmark: sourceBookmark,
+            cacheRelativePath: nil,
+            resourceLocation: .sourceFolder
+        )
+        return .ready(
+            .video(bookmarkData: videoBookmark, packageEntryName: project.entryFile),
+            origin: origin
+        )
+    }
+
+    /// Legacy fallback: extracts the whole `scene.pkg` into `wpe-cache` and
+    /// points the wallpaper at the extracted video file. Used only when the
+    /// package can't be opened for in-place reading.
+    private func importPackagedVideoViaExtraction(
         project: WallpaperEngineProject,
         pkgURL: URL,
         sourceBookmark: Data
@@ -761,15 +813,28 @@ struct WPECachedContentResolver {
         let didStart = folderURL.startAccessingSecurityScopedResource()
         defer { if didStart { folderURL.stopAccessingSecurityScopedResource() } }
 
-        guard let entryURL = resourceURL(root: folderURL, relativePath: entryFile),
-              fileManager.fileExists(atPath: entryURL.path) else { return nil }
+        let looseEntryURL = resourceURL(root: folderURL, relativePath: entryFile)
+        let looseEntryExists = looseEntryURL.map { fileManager.fileExists(atPath: $0.path) } ?? false
+        let pkgURL = folderURL.appendingPathComponent("scene.pkg")
+        let packagedEntryExists = fileManager.fileExists(atPath: pkgURL.path)
+            && Self.packageContainsEntry(pkgURL, relativePath: entryFile)
 
         switch origin.originalType {
         case .video:
-            guard let bookmark = makeBookmark(entryURL) else { return nil }
-            return .video(bookmarkData: bookmark)
+            // Loose video file → play directly; in-place packaged video →
+            // bookmark the package and carry the entry name for windowed playback.
+            if looseEntryExists, let entryURL = looseEntryURL, let bookmark = makeBookmark(entryURL) {
+                return .video(bookmarkData: bookmark)
+            }
+            if packagedEntryExists, let bookmark = makeBookmark(pkgURL) {
+                return .video(bookmarkData: bookmark, packageEntryName: entryFile)
+            }
+            return nil
         case .web:
-            guard let bookmark = makeBookmark(folderURL) else { return nil }
+            // Index may be loose or inside scene.pkg; the scheme handler serves
+            // from the package first, then loose siblings. Bookmark the folder.
+            guard looseEntryExists || packagedEntryExists,
+                  let bookmark = makeBookmark(folderURL) else { return nil }
             return .html(
                 source: .folder(bookmarkData: bookmark, indexFileName: entryFile),
                 config: HTMLConfig(physicalPixelLayout: true, originKind: origin.originKind)
@@ -777,6 +842,12 @@ struct WPECachedContentResolver {
         case .scene, .application, .unknown:
             return nil
         }
+    }
+
+    /// True when `scene.pkg` at `pkgURL` contains an entry for `relativePath`.
+    private static func packageContainsEntry(_ pkgURL: URL, relativePath: String) -> Bool {
+        guard let provider = try? WPEPackageSceneAssetProvider(packageURL: pkgURL) else { return false }
+        return provider.exists(atRelativePath: relativePath)
     }
 
     private func cacheContent(for origin: WPEOrigin) -> WallpaperContent? {

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -139,7 +139,12 @@ final class WallpaperEngineImportService {
     ) async -> ImportResult {
         let pkgURL = folderURL.appendingPathComponent("scene.pkg")
         if fileManager.fileExists(atPath: pkgURL.path) {
-            return await importPackagedWeb(project: project, pkgURL: pkgURL, sourceBookmark: sourceBookmark)
+            return await importPackagedWeb(
+                project: project,
+                folderURL: folderURL,
+                pkgURL: pkgURL,
+                sourceBookmark: sourceBookmark
+            )
         }
 
         guard let indexURL = resourceURL(root: folderURL, relativePath: project.entryFile),
@@ -169,7 +174,56 @@ final class WallpaperEngineImportService {
         return .ready(content, origin: origin)
     }
 
+    /// Package-aware web import: serves the web payload in place from `scene.pkg`
+    /// via the render-time scheme handler (which reads pkg entries first, then
+    /// falls back to loose siblings like `project.json`). No whole-package
+    /// extraction, so no second on-disk copy in `wpe-cache`. Falls back to
+    /// extraction only when the package can't be opened or the index entry is
+    /// missing from it.
     private func importPackagedWeb(
+        project: WallpaperEngineProject,
+        folderURL: URL,
+        pkgURL: URL,
+        sourceBookmark: Data
+    ) async -> ImportResult {
+        if let provider = try? WPEPackageSceneAssetProvider(packageURL: pkgURL),
+           provider.exists(atRelativePath: project.entryFile) {
+            // Zero-cache: drop any stale prior extraction for this id so the
+            // source `.pkg` is never shadowed by a redundant, reclaimable copy.
+            await purgeStaleCache(workshopID: project.workshopID)
+
+            guard let folderBookmark = makeBookmark(folderURL) else {
+                return .rejected(reason: "Cannot create web folder bookmark")
+            }
+            let originKind = WallpaperEngineImportService.originKind(forSourceFolder: folderURL)
+            let origin = makeOrigin(
+                project: project,
+                sourceBookmark: sourceBookmark,
+                cacheRelativePath: nil,
+                resourceLocation: .sourceFolder,
+                originKind: originKind
+            )
+            let content = WallpaperContent.html(
+                source: .folder(bookmarkData: folderBookmark, indexFileName: project.entryFile),
+                config: HTMLConfig(
+                    physicalPixelLayout: true,
+                    originKind: originKind
+                )
+            )
+            return .ready(content, origin: origin)
+        }
+
+        return await importPackagedWebViaExtraction(
+            project: project,
+            pkgURL: pkgURL,
+            sourceBookmark: sourceBookmark
+        )
+    }
+
+    /// Legacy fallback: extracts the whole `scene.pkg` into `wpe-cache` and
+    /// points the wallpaper at the extracted folder. Used only when the package
+    /// can't be opened for in-place reading.
+    private func importPackagedWebViaExtraction(
         project: WallpaperEngineProject,
         pkgURL: URL,
         sourceBookmark: Data

--- a/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
+++ b/LiveWallpaper/Infrastructure/WallpaperEngineImportService.swift
@@ -573,7 +573,12 @@ struct WPECachedContentResolver {
     func content(for origin: WPEOrigin) -> WallpaperContent? {
         switch origin.resourceLocation {
         case .cache:
-            return cacheContent(for: origin)
+            // Cache retirement: rebuild a legacy `.cache` import in place from
+            // its source (video/web via the source folder, scene via the
+            // source-backed scene path inside `cacheContent`). A wallpaper whose
+            // source folder is gone can no longer be rebuilt — the cache was its
+            // only copy; accepted as part of retiring the extraction cache.
+            return sourceFolderContent(for: origin) ?? cacheContent(for: origin)
         case .sourceFolder:
             return sourceFolderContent(for: origin)
         default:

--- a/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
@@ -317,7 +317,7 @@ final class PlaybackCoordinator {
 
     // MARK: - Video session lifecycle
 
-    func setVideo(url: URL, bookmarkData: Data, for screen: Screen) {
+    func setVideo(url: URL, bookmarkData: Data, packageEntryName: String? = nil, for screen: Screen) {
         Logger.info("Setting video for screen \(screen.id): \(url.lastPathComponent)", category: .screenManager)
 
         let existing = configurationStore.get(for: screen.id, fingerprint: screen.displayFingerprint)
@@ -326,10 +326,13 @@ final class PlaybackCoordinator {
         let previousContent = existing?.activeWallpaper
         var configuration: ScreenConfiguration
         if var prior = existing {
-            prior.replacePrimaryVideo(bookmarkData: bookmarkData)
+            prior.replacePrimaryVideo(bookmarkData: bookmarkData, packageEntryName: packageEntryName)
             configuration = prior
         } else {
             configuration = ScreenConfiguration(screenID: screen.id, videoBookmarkData: bookmarkData)
+            // Carry the in-place package entry (the convenience init defaults to
+            // a loose video); everything else the init set stays intact.
+            configuration.activeWallpaper = .video(bookmarkData: bookmarkData, packageEntryName: packageEntryName)
         }
         originReconciler.reconcile(
             &configuration,
@@ -350,7 +353,11 @@ final class PlaybackCoordinator {
         let task = Task {
             do {
                 try Task.checkCancellation()
-                try await videoLoader.validatePlayableVideo(at: url)
+                if let packageEntryName {
+                    try await WallpaperVideoPlayer.validatePackagedVideo(packageURL: url, entryName: packageEntryName)
+                } else {
+                    try await videoLoader.validatePlayableVideo(at: url)
+                }
                 try Task.checkCancellation()
                 await MainActor.run { [weak self] in
                     guard let self,
@@ -490,7 +497,8 @@ final class PlaybackCoordinator {
             let player = WallpaperVideoPlayer(
                 url: url,
                 frame: screen.frame,
-                fitMode: configuration.fitMode
+                fitMode: configuration.fitMode,
+                packageEntryName: configuration.activeWallpaper.packageVideoEntryName
             )
             let session = VideoWallpaperSession(player: player)
             session.onRuntimeErrorChange = { [markSessionStateChanged] in markSessionStateChanged() }
@@ -528,7 +536,8 @@ final class PlaybackCoordinator {
         let player = WallpaperVideoPlayer(
             url: url,
             frame: screen.frame,
-            fitMode: configuration?.fitMode ?? .aspectFill
+            fitMode: configuration?.fitMode ?? .aspectFill,
+            packageEntryName: configuration?.activeWallpaper.packageVideoEntryName
         )
 
         if let configuration {

--- a/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
@@ -334,8 +334,10 @@ final class PlaybackCoordinator {
         } else {
             configuration = ScreenConfiguration(screenID: screen.id, videoBookmarkData: bookmarkData)
             // Carry the in-place package entry (the convenience init defaults to
-            // a loose video); everything else the init set stays intact.
+            // a loose video) on both the active and saved primary, so a later
+            // type-swap restore doesn't downgrade it to raw-package playback.
             configuration.activeWallpaper = .video(bookmarkData: bookmarkData, packageEntryName: packageEntryName)
+            configuration.savedVideoPackageEntryName = packageEntryName
         }
         originReconciler.reconcile(
             &configuration,

--- a/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/PlaybackCoordinator.swift
@@ -321,7 +321,10 @@ final class PlaybackCoordinator {
         Logger.info("Setting video for screen \(screen.id): \(url.lastPathComponent)", category: .screenManager)
 
         let existing = configurationStore.get(for: screen.id, fingerprint: screen.displayFingerprint)
+        // Identity is (resolved URL, package entry): two different entries inside
+        // the same scene.pkg resolve to the same URL but are different videos.
         let isSameURL = Self.bookmarkResolves(to: url, bookmark: existing?.videoBookmarkData)
+            && existing?.activeWallpaper.packageVideoEntryName == packageEntryName
 
         let previousContent = existing?.activeWallpaper
         var configuration: ScreenConfiguration
@@ -464,7 +467,8 @@ final class PlaybackCoordinator {
     ) {
         let existingPlayer = screen.videoPlayer
         let needsNewPlayer = existingPlayer == nil ||
-            Self.videoAudioURLKey(for: existingPlayer?.videoURL) != Self.videoAudioURLKey(for: url)
+            Self.videoAudioURLKey(for: existingPlayer?.videoURL) != Self.videoAudioURLKey(for: url) ||
+            existingPlayer?.packageEntryName != configuration.activeWallpaper.packageVideoEntryName
 
         if !needsNewPlayer, let player = existingPlayer {
             let currentTime = preservingState ? player.player?.currentTime() : .zero

--- a/LiveWallpaper/Runtime/Coordinators/WPEImportCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/WPEImportCoordinator.swift
@@ -188,8 +188,9 @@ final class WPEImportCoordinator {
         if case .html(let source, let htmlConfig) = content {
             config.savedHTMLSource = source
             config.savedHTMLConfig = htmlConfig
-        } else if case .video(let bookmarkData, _) = content {
+        } else if case .video(let bookmarkData, let packageEntryName) = content {
             config.savedVideoBookmarkData = bookmarkData
+            config.savedVideoPackageEntryName = packageEntryName
         }
         config.wpeOrigin = origin
         saveConfiguration(config)

--- a/LiveWallpaper/Runtime/Coordinators/WPEImportCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/WPEImportCoordinator.swift
@@ -188,7 +188,7 @@ final class WPEImportCoordinator {
         if case .html(let source, let htmlConfig) = content {
             config.savedHTMLSource = source
             config.savedHTMLConfig = htmlConfig
-        } else if case .video(let bookmarkData) = content {
+        } else if case .video(let bookmarkData, _) = content {
             config.savedVideoBookmarkData = bookmarkData
         }
         config.wpeOrigin = origin

--- a/LiveWallpaper/Runtime/Coordinators/WallpaperPersistenceCoordinator.swift
+++ b/LiveWallpaper/Runtime/Coordinators/WallpaperPersistenceCoordinator.swift
@@ -93,7 +93,7 @@ final class WallpaperPersistenceCoordinator {
             result.append(bookmarkData)
         }
 
-        if case .video(let bookmarkData) = configuration.activeWallpaper {
+        if case .video(let bookmarkData, _) = configuration.activeWallpaper {
             append(bookmarkData)
         }
         append(configuration.savedVideoBookmarkData)

--- a/LiveWallpaper/Runtime/ScreenManager+Bookmarks.swift
+++ b/LiveWallpaper/Runtime/ScreenManager+Bookmarks.swift
@@ -9,7 +9,7 @@ extension ScreenManager {
         }
 
         switch bookmark.content {
-        case .video(let bookmarkData):
+        case .video(let bookmarkData, let packageEntryName):
             guard case .success(let resolved) = SecurityScopedBookmarkResolver.shared.resolve(
                 bookmarkData,
                 target: .transient
@@ -17,7 +17,12 @@ extension ScreenManager {
                 Logger.warning("Bookmark video unresolvable; user may need to re-pick", category: .fileAccess)
                 return
             }
-            setVideo(url: resolved.url, bookmarkData: resolved.bookmarkData, for: screen)
+            setVideo(
+                url: resolved.url,
+                bookmarkData: resolved.bookmarkData,
+                packageEntryName: packageEntryName,
+                for: screen
+            )
         case .html(let source, let config):
             setHTMLWallpaper(source: source, config: config, for: screen)
         case .metalShader(let source):

--- a/LiveWallpaper/Runtime/WallpaperRuntimeSession.swift
+++ b/LiveWallpaper/Runtime/WallpaperRuntimeSession.swift
@@ -226,9 +226,15 @@ final class VideoWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
         let intent = userIntendsToPlay
         let profile = currentProfile
 
+        let packageEntryName = oldPlayer.packageEntryName
         oldPlayer.cleanup()
 
-        let replacement = WallpaperVideoPlayer(url: url, frame: frame, fitMode: fitMode)
+        let replacement = WallpaperVideoPlayer(
+            url: url,
+            frame: frame,
+            fitMode: fitMode,
+            packageEntryName: packageEntryName
+        )
         attachErrorHandler(to: replacement)
         replacement.setVolume(volume)
         replacement.setMuted(muted)

--- a/LiveWallpaper/ScreenManager.swift
+++ b/LiveWallpaper/ScreenManager.swift
@@ -824,9 +824,14 @@ final class ScreenManager {
     // MARK: - Video Management
 
     /// Replaces the primary video while preserving per-screen settings.
-    func setVideo(url: URL, bookmarkData: Data, for screen: Screen) {
+    func setVideo(url: URL, bookmarkData: Data, packageEntryName: String? = nil, for screen: Screen) {
         recordBookmarkDisplayName(bookmarkData, name: url.lastPathComponent)
-        playbackCoordinator.setVideo(url: url, bookmarkData: bookmarkData, for: screen)
+        playbackCoordinator.setVideo(
+            url: url,
+            bookmarkData: bookmarkData,
+            packageEntryName: packageEntryName,
+            for: screen
+        )
     }
 
     @discardableResult

--- a/LiveWallpaper/SettingsManager.swift
+++ b/LiveWallpaper/SettingsManager.swift
@@ -435,7 +435,7 @@ final class SettingsManager {
         }
 
         switch definition {
-        case .video(let bookmarkData):
+        case .video(let bookmarkData, _):
             return validateVideoBookmark(bookmarkData, for: screenID, configuration: configuration)
         case .html(let source, _):
             return validateHTMLSource(source, for: screenID)

--- a/LiveWallpaper/VideoPlayback/FolderURLSchemeHandler.swift
+++ b/LiveWallpaper/VideoPlayback/FolderURLSchemeHandler.swift
@@ -156,37 +156,42 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
             return
         }
 
-        // Resolve a byte source: an in-place `scene.pkg` entry first (when a
-        // package backend is active), otherwise a loose file under the folder.
+        // Resolve the loose candidate first (rejects path traversal). A loose
+        // file — when it actually exists — wins, preserving plain-folder
+        // semantics for ordinary HTML folders that merely happen to sit next to
+        // a `scene.pkg`. Only paths the folder does NOT have loose fall back to
+        // an in-place package entry (that's the packaged web payload).
+        let primaryURL: URL
+        do {
+            primaryURL = try Self.resolvedFileURL(for: url, inside: activeFolderURL!)
+        } catch {
+            urlSchemeTask.didFailWithError(error)
+            return
+        }
+
         let source: ByteSource
         let mime: String
-        if let resolved = packageByteSource(for: url) {
+        if Self.isRegularFile(primaryURL) {
+            source = .file(primaryURL)
+            mime = Self.mimeType(for: primaryURL)
+        } else if let fallback = Self.oggFallbackURL(for: primaryURL) {
+            if !reportedOggSubstitutions.contains(primaryURL.lastPathComponent) {
+                reportedOggSubstitutions.insert(primaryURL.lastPathComponent)
+                Logger.info(
+                    "FolderScheme: serving \(fallback.lastPathComponent) for \(primaryURL.lastPathComponent) (macOS WebKit Ogg/Opus decoder workaround)",
+                    category: .screenManager
+                )
+            }
+            source = .file(fallback)
+            mime = Self.mimeType(for: fallback)
+        } else if let resolved = packageByteSource(for: url) {
             source = resolved.source
             mime = resolved.mime
         } else {
-            let primaryURL: URL
-            do {
-                primaryURL = try Self.resolvedFileURL(for: url, inside: activeFolderURL!)
-            } catch {
-                urlSchemeTask.didFailWithError(error)
-                return
-            }
-
-            let fileURL: URL
-            if let fallback = Self.oggFallbackURL(for: primaryURL) {
-                if !reportedOggSubstitutions.contains(primaryURL.lastPathComponent) {
-                    reportedOggSubstitutions.insert(primaryURL.lastPathComponent)
-                    Logger.info(
-                        "FolderScheme: serving \(fallback.lastPathComponent) for \(primaryURL.lastPathComponent) (macOS WebKit Ogg/Opus decoder workaround)",
-                        category: .screenManager
-                    )
-                }
-                fileURL = fallback
-            } else {
-                fileURL = primaryURL
-            }
-            source = .file(fileURL)
-            mime = Self.mimeType(for: fileURL)
+            // Nothing loose, nothing in the package: serve the loose candidate
+            // so the worker emits the existing 404 + missing-resource log.
+            source = .file(primaryURL)
+            mime = Self.mimeType(for: primaryURL)
         }
 
         let rangeHeader = urlSchemeTask.request.value(forHTTPHeaderField: "Range")
@@ -573,6 +578,15 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
             bytesRemaining -= chunk.count
             await delivery.deliver(chunk: chunk)
         }
+        // A package entry has a known exact size; a short read means a truncated
+        // or corrupt package, not EOF — surface it instead of a silent success.
+        if bytesRemaining > 0 {
+            throw makeError(.cannotParseResponse, "Package entry truncated by \(bytesRemaining) bytes")
+        }
+    }
+
+    nonisolated private static func isRegularFile(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true
     }
 
     private struct ByteRange: Sendable {

--- a/LiveWallpaper/VideoPlayback/FolderURLSchemeHandler.swift
+++ b/LiveWallpaper/VideoPlayback/FolderURLSchemeHandler.swift
@@ -82,12 +82,13 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
     private var sessionNonce: String?
     private var activeTasks: [ObjectIdentifier: ActiveTask] = [:]
 
-    /// Optional in-place package backend. When set, a request is resolved
-    /// against the parsed `scene.pkg` table-of-contents first (entries are
-    /// contiguous, uncompressed byte slices); anything not in the package falls
-    /// back to a loose file under `activeFolderURL` (e.g. `project.json`, or
-    /// assets the author shipped unpacked). Set/cleared together with
-    /// `folderURL`; changing the folder always clears it.
+    /// Optional in-place package backend. When set, a request that the folder
+    /// does NOT have as a loose file is resolved against the parsed `scene.pkg`
+    /// table-of-contents (entries are contiguous, uncompressed byte slices).
+    /// Loose files always win, so an ordinary HTML folder next to a `scene.pkg`
+    /// keeps its plain-folder behaviour; the package only serves the packaged
+    /// payload (index + bundle). Set/cleared together with `folderURL`; changing
+    /// the folder always clears it.
     private var activePackageBacking: PackageBacking?
 
     struct PackageBacking: Sendable {

--- a/LiveWallpaper/VideoPlayback/FolderURLSchemeHandler.swift
+++ b/LiveWallpaper/VideoPlayback/FolderURLSchemeHandler.swift
@@ -81,6 +81,19 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
     private var activeFolderURL: URL?
     private var sessionNonce: String?
     private var activeTasks: [ObjectIdentifier: ActiveTask] = [:]
+
+    /// Optional in-place package backend. When set, a request is resolved
+    /// against the parsed `scene.pkg` table-of-contents first (entries are
+    /// contiguous, uncompressed byte slices); anything not in the package falls
+    /// back to a loose file under `activeFolderURL` (e.g. `project.json`, or
+    /// assets the author shipped unpacked). Set/cleared together with
+    /// `folderURL`; changing the folder always clears it.
+    private var activePackageBacking: PackageBacking?
+
+    struct PackageBacking: Sendable {
+        let url: URL
+        let package: WallpaperEnginePackage
+    }
     /// Filenames already reported as missing for the current folder session.
     /// Wallpaper Engine projects routinely reference voiceline / sprite
     /// resources that were never packaged (the author shipped placeholders),
@@ -105,8 +118,18 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
                 reportedOggSubstitutions.removeAll()
             }
             activeFolderURL = newValue
+            // A folder swap invalidates any prior package backend; the caller
+            // re-supplies one via `setPackageBacking(_:)` right after if needed.
+            activePackageBacking = nil
             sessionNonce = newValue == nil ? nil : UUID().uuidString
         }
+    }
+
+    /// Supplies (or clears) the in-place package backend for the current folder
+    /// session. Must be called *after* assigning `folderURL` (which resets it),
+    /// and does not regenerate the session nonce.
+    func setPackageBacking(_ backing: PackageBacking?) {
+        activePackageBacking = backing
     }
 
     /// Nonce produced for the current `folderURL` session. `HTMLWallpaperView`
@@ -128,34 +151,44 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
             return
         }
 
-        guard let folderURL = activeFolderURL else {
+        guard activeFolderURL != nil else {
             urlSchemeTask.didFailWithError(Self.makeError(.notConnectedToInternet, "No active folder"))
             return
         }
 
-        let primaryURL: URL
-        do {
-            primaryURL = try Self.resolvedFileURL(for: url, inside: folderURL)
-        } catch {
-            urlSchemeTask.didFailWithError(error)
-            return
-        }
-
-        let fileURL: URL
-        if let fallback = Self.oggFallbackURL(for: primaryURL) {
-            if !reportedOggSubstitutions.contains(primaryURL.lastPathComponent) {
-                reportedOggSubstitutions.insert(primaryURL.lastPathComponent)
-                Logger.info(
-                    "FolderScheme: serving \(fallback.lastPathComponent) for \(primaryURL.lastPathComponent) (macOS WebKit Ogg/Opus decoder workaround)",
-                    category: .screenManager
-                )
-            }
-            fileURL = fallback
+        // Resolve a byte source: an in-place `scene.pkg` entry first (when a
+        // package backend is active), otherwise a loose file under the folder.
+        let source: ByteSource
+        let mime: String
+        if let resolved = packageByteSource(for: url) {
+            source = resolved.source
+            mime = resolved.mime
         } else {
-            fileURL = primaryURL
+            let primaryURL: URL
+            do {
+                primaryURL = try Self.resolvedFileURL(for: url, inside: activeFolderURL!)
+            } catch {
+                urlSchemeTask.didFailWithError(error)
+                return
+            }
+
+            let fileURL: URL
+            if let fallback = Self.oggFallbackURL(for: primaryURL) {
+                if !reportedOggSubstitutions.contains(primaryURL.lastPathComponent) {
+                    reportedOggSubstitutions.insert(primaryURL.lastPathComponent)
+                    Logger.info(
+                        "FolderScheme: serving \(fallback.lastPathComponent) for \(primaryURL.lastPathComponent) (macOS WebKit Ogg/Opus decoder workaround)",
+                        category: .screenManager
+                    )
+                }
+                fileURL = fallback
+            } else {
+                fileURL = primaryURL
+            }
+            source = .file(fileURL)
+            mime = Self.mimeType(for: fileURL)
         }
 
-        let mime = Self.mimeType(for: fileURL)
         let rangeHeader = urlSchemeTask.request.value(forHTTPHeaderField: "Range")
         let delivery = SchemeTaskDelivery(urlSchemeTask)
         let taskID = ObjectIdentifier(urlSchemeTask as AnyObject)
@@ -171,12 +204,12 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
 
         activeTasks[taskID]?.cancel()
 
-        let worker = Task.detached(priority: .userInitiated) { [weak self, fileURL, mime, rangeHeader, url, delivery, taskID, cspHeader] in
+        let worker = Task.detached(priority: .userInitiated) { [weak self, source, mime, rangeHeader, url, delivery, taskID, cspHeader] in
             do {
-                let fileSize = try Self.fileSize(for: fileURL)
-                let range = Self.byteRange(from: rangeHeader, totalLength: fileSize)
+                let totalLength = try Self.totalLength(of: source)
+                let range = Self.byteRange(from: rangeHeader, totalLength: totalLength)
                 let statusCode = range == nil ? 200 : 206
-                let contentLength = range?.length ?? fileSize
+                let contentLength = range?.length ?? totalLength
 
                 var headers = [
                     "Content-Type": mime,
@@ -194,7 +227,7 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
                     headers["Access-Control-Allow-Origin"] = "*"
                 }
                 if let range {
-                    headers["Content-Range"] = "bytes \(range.start)-\(range.end)/\(fileSize)"
+                    headers["Content-Range"] = "bytes \(range.start)-\(range.end)/\(totalLength)"
                 }
 
                 let response = HTTPURLResponse(
@@ -210,8 +243,8 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
                 )
 
                 await delivery.deliver(response: response)
-                try await Self.streamFile(
-                    fileURL,
+                try await Self.stream(
+                    source,
                     to: delivery,
                     offset: range?.start ?? 0,
                     length: contentLength
@@ -223,10 +256,10 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
                 let isMissingFile = (error as NSError).domain == NSCocoaErrorDomain
                     && ((error as NSError).code == NSFileReadNoSuchFileError
                         || (error as NSError).code == NSFileNoSuchFileError)
-                if isMissingFile {
+                if isMissingFile, case .file(let fileURL) = source {
                     await self?.logMissingResource(fileURL: fileURL, requestURL: url)
                 } else {
-                    Logger.warning("FolderScheme: \(fileURL.lastPathComponent) — \(error.localizedDescription)", category: .screenManager)
+                    Logger.warning("FolderScheme: \(source.lastComponent) — \(error.localizedDescription)", category: .screenManager)
                 }
                 await delivery.fail(with: error)
             }
@@ -240,6 +273,61 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
         if delivery.hasTerminated {
             activeTasks.removeValue(forKey: taskID)
         }
+    }
+
+    /// Resolves a request to an in-place `scene.pkg` entry when a package
+    /// backend is active. Returns `nil` (→ loose-folder fallback) when there is
+    /// no package, the path is unsafe, or the entry isn't in the package. Path
+    /// safety is enforced by `canonicalLookupName` (rejects leading `/` / `..`).
+    private func packageByteSource(for url: URL) -> (source: ByteSource, mime: String)? {
+        guard let backing = activePackageBacking else { return nil }
+        let requestPath = url.path.removingPercentEncoding ?? url.path
+        let relativePath = requestPath.hasPrefix("/") ? String(requestPath.dropFirst()) : requestPath
+        guard let lookup = WallpaperEnginePackage.canonicalLookupName(relativePath) else { return nil }
+
+        if let entry = backing.package.entry(named: lookup) {
+            return (Self.packageSource(for: entry, in: backing), Self.mimeType(forEntryName: entry.name))
+        }
+        // Ogg-family substitution, mirroring the loose-folder workaround but
+        // resolved against the package's in-memory table of contents.
+        if let fallback = Self.packageOggFallbackEntry(for: lookup, in: backing.package) {
+            let requested = (lookup as NSString).lastPathComponent
+            if !reportedOggSubstitutions.contains(requested) {
+                reportedOggSubstitutions.insert(requested)
+                Logger.info(
+                    "FolderScheme: serving \(fallback.name) for \(requested) from package (macOS WebKit Ogg/Opus decoder workaround)",
+                    category: .screenManager
+                )
+            }
+            return (Self.packageSource(for: fallback, in: backing), Self.mimeType(forEntryName: fallback.name))
+        }
+        return nil
+    }
+
+    nonisolated private static func packageSource(
+        for entry: WallpaperEnginePackage.Entry,
+        in backing: PackageBacking
+    ) -> ByteSource {
+        .packageEntry(
+            packageURL: backing.url,
+            absoluteStart: backing.package.dataStart + entry.dataOffset,
+            size: entry.dataSize
+        )
+    }
+
+    nonisolated private static func packageOggFallbackEntry(
+        for lookup: String,
+        in package: WallpaperEnginePackage
+    ) -> WallpaperEnginePackage.Entry? {
+        let ext = (lookup as NSString).pathExtension.lowercased()
+        guard ext == "ogg" || ext == "oga" || ext == "opus" else { return nil }
+        let base = (lookup as NSString).deletingPathExtension
+        for candidateExt in oggFallbackExtensions {
+            if let entry = package.entry(named: "\(base).\(candidateExt)") {
+                return entry
+            }
+        }
+        return nil
     }
 
     /// Diagnostic log for the "file not found" branch. The lightweight version
@@ -426,6 +514,67 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
         }
     }
 
+    /// Total servable length of a byte source: the file's size, or the package
+    /// entry's declared `dataSize`.
+    nonisolated private static func totalLength(of source: ByteSource) throws -> Int {
+        switch source {
+        case .file(let url):
+            return try fileSize(for: url)
+        case .packageEntry(_, _, let size):
+            guard let length = Int(exactly: size) else {
+                throw makeError(.cannotOpenFile, "Package entry exceeds addressable size")
+            }
+            return length
+        }
+    }
+
+    /// Streams `length` bytes from `offset` within the source to the delivery.
+    nonisolated private static func stream(
+        _ source: ByteSource,
+        to delivery: SchemeTaskDelivery,
+        offset: Int,
+        length: Int
+    ) async throws {
+        switch source {
+        case .file(let url):
+            try await streamFile(url, to: delivery, offset: offset, length: length)
+        case .packageEntry(let packageURL, let absoluteStart, _):
+            try await streamPackageEntry(
+                packageURL: packageURL,
+                absoluteStart: absoluteStart,
+                to: delivery,
+                offset: offset,
+                length: length
+            )
+        }
+    }
+
+    /// Streams a slice of a `scene.pkg` entry. Each task opens its **own** file
+    /// handle (entries are contiguous, uncompressed byte ranges) so concurrent
+    /// subresource requests never contend on a shared seek offset.
+    nonisolated private static func streamPackageEntry(
+        packageURL: URL,
+        absoluteStart: UInt64,
+        to delivery: SchemeTaskDelivery,
+        offset: Int,
+        length: Int
+    ) async throws {
+        let handle = try FileHandle(forReadingFrom: packageURL)
+        defer { try? handle.close() }
+
+        try handle.seek(toOffset: absoluteStart + UInt64(max(0, offset)))
+
+        var bytesRemaining = length
+        while bytesRemaining > 0 {
+            try Task.checkCancellation()
+            let chunkLimit = min(responseChunkSize, bytesRemaining)
+            let chunk = try handle.read(upToCount: chunkLimit) ?? Data()
+            guard !chunk.isEmpty else { break }
+            bytesRemaining -= chunk.count
+            await delivery.deliver(chunk: chunk)
+        }
+    }
+
     private struct ByteRange: Sendable {
         let start: Int
         let end: Int
@@ -464,7 +613,15 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
     }
 
     nonisolated private static func mimeType(for url: URL) -> String {
-        let ext = url.pathExtension.lowercased()
+        mimeType(forPathExtension: url.pathExtension)
+    }
+
+    nonisolated private static func mimeType(forEntryName name: String) -> String {
+        mimeType(forPathExtension: (name as NSString).pathExtension)
+    }
+
+    nonisolated private static func mimeType(forPathExtension rawExtension: String) -> String {
+        let ext = rawExtension.lowercased()
         if let utType = UTType(filenameExtension: ext), let mime = utType.preferredMIMEType {
             return mime
         }
@@ -505,6 +662,23 @@ final class FolderURLSchemeHandler: NSObject, WKURLSchemeHandler, @unchecked Sen
 }
 
 // MARK: - Internal Types
+
+/// Where a resolved request's bytes come from: a loose file on disk, or a
+/// contiguous slice of an in-place `scene.pkg`.
+private enum ByteSource: Sendable {
+    case file(URL)
+    case packageEntry(packageURL: URL, absoluteStart: UInt64, size: UInt64)
+
+    /// A short label for diagnostics.
+    var lastComponent: String {
+        switch self {
+        case .file(let url):
+            return url.lastPathComponent
+        case .packageEntry(let packageURL, _, _):
+            return "\(packageURL.lastPathComponent)#entry"
+        }
+    }
+}
 
 private struct ActiveTask {
     let worker: Task<Void, Never>

--- a/LiveWallpaper/VideoPlayback/HTMLWallpaperView.swift
+++ b/LiveWallpaper/VideoPlayback/HTMLWallpaperView.swift
@@ -644,6 +644,11 @@ final class HTMLWallpaperView: NSView, HTMLWallpaperConfigApplying {
             currentLocalReadAccessRoot = folderURL
             updateWallpaperEnginePropertyBridge(for: folderURL)
             folderHandler.folderURL = folderURL
+            // In-place package serving: when the source folder holds a
+            // `scene.pkg`, the handler reads web assets straight from it
+            // (loose siblings like `project.json` still fall back to the
+            // folder). Must be set after `folderURL` (which clears it).
+            folderHandler.setPackageBacking(Self.packageBacking(forFolder: folderURL))
             guard let nonce = folderHandler.currentSessionNonce else {
                 Logger.error("HTML folder load: missing session nonce for \(indexFileName)", category: .screenManager)
                 return
@@ -662,6 +667,29 @@ final class HTMLWallpaperView: NSView, HTMLWallpaperConfigApplying {
         case .inline(let html):
             currentLocalReadAccessRoot = nil
             webView.loadHTMLString(html, baseURL: nil)
+        }
+    }
+
+    /// Detects an in-place `scene.pkg` inside a packaged web wallpaper's source
+    /// folder and parses its table of contents so the scheme handler can serve
+    /// web assets directly from the package. Returns `nil` for an unpacked
+    /// folder (no `scene.pkg`) or an unreadable/invalid package, in which case
+    /// the handler serves loose files only. Parsing reads just the header (it
+    /// seeks past the payload), so cost scales with entry count, not pkg size.
+    private static func packageBacking(forFolder folderURL: URL) -> FolderURLSchemeHandler.PackageBacking? {
+        let pkgURL = folderURL.appendingPathComponent("scene.pkg")
+        guard FileManager.default.fileExists(atPath: pkgURL.path) else { return nil }
+        do {
+            let handle = try FileHandle(forReadingFrom: pkgURL)
+            defer { try? handle.close() }
+            let package = try WallpaperEnginePackage.parseIndex(streamingFrom: handle)
+            return FolderURLSchemeHandler.PackageBacking(url: pkgURL, package: package)
+        } catch {
+            Logger.info(
+                "HTML folder load: scene.pkg present but not parseable (\(error)) — serving folder directly",
+                category: .screenManager
+            )
+            return nil
         }
     }
 

--- a/LiveWallpaper/VideoPlayback/InMemoryVideoAssetLoader.swift
+++ b/LiveWallpaper/VideoPlayback/InMemoryVideoAssetLoader.swift
@@ -2,8 +2,8 @@ import AVFoundation
 import Foundation
 
 /// `AVAssetResourceLoaderDelegate` that serves a video's bytes from an
-/// in-memory `Data` blob instead of letting AVFoundation re-read the file
-/// from disk on every loop iteration.
+/// in-memory `Data` blob (a `.mappedIfSafe` mapping) instead of letting
+/// AVFoundation re-read the file from disk on every loop iteration.
 ///
 /// Why this exists: `AVPlayerItem.preferredForwardBufferDuration` is a hint
 /// AVFoundation can — and on 4K HEVC clips does — ignore, leaving the
@@ -11,6 +11,13 @@ import Foundation
 /// `fs_usage`). Wrapping a custom-scheme URL with this delegate forces
 /// every byte request to come from RAM, giving a hard 0 physical-read
 /// guarantee once the initial load is done.
+///
+/// It also backs **in-place packaged video**: `loadPackageEntry` maps the
+/// whole `scene.pkg` and exposes a *window* `[windowStart, windowStart+
+/// windowLength)` into it (the video entry's contiguous, uncompressed byte
+/// slice). The player gets a normal-looking byte-range resource without the
+/// package ever being extracted. `mappedIfSafe` keeps the RSS profile lazy —
+/// only the pages AVFoundation actually reads page in.
 ///
 /// The owner must keep a reference to the loader for the lifetime of the
 /// player — `AVAssetResourceLoader.setDelegate(_:queue:)` only holds a
@@ -23,27 +30,77 @@ final class InMemoryVideoAssetLoader: NSObject, AVAssetResourceLoaderDelegate, @
 
     private let data: Data
     private let mimeType: String
+    /// Window into `data` that this loader exposes as the resource. For a plain
+    /// file the window is the whole blob; for a packaged entry it's the entry's
+    /// byte slice within the mapped `scene.pkg`.
+    private let windowStart: Int
+    private let windowLength: Int
 
-    /// Build a `Data` + MIME pair from a local file URL.
+    /// Build a `Data` + MIME pair from a local file URL (whole-file window).
     static func load(from url: URL) throws -> (loader: InMemoryVideoAssetLoader, customURL: URL) {
         let data = try Data(contentsOf: url, options: .mappedIfSafe)
-        let mime = mimeType(for: url)
-        let loader = InMemoryVideoAssetLoader(data: data, mimeType: mime)
-        let customURL = customURL(for: url)
-        return (loader, customURL)
+        let mime = mimeType(forPathExtension: url.pathExtension)
+        let loader = InMemoryVideoAssetLoader(
+            data: data,
+            mimeType: mime,
+            windowStart: 0,
+            windowLength: data.count
+        )
+        return (loader, customURL(forLastComponent: url.lastPathComponent))
+    }
+
+    /// Build a loader windowed into a `scene.pkg` entry — the in-place packaged
+    /// video path. Maps the whole package (`mappedIfSafe`, lazy) and exposes
+    /// only the entry's contiguous byte range. No extraction.
+    static func loadPackageEntry(
+        packageURL: URL,
+        entryName: String
+    ) throws -> (loader: InMemoryVideoAssetLoader, customURL: URL) {
+        let package: WallpaperEnginePackage
+        do {
+            let handle = try FileHandle(forReadingFrom: packageURL)
+            defer { try? handle.close() }
+            package = try WallpaperEnginePackage.parseIndex(streamingFrom: handle)
+        }
+        guard let lookup = WallpaperEnginePackage.canonicalLookupName(entryName),
+              let entry = package.entry(named: lookup) else {
+            throw NSError(domain: "InMemoryVideoAssetLoader", code: 404, userInfo: [
+                NSLocalizedDescriptionKey: "Video entry \(entryName) not found in package"
+            ])
+        }
+        let data = try Data(contentsOf: packageURL, options: .mappedIfSafe)
+        let absoluteStart = package.dataStart + entry.dataOffset
+        guard let start = Int(exactly: absoluteStart),
+              let length = Int(exactly: entry.dataSize),
+              start >= 0, length >= 0, start &+ length <= data.count else {
+            throw NSError(domain: "InMemoryVideoAssetLoader", code: 422, userInfo: [
+                NSLocalizedDescriptionKey: "Video entry \(entryName) is out of package bounds"
+            ])
+        }
+        let loader = InMemoryVideoAssetLoader(
+            data: data,
+            mimeType: mimeType(forPathExtension: (entryName as NSString).pathExtension),
+            windowStart: start,
+            windowLength: length
+        )
+        return (loader, customURL(forLastComponent: (entryName as NSString).lastPathComponent))
     }
 
     /// Convert a regular file URL into the `lwmem://` form that triggers the resource-loader delegate path.
     static func customURL(for url: URL) -> URL {
+        customURL(forLastComponent: url.lastPathComponent)
+    }
+
+    private static func customURL(forLastComponent lastComponent: String) -> URL {
         var components = URLComponents()
         components.scheme = scheme
         components.host = "wallpaper"
-        components.path = "/" + url.lastPathComponent
+        components.path = "/" + (lastComponent.isEmpty ? "video" : lastComponent)
         return components.url ?? URL(string: "\(scheme)://wallpaper/video")!
     }
 
-    private static func mimeType(for url: URL) -> String {
-        switch url.pathExtension.lowercased() {
+    private static func mimeType(forPathExtension rawExtension: String) -> String {
+        switch rawExtension.lowercased() {
         case "mp4", "m4v": return "video/mp4"
         case "mov":        return "video/quicktime"
         case "m4a":        return "audio/mp4"
@@ -51,9 +108,11 @@ final class InMemoryVideoAssetLoader: NSObject, AVAssetResourceLoaderDelegate, @
         }
     }
 
-    private init(data: Data, mimeType: String) {
+    private init(data: Data, mimeType: String, windowStart: Int, windowLength: Int) {
         self.data = data
         self.mimeType = mimeType
+        self.windowStart = windowStart
+        self.windowLength = windowLength
     }
 
     // MARK: - AVAssetResourceLoaderDelegate
@@ -64,27 +123,31 @@ final class InMemoryVideoAssetLoader: NSObject, AVAssetResourceLoaderDelegate, @
     ) -> Bool {
         if let info = loadingRequest.contentInformationRequest {
             info.contentType = mimeType
-            info.contentLength = Int64(data.count)
+            info.contentLength = Int64(windowLength)
             info.isByteRangeAccessSupported = true
         }
 
         if let dataRequest = loadingRequest.dataRequest {
-            let start = Int(clamping: dataRequest.currentOffset)
+            // Offsets are relative to the logical resource (0..<windowLength);
+            // map them into the underlying blob via `windowStart`.
+            let logicalStart = Int(clamping: dataRequest.currentOffset)
             let requested = dataRequest.requestedLength
-            let end: Int
+            let logicalEnd: Int
             if requested == Int.max {
-                end = data.count
+                logicalEnd = windowLength
             } else {
-                end = min(start &+ requested, data.count)
+                logicalEnd = min(logicalStart &+ requested, windowLength)
             }
             // Respond in bounded chunks so a large requested range can't
             // trigger a single multi-hundred-MB `Data` copy. AVFoundation
             // accepts repeated `respond(with:)` calls before
             // `finishLoading()` and stitches them into one fulfilled range.
-            var offset = start
-            while offset < end {
-                let next = min(offset &+ Self.chunkSize, end)
-                dataRequest.respond(with: Data(data[offset..<next]))
+            var offset = logicalStart
+            while offset < logicalEnd {
+                let next = min(offset &+ Self.chunkSize, logicalEnd)
+                let physicalLow = windowStart &+ offset
+                let physicalHigh = windowStart &+ next
+                dataRequest.respond(with: Data(data[physicalLow..<physicalHigh]))
                 offset = next
             }
         }

--- a/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
+++ b/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
@@ -27,6 +27,10 @@ final class WallpaperVideoPlayer {
 
     private(set) var player: AVQueuePlayer?
     var videoURL: URL?
+    /// Non-nil when `videoURL` is a `scene.pkg` and this entry is played in
+    /// place (windowed resource loader, no extraction). Read by the runtime
+    /// session when it rebuilds the player on `retry()`.
+    private(set) var packageEntryName: String?
     /// Whether audio tracks are disabled at the AVPlayerItem level.
     private(set) var isMuted: Bool = true
     /// User-controlled output level applied when audio is not muted.
@@ -87,11 +91,18 @@ final class WallpaperVideoPlayer {
     var isForceSDRActive: Bool { lastColorSpacePreference == .forceSDR }
     
     // MARK: - Initialization
-    init(url: URL, frame: CGRect, fitMode: VideoFitMode = .aspectFill, loadImmediately: Bool = true) {
+    init(
+        url: URL,
+        frame: CGRect,
+        fitMode: VideoFitMode = .aspectFill,
+        packageEntryName: String? = nil,
+        loadImmediately: Bool = true
+    ) {
         Logger.functionStart(category: .videoPlayer)
         self.initialFrame = frame
         self.fitMode = fitMode
         self.videoURL = url
+        self.packageEntryName = packageEntryName
         
         guard !frame.isEmpty else {
             let error = NSError(
@@ -142,7 +153,26 @@ final class WallpaperVideoPlayer {
 
             do {
                 let timer = PerformanceTimer(description: "Loading video asset", category: .videoPlayer)
-                let asset = AVURLAsset(url: url)
+
+                // In-place packaged video: build a custom-scheme asset backed by
+                // a resource loader windowed into the scene.pkg. The same asset
+                // is used for probing (isPlayable/tracks/duration) and playback;
+                // there is no plain file URL to open.
+                let asset: AVURLAsset
+                let packagedLoader: InMemoryVideoAssetLoader?
+                if let entryName = self.packageEntryName {
+                    let result = try await Task.detached(priority: .utility) {
+                        try InMemoryVideoAssetLoader.loadPackageEntry(packageURL: url, entryName: entryName)
+                    }.value
+                    try Task.checkCancellation()
+                    let memAsset = AVURLAsset(url: result.customURL, options: Self.inMemoryAssetOptions)
+                    memAsset.resourceLoader.setDelegate(result.loader, queue: Self.resourceLoaderQueue)
+                    asset = memAsset
+                    packagedLoader = result.loader
+                } else {
+                    asset = AVURLAsset(url: url)
+                    packagedLoader = nil
+                }
 
                 try Task.checkCancellation()
 
@@ -172,64 +202,69 @@ final class WallpaperVideoPlayer {
                 let cmDuration = try? await asset.load(.duration)
                 let durationSeconds = Self.usableDuration(from: cmDuration)
 
-                let fileSize = Self.fileSize(of: url)
-                let memoryCached = Self.shouldUseInMemoryCache(fileSize: fileSize)
-                // Differentiated buffer hint: in-memory path doesn't need
-                // to pre-fetch ahead because the bytes are already in RAM,
-                // so we skip the "buffer the entire short clip" behaviour
-                // that exists to absorb loop-wrap disk reads on streaming.
-                // This cuts AVFoundation's per-player buffer state from
-                // ~duration×bitrate to a flat ~2s, which is the dominant
-                // savings on multi-screen same-video setups.
-                let bufferDuration = memoryCached
-                    ? Self.inMemoryBufferDuration
-                    : Self.bufferDuration(forDuration: durationSeconds)
-
                 let activeAsset: AVURLAsset
                 let loader: InMemoryVideoAssetLoader?
-                if memoryCached {
-                    do {
-                        // Hop off MainActor for the synchronous mmap +
-                        // file-attribute walk inside `load(from:)`. On a
-                        // 4K@60 clip this can touch several hundred MB
-                        // of virtual memory mapping — even when
-                        // `mappedIfSafe` succeeds the syscall cost is
-                        // non-trivial and shouldn't sit on main.
-                        let result = try await Task.detached(priority: .utility) {
-                            try InMemoryVideoAssetLoader.load(from: url)
-                        }.value
-                        try Task.checkCancellation()
-                        let memOptions: [String: Any] = [
-                            AVURLAssetReferenceRestrictionsKey: AVAssetReferenceRestrictions.forbidAll.rawValue,
-                            AVURLAssetAllowsCellularAccessKey: false,
-                            AVURLAssetAllowsExpensiveNetworkAccessKey: false,
-                            AVURLAssetAllowsConstrainedNetworkAccessKey: false
-                        ]
-                        let memAsset = AVURLAsset(url: result.customURL, options: memOptions)
-                        memAsset.resourceLoader.setDelegate(result.loader, queue: Self.resourceLoaderQueue)
-                        activeAsset = memAsset
-                        loader = result.loader
-                        Logger.notice(
-                            "Loaded \(fileSize / (1024 * 1024)) MB video into RAM — 0 physical reads expected after warmup",
-                            category: .videoPlayer
-                        )
-                    } catch {
-                        Logger.info(
-                            "In-memory load failed (\(error.localizedDescription)) — falling back to streaming",
-                            category: .videoPlayer
-                        )
+                let bufferDuration: TimeInterval
+
+                if let packagedLoader {
+                    // Packaged video always serves windowed from the mapped
+                    // package (mmap pages in lazily, covering small + large
+                    // clips); skip the file-size in-memory/stream decision.
+                    activeAsset = asset
+                    loader = packagedLoader
+                    bufferDuration = Self.inMemoryBufferDuration
+                } else {
+                    let fileSize = Self.fileSize(of: url)
+                    let memoryCached = Self.shouldUseInMemoryCache(fileSize: fileSize)
+                    // Differentiated buffer hint: in-memory path doesn't need
+                    // to pre-fetch ahead because the bytes are already in RAM,
+                    // so we skip the "buffer the entire short clip" behaviour
+                    // that exists to absorb loop-wrap disk reads on streaming.
+                    // This cuts AVFoundation's per-player buffer state from
+                    // ~duration×bitrate to a flat ~2s, which is the dominant
+                    // savings on multi-screen same-video setups.
+                    bufferDuration = memoryCached
+                        ? Self.inMemoryBufferDuration
+                        : Self.bufferDuration(forDuration: durationSeconds)
+
+                    if memoryCached {
+                        do {
+                            // Hop off MainActor for the synchronous mmap +
+                            // file-attribute walk inside `load(from:)`. On a
+                            // 4K@60 clip this can touch several hundred MB
+                            // of virtual memory mapping — even when
+                            // `mappedIfSafe` succeeds the syscall cost is
+                            // non-trivial and shouldn't sit on main.
+                            let result = try await Task.detached(priority: .utility) {
+                                try InMemoryVideoAssetLoader.load(from: url)
+                            }.value
+                            try Task.checkCancellation()
+                            let memAsset = AVURLAsset(url: result.customURL, options: Self.inMemoryAssetOptions)
+                            memAsset.resourceLoader.setDelegate(result.loader, queue: Self.resourceLoaderQueue)
+                            activeAsset = memAsset
+                            loader = result.loader
+                            Logger.notice(
+                                "Loaded \(fileSize / (1024 * 1024)) MB video into RAM — 0 physical reads expected after warmup",
+                                category: .videoPlayer
+                            )
+                        } catch {
+                            Logger.info(
+                                "In-memory load failed (\(error.localizedDescription)) — falling back to streaming",
+                                category: .videoPlayer
+                            )
+                            activeAsset = asset
+                            loader = nil
+                        }
+                    } else {
                         activeAsset = asset
                         loader = nil
+                        let budgetMB = SettingsManager.shared.loadGlobalSettings()
+                            .videoCacheMaxBytesPerScreen / (1024 * 1024)
+                        Logger.debug(
+                            "Streaming from disk: \(fileSize / (1024 * 1024)) MB exceeds in-memory budget (\(budgetMB) MB). Raise the slider in General Settings to keep this clip in RAM.",
+                            category: .videoPlayer
+                        )
                     }
-                } else {
-                    activeAsset = asset
-                    loader = nil
-                    let budgetMB = SettingsManager.shared.loadGlobalSettings()
-                        .videoCacheMaxBytesPerScreen / (1024 * 1024)
-                    Logger.debug(
-                        "Streaming from disk: \(fileSize / (1024 * 1024)) MB exceeds in-memory budget (\(budgetMB) MB). Raise the slider in General Settings to keep this clip in RAM.",
-                        category: .videoPlayer
-                    )
                 }
 
                 timer.checkpoint("Properties loaded")
@@ -242,7 +277,10 @@ final class WallpaperVideoPlayer {
                 }
 
                 do {
-                    try await self.detectFormatInfoIfNeeded(for: url)
+                    // Probe HDR/codec from the active asset: for packaged /
+                    // in-memory videos there is no plain file URL, and the
+                    // windowed custom-scheme asset answers track queries fine.
+                    try await self.detectFormatInfoIfNeeded(asset: activeAsset)
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch {
@@ -286,6 +324,28 @@ final class WallpaperVideoPlayer {
         label: "app.livewallpaper.video.in-memory-loader",
         qos: .userInitiated
     )
+
+    /// Asset options for custom-scheme (`lwmem://`) assets — both the in-memory
+    /// file loader and the in-place packaged loader. Forbids AVFoundation from
+    /// resolving any external reference or touching the network.
+    private static let inMemoryAssetOptions: [String: Any] = [
+        AVURLAssetReferenceRestrictionsKey: AVAssetReferenceRestrictions.forbidAll.rawValue,
+        AVURLAssetAllowsCellularAccessKey: false,
+        AVURLAssetAllowsExpensiveNetworkAccessKey: false,
+        AVURLAssetAllowsConstrainedNetworkAccessKey: false
+    ]
+
+    /// Validates an in-place packaged video by building the windowed
+    /// custom-scheme asset and probing `isPlayable` — there is no plain file
+    /// URL to hand the URL-based validator. The loader is held alive across the
+    /// async probe so AVFoundation's weak delegate ref stays valid.
+    static func validatePackagedVideo(packageURL: URL, entryName: String) async throws {
+        let result = try InMemoryVideoAssetLoader.loadPackageEntry(packageURL: packageURL, entryName: entryName)
+        let asset = AVURLAsset(url: result.customURL, options: inMemoryAssetOptions)
+        asset.resourceLoader.setDelegate(result.loader, queue: resourceLoaderQueue)
+        try await PlayableVideoLoader.validatePlayableVideo(asset: asset)
+        withExtendedLifetime(result.loader) {}
+    }
 
 
     private static func fileSize(of url: URL) -> Int {
@@ -405,9 +465,9 @@ final class WallpaperVideoPlayer {
         setupPlayerReadyObserver()
     }
 
-    private func detectFormatInfoIfNeeded(for url: URL) async throws {
+    private func detectFormatInfoIfNeeded(asset: AVURLAsset) async throws {
         guard formatInfo == nil else { return }
-        let detected = try await PlayableVideoLoader.detectFormat(at: url)
+        let detected = try await PlayableVideoLoader.detectFormat(asset: asset)
         try Task.checkCancellation()
         formatInfo = detected
         applyHDRPreferenceIfNeeded(for: detected)

--- a/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
+++ b/LiveWallpaper/VideoPlayback/WallpaperVideoPlayer.swift
@@ -340,6 +340,12 @@ final class WallpaperVideoPlayer {
     /// URL to hand the URL-based validator. The loader is held alive across the
     /// async probe so AVFoundation's weak delegate ref stays valid.
     static func validatePackagedVideo(packageURL: URL, entryName: String) async throws {
+        // Mapping the package requires the security scope active; unlike the
+        // player path (which holds it via `accessToken`), this static helper is
+        // reached from the bookmark-apply flow with no scope held.
+        let didStart = packageURL.startAccessingSecurityScopedResource()
+        defer { if didStart { packageURL.stopAccessingSecurityScopedResource() } }
+
         let result = try InMemoryVideoAssetLoader.loadPackageEntry(packageURL: packageURL, entryName: entryName)
         let asset = AVURLAsset(url: result.customURL, options: inMemoryAssetOptions)
         asset.resourceLoader.setDelegate(result.loader, queue: resourceLoaderQueue)

--- a/LiveWallpaper/Views/BookmarksLibraryView.swift
+++ b/LiveWallpaper/Views/BookmarksLibraryView.swift
@@ -414,7 +414,10 @@ private struct BookmarkTile: View {
         }
 
         switch bookmark.content {
-        case .video(let bookmarkData):
+        case .video(let bookmarkData, let packageEntryName):
+            // Packaged videos resolve to a scene.pkg, which has no plain video
+            // poster frame; skip the thumbnail rather than mis-decode the pkg.
+            guard packageEntryName == nil else { break }
             guard case .success(let resolved) = SecurityScopedBookmarkResolver.shared.resolve(
                 bookmarkData,
                 target: .transient

--- a/LiveWallpaper/Views/BookmarksPopover.swift
+++ b/LiveWallpaper/Views/BookmarksPopover.swift
@@ -185,7 +185,7 @@ struct BookmarksPopover: View {
 
     private func sourceDisplayName(for content: WallpaperContent) -> String? {
         switch content {
-        case .video(let bookmarkData):
+        case .video(let bookmarkData, _):
             return screenManager.bookmarkDisplayName(for: bookmarkData)
         case .html(let source, _):
             return source.displayName

--- a/LiveWallpaper/Views/ContentView.swift
+++ b/LiveWallpaper/Views/ContentView.swift
@@ -392,21 +392,27 @@ struct Sidebar: View {
                 SidebarSectionHeader(title: "Library")
             }
 
+        }
+        .listStyle(.sidebar)
+        // Pin Usage to the bottom of the sidebar (like the mockup's
+        // `margin-top:auto`) instead of letting it flow as the last section —
+        // the gauges stay anchored at the floor with the nav list scrolling above.
+        .safeAreaInset(edge: .bottom, spacing: 0) {
             if featureCatalog.isEnabled(.systemMonitor) {
-                Section {
+                VStack(spacing: 0) {
+                    Divider()
                     SystemMonitorView(
                         activeDisplayCount: activeWallpaperDisplayCount,
                         totalDisplayCount: screenManager.screens.count
                     )
-                        .padding(.vertical, 2)
-                        .listRowInsets(EdgeInsets(top: 2, leading: 4, bottom: 2, trailing: 4))
-                        .listRowBackground(Color.clear)
-                } header: {
-                    SidebarSectionHeader(title: "Usage")
+                    .padding(.horizontal, 10)
+                    .padding(.top, 8)
+                    .padding(.bottom, 10)
                 }
+                // Transparent — the sidebar's own material shows through; no
+                // extra layer over the gauges.
             }
         }
-        .listStyle(.sidebar)
         .navigationSplitViewColumnWidth(
             min: SettingsWindowMetrics.sidebarColumnWidth,
             ideal: SettingsWindowMetrics.sidebarColumnWidth,

--- a/LiveWallpaper/Views/GeneralSettingsView.swift
+++ b/LiveWallpaper/Views/GeneralSettingsView.swift
@@ -356,16 +356,28 @@ struct GeneralSettingsView: View {
                         .accessibilityHint(Text("Automatically launch LiveWallpaper when you log in"))
                 }
 
-                SettingRow(icon: "lock.display", iconColor: .blue, title: "Refresh desktop picture on lock", subtitle: "When your Mac locks, capture the current frame for screens with Desktop Picture enabled") {
+                SettingRow(
+                    icon: "lock.display",
+                    iconColor: .blue,
+                    title: "Preserve wallpaper on the lock screen",
+                    subtitle: "Show your wallpaper's last frame when locked, instead of the default picture",
+                    info: "On lock, the current wallpaper frame is captured as the macOS desktop picture so the lock screen keeps your wallpaper's look. Only affects displays that already have a Desktop Picture set."
+                ) {
                     Toggle("", isOn: $preservePlaybackOnLock)
                         .labelsHidden()
                         .toggleStyle(.switch)
                         .onChange(of: preservePlaybackOnLock) { _, _ in updateGlobalSettings() }
-                        .accessibilityLabel(Text("Refresh desktop picture on lock"))
-                        .accessibilityHint(Text("When your Mac locks, capture the current frame for screens with Desktop Picture enabled"))
+                        .accessibilityLabel(Text("Preserve wallpaper on the lock screen"))
+                        .accessibilityHint(Text("Shows your wallpaper's last frame on the lock screen instead of the default picture"))
                 }
 
-                SettingRow(icon: "dock.rectangle", iconColor: .indigo, title: "Show in Dock", subtitle: "Make the app visible in the Dock and Cmd-Tab switcher") {
+                SettingRow(
+                    icon: "dock.rectangle",
+                    iconColor: .indigo,
+                    title: "Show in Dock",
+                    subtitle: "Make the app visible in the Dock and Cmd-Tab switcher",
+                    info: "When off, the app keeps running in the background — reopen this window anytime from the menu bar icon at the top-right of your screen."
+                ) {
                     Toggle("", isOn: $showInDock)
                         .labelsHidden()
                         .toggleStyle(.switch)
@@ -501,7 +513,13 @@ struct GeneralSettingsView: View {
                     .accessibilityHint(Text("Automatically pause wallpapers when a full-screen app is active"))
             }
 
-            SettingRow(icon: "rectangle.on.rectangle", iconColor: .purple, title: "Pause when windows cover the desktop", subtitle: "Also pause when other apps' windows blanket at least 85 percent of a display, even if none is full-screen") {
+            SettingRow(
+                icon: "rectangle.on.rectangle",
+                iconColor: .purple,
+                title: "Pause when windows cover the desktop",
+                subtitle: "Pause when app windows cover most of the screen, even without full-screen",
+                info: "When open windows cover about 85% or more of a display, the wallpaper pauses to free CPU and GPU. It resumes as soon as you reveal the desktop."
+            ) {
                 Toggle("", isOn: $pauseOnWindowOcclusion)
                     .labelsHidden()
                     .toggleStyle(.switch)
@@ -551,8 +569,8 @@ struct GeneralSettingsView: View {
                 icon: "memorychip",
                 iconColor: .pink,
                 title: "Video memory cache",
-                subtitle: "Per-screen RAM budget",
-                info: "Higher = fewer disk reads, more RAM. Lower = less RAM, video re-reads disk on every loop."
+                subtitle: "Preload video loops into memory to reduce disk reads",
+                info: "Caching keeps each looping video in RAM so it doesn't re-read your disk every cycle — saving SSD wear and power. Drag to Off to stream straight from disk and use the least memory. The value below is the budget per screen (and the total across all displays)."
             ) {
                 // Slider sits in the SettingRow's trailing slot so the
                 // header, the affordance, and the current value all read as
@@ -623,11 +641,15 @@ struct GeneralSettingsView: View {
     @ViewBuilder
     private var weatherSection: some View {
         Section {
-            VStack(spacing: 8) {
-                // Centered fixed-size pill matches macOS System Settings'
-                // top-of-section segmented controls (e.g. Display arrangement
-                // mode), reading as a "choose your input" hero rather than a
-                // dense form row.
+            // Standard SettingRow (icon + title + subtitle + trailing control)
+            // so the weather source reads like every other setting instead of
+            // an anonymous segmented pill that breaks the form's visual rhythm.
+            SettingRow(
+                icon: "cloud.sun",
+                iconColor: .cyan,
+                title: "Weather Location",
+                subtitle: "Where weather-reactive effects read conditions"
+            ) {
                 Picker("Source", selection: weatherSourceBinding) {
                     Text("Off").tag(WeatherLocationPreference.Source.off)
                     Text("System").tag(WeatherLocationPreference.Source.coreLocation)
@@ -637,23 +659,22 @@ struct GeneralSettingsView: View {
                 .labelsHidden()
                 .fixedSize()
                 .accessibilityLabel(Text("Weather location source"))
-
-                if weatherLocation.source == .manual {
-                    ManualLocationPicker(
-                        currentSelection: weatherLocation.manual,
-                        onCommit: { manual in
-                            weatherLocation.manual = manual
-                            persistWeatherLocation()
-                        }
-                    )
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
             }
-            .frame(maxWidth: .infinity)
+
+            if weatherLocation.source == .manual {
+                ManualLocationPicker(
+                    currentSelection: weatherLocation.manual,
+                    onCommit: { manual in
+                        weatherLocation.manual = manual
+                        persistWeatherLocation()
+                    }
+                )
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         } header: {
             Text("Weather")
         } footer: {
-            Text("Used by weather-reactive effects like rain, snow, and fog.")
+            Text("System uses Location Services; Manual lets you pick a city. Powers rain, snow, and fog effects.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/LiveWallpaper/Views/ScreenDetail/EmptyStateGuideView.swift
+++ b/LiveWallpaper/Views/ScreenDetail/EmptyStateGuideView.swift
@@ -116,14 +116,27 @@ struct EmptyStateGuideView: View {
     private var hint: some View {
         HStack(spacing: 8) {
             Image(systemName: "arrow.down.doc")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.tertiary)
+                .font(.system(size: 13, weight: .medium))
                 .accessibilityHidden(true)
             Text("Or drag a video, HTML file, or folder here.")
                 .font(DesignTokens.Typography.caption)
-                .foregroundStyle(.tertiary)
         }
-        .padding(.top, 2)
+        .foregroundStyle(Color.accentColor)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 16)
+        .padding(.horizontal, 24)
+        .background(
+            RoundedRectangle(cornerRadius: DesignTokens.Corner.lg, style: .continuous)
+                .fill(Color.accentColor.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DesignTokens.Corner.lg, style: .continuous)
+                .strokeBorder(
+                    Color.accentColor.opacity(0.4),
+                    style: StrokeStyle(lineWidth: 1.5, dash: [6, 4])
+                )
+        )
+        .padding(.top, 6)
     }
 }
 
@@ -147,7 +160,7 @@ private struct GuideCard: View {
         Button(action: action) {
             VStack(alignment: .leading, spacing: 10) {
                 ZStack {
-                    Circle()
+                    RoundedRectangle(cornerRadius: DesignTokens.Corner.md, style: .continuous)
                         .fill(iconTint.opacity(0.15))
                         .frame(width: 40, height: 40)
                     Image(systemName: icon)
@@ -185,7 +198,7 @@ private struct GuideCard: View {
             .contentShape(RoundedRectangle(cornerRadius: DesignTokens.Corner.lg, style: .continuous))
             .background(
                 RoundedRectangle(cornerRadius: DesignTokens.Corner.lg, style: .continuous)
-                    .fill(.regularMaterial)
+                    .fill(DesignTokens.Colors.surfaceRaised)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: DesignTokens.Corner.lg, style: .continuous)

--- a/LiveWallpaper/Views/ScreenDetail/ScreenDetailHeader.swift
+++ b/LiveWallpaper/Views/ScreenDetail/ScreenDetailHeader.swift
@@ -62,20 +62,25 @@ struct ScreenDetailHeader: View {
                 HStack(spacing: 8) {
                     applyToAllButton
 
-                    Button {
-                        showBookmarks = true
-                    } label: {
-                        Image(systemName: isCurrentBookmarked ? "bookmark.fill" : "bookmark")
-                    }
-                    .adaptiveGlassButton(isCurrentBookmarked ? .prominent : .regular)
-                    .controlSize(.regular)
-                    .help(Text(isCurrentBookmarked
-                        ? "Bookmarked — click to rename or remove"
-                        : "Bookmark this wallpaper"))
-                    .accessibilityLabel(Text(isCurrentBookmarked ? "Bookmarked" : "Bookmark"))
-                    .popover(isPresented: $showBookmarks, arrowEdge: .bottom) {
-                        BookmarksPopover(screen: screen, candidateContent: inspectorContent)
-                            .environment(screenManager)
+                    // Bookmark is an "add the current project" action, so only
+                    // offer it when this type actually has bookmarkable content —
+                    // no empty bookmark icon on a display with nothing configured.
+                    if inspectorContent != nil {
+                        Button {
+                            showBookmarks = true
+                        } label: {
+                            Image(systemName: isCurrentBookmarked ? "bookmark.fill" : "bookmark")
+                        }
+                        .adaptiveGlassButton(isCurrentBookmarked ? .prominent : .regular)
+                        .controlSize(.regular)
+                        .help(Text(isCurrentBookmarked
+                            ? "Bookmarked — click to rename or remove"
+                            : "Bookmark this wallpaper"))
+                        .accessibilityLabel(Text(isCurrentBookmarked ? "Bookmarked" : "Bookmark"))
+                        .popover(isPresented: $showBookmarks, arrowEdge: .bottom) {
+                            BookmarksPopover(screen: screen, candidateContent: inspectorContent)
+                                .environment(screenManager)
+                        }
                     }
 
                     if showsHeaderWallpaperActions {

--- a/LiveWallpaper/Views/ScreenDetail/ScreenDetailHeader.swift
+++ b/LiveWallpaper/Views/ScreenDetail/ScreenDetailHeader.swift
@@ -180,8 +180,8 @@ struct ScreenDetailHeader: View {
         let config = screenManager.getConfiguration(for: screen)
         switch draft.selectedWallpaperType {
         case .video:
-            if case .video(let bookmark)? = config?.activeWallpaper {
-                return .video(bookmarkData: bookmark)
+            if case .video(let bookmark, let packageEntryName)? = config?.activeWallpaper {
+                return .video(bookmarkData: bookmark, packageEntryName: packageEntryName)
             }
             if let saved = config?.savedVideoBookmarkData {
                 return .video(bookmarkData: saved)

--- a/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
+++ b/LiveWallpaper/Views/ScreenDetail/WPESceneSection.swift
@@ -7,7 +7,13 @@ import SwiftUI
 struct WPESceneSection: View {
     let screen: Screen
     @Environment(ScreenManager.self) private var screenManager
+    @Environment(\.featureCatalog) private var featureCatalog
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// The per-display grid is a quick-apply surface, not the full library —
+    /// the Workshop tab owns search / filter / management. Cap the inline grid
+    /// so a large library never turns this into an unsearchable long scroll.
+    private let recentGridCap = 18
 
     @State private var recentImports: [WPEHistoryEntry] = []
     @State private var selectedHistoryEntry: WPEHistoryEntry?
@@ -75,10 +81,15 @@ struct WPESceneSection: View {
                 .controlSize(.large)
                 .accessibilityHint(Text("Opens a folder chooser to apply a copied local project"))
 
-                Text("Browse and manage your whole library in the Steam Workshop tab.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
+                #if DIRECT_DISTRIBUTION
+                if featureCatalog.isEnabled(.wpeImport) {
+                    browseWorkshopButton("Browse all in Workshop")
+                } else {
+                    workshopHintText
+                }
+                #else
+                workshopHintText
+                #endif
             }
             .padding(.top, 4)
 
@@ -93,10 +104,15 @@ struct WPESceneSection: View {
     private var historyList: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                HStack(alignment: .firstTextBaseline, spacing: 12) {
                     Text("Recent Imported Projects")
-                        .font(.headline)
+                        .font(DesignTokens.Typography.sectionTitle)
                     Spacer()
+                    #if DIRECT_DISTRIBUTION
+                    if featureCatalog.isEnabled(.wpeImport) {
+                        browseWorkshopButton("Browse all in Workshop")
+                    }
+                    #endif
                     Button {
                         presentFolderPicker()
                     } label: {
@@ -111,7 +127,7 @@ struct WPESceneSection: View {
                     alignment: .leading,
                     spacing: 16
                 ) {
-                    ForEach(recentImports) { entry in
+                    ForEach(recentImports.prefix(recentGridCap)) { entry in
                         WPEHistoryRow(
                             entry: entry,
                             isActive: activeWorkshopID == entry.id,
@@ -187,6 +203,37 @@ struct WPESceneSection: View {
             EmptyView()
         }
     }
+
+    /// Informational fallback for builds without the in-app Workshop tab
+    /// (non-direct-distribution), where there is nothing to jump to.
+    private var workshopHintText: some View {
+        Text("Browse and manage your whole library in the Steam Workshop tab.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+    }
+
+    #if DIRECT_DISTRIBUTION
+    /// Accent link that jumps to the Workshop tab — the single surface that
+    /// owns search / filter / management of the full library. The per-display
+    /// grid stays a lightweight quick-apply list.
+    @ViewBuilder
+    private func browseWorkshopButton(_ title: LocalizedStringKey) -> some View {
+        Button {
+            NotificationCenter.default.post(name: .openWorkshopPane, object: nil)
+        } label: {
+            HStack(spacing: 4) {
+                Text(title)
+                Image(systemName: "arrow.right")
+                    .imageScale(.small)
+            }
+            .font(DesignTokens.Typography.body)
+            .foregroundStyle(Color.accentColor)
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint(Text("Opens the Steam Workshop tab to browse and manage your full library"))
+    }
+    #endif
 
     // MARK: - Actions
 

--- a/LiveWallpaper/Views/Settings/ShortcutsSettingsView.swift
+++ b/LiveWallpaper/Views/Settings/ShortcutsSettingsView.swift
@@ -67,9 +67,18 @@ struct ShortcutsSettingsView: View {
     /// footer rather than repeating itself as a subtitle inside the row.
     private var masterEnableSection: some View {
         Section {
-            Toggle("Enable Global Shortcuts", isOn: masterEnableBinding)
-                .toggleStyle(.switch)
-                .accessibilityHint(Text("Master switch for every global shortcut. Bindings are preserved while off."))
+            SettingRow(
+                icon: "command",
+                iconColor: .blue,
+                title: "Enable Global Shortcuts",
+                subtitle: "Master switch — your bindings are kept while it's off"
+            ) {
+                Toggle("", isOn: masterEnableBinding)
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .accessibilityLabel(Text("Enable Global Shortcuts"))
+                    .accessibilityHint(Text("Master switch for every global shortcut. Bindings are preserved while off."))
+            }
         }
     }
 

--- a/LiveWallpaper/Views/Settings/WorkshopSettingsView.swift
+++ b/LiveWallpaper/Views/Settings/WorkshopSettingsView.swift
@@ -51,29 +51,62 @@ struct WorkshopSettingsView: View {
             }
 
             Section("Onboarding") {
-                Toggle("Show the welcome sheet next time", isOn: Binding(
-                    get: { !onboardingShown },
-                    set: { onboardingShown = !$0 }
-                ))
-                .toggleStyle(.switch)
+                SettingRow(
+                    icon: "hand.wave",
+                    iconColor: .blue,
+                    title: "Show the welcome sheet next time",
+                    subtitle: "Reopen the Workshop intro the next time you open it"
+                ) {
+                    Toggle("", isOn: Binding(
+                        get: { !onboardingShown },
+                        set: { onboardingShown = !$0 }
+                    ))
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .accessibilityLabel(Text("Show the welcome sheet next time"))
+                }
             }
 
             Section {
-                Toggle("Blur mature thumbnails until clicked", isOn: $blurMatureThumbnails)
-                    .toggleStyle(.switch)
-                Toggle("Hide items already in my library when browsing", isOn: $hidesDownloadedInBrowse)
-                    .toggleStyle(.switch)
+                SettingRow(
+                    icon: "eye.slash",
+                    iconColor: .pink,
+                    title: "Blur mature thumbnails",
+                    subtitle: "Hide Mature covers in Browse until you click to reveal"
+                ) {
+                    Toggle("", isOn: $blurMatureThumbnails)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel(Text("Blur mature thumbnails until clicked"))
+                }
+                SettingRow(
+                    icon: "tray.full",
+                    iconColor: .indigo,
+                    title: "Hide items already in my library",
+                    subtitle: "Keep Browse Online focused on wallpapers you don't have yet"
+                ) {
+                    Toggle("", isOn: $hidesDownloadedInBrowse)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .accessibilityLabel(Text("Hide items already in my library when browsing"))
+                }
             } header: {
                 Text("Content")
             } footer: {
-                Text("Wallpapers tagged Mature show a blurred cover in the browse grid and details until you click to reveal them. Application wallpapers are always hidden because they can't run here. Hiding already-downloaded items keeps Browse Online focused on things you don't have yet — the Installed tab is where you revisit your library.")
+                Text("Application wallpapers are always hidden because they can't run here. The Installed tab is where you revisit your full library.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             Section {
-                LabeledContent {
+                SettingRow(
+                    icon: "stethoscope",
+                    iconColor: .teal,
+                    title: "SteamCMD Doctor",
+                    subtitle: "Check SteamCMD and Steam sign-in before downloading",
+                    info: "Downloading from the Workshop needs the official SteamCMD command-line tool plus your own Steam sign-in. The Doctor runs probes and tells you exactly what's missing."
+                ) {
                     HStack(spacing: DesignTokens.Spacing.xs) {
                         doctorIndicator
                         Button("Open") { showingDoctor = true }
@@ -81,23 +114,25 @@ struct WorkshopSettingsView: View {
                             .controlSize(.small)
                             .help("Open the SteamCMD diagnostics sheet")
                     }
-                } label: {
-                    Label("SteamCMD Doctor", systemImage: "stethoscope")
+                    // Claim intrinsic width: SettingRow's title column is greedy
+                    // (maxWidth:.infinity, layoutPriority 1) and would otherwise
+                    // starve these controls, wrapping/clipping their labels.
+                    .fixedSize()
                 }
             } header: {
                 Text("Downloads")
-            } footer: {
-                Text("Verify your SteamCMD install + Steam sign-in before enabling Workshop downloads.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Section {
-                LabeledContent {
+                SettingRow(
+                    icon: "key",
+                    iconColor: .orange,
+                    title: "Steam Web API key",
+                    subtitle: "Your own free key — required to browse the Workshop online",
+                    info: "The key belongs to your own Steam account, not Loomscreen. Calls go directly to Valve over HTTPS, and the key is stored only in this Mac's Keychain (no iCloud sync). Get one free at steamcommunity.com/dev/apikey."
+                ) {
                     keyStatusBadge
-                } label: {
-                    Label("Steam Web API key", systemImage: "key")
+                        .fixedSize()
                 }
 
                 HStack(spacing: DesignTokens.Spacing.xs) {
@@ -130,35 +165,39 @@ struct WorkshopSettingsView: View {
             } header: {
                 Text("Browse Online")
             } footer: {
-                Text("The key belongs to your own Steam account, not Loomscreen. Calls go directly to Valve over HTTPS; the key is stored in this Mac's Keychain (no iCloud sync). \"Forget on this Mac\" only removes the local copy — revoke the key itself at steamcommunity.com/dev/apikey.")
+                Text("\"Forget on this Mac\" only removes the local copy — revoke the key itself at steamcommunity.com/dev/apikey.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             Section {
-                LabeledContent {
+                SettingRow(
+                    icon: "internaldrive",
+                    iconColor: .gray,
+                    title: "Workshop browse cache",
+                    subtitle: "Cached browse results (5-min refresh, 100 MB cap)",
+                    info: "Holds the JSON responses behind Browse Online so paging stays fast. Scene assets are read in place from their source — they're no longer copied into a cache."
+                ) {
                     Button("Manage") { showingCacheManagement = true }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                        .fixedSize()
                         .help("Inspect and clear the Workshop browse cache")
-                } label: {
-                    Label("Workshop browse cache", systemImage: "internaldrive")
                 }
             } header: {
                 Text("Cache")
-            } footer: {
-                Text("The browse cache holds QueryFiles JSON responses (5-minute TTL, 100 MB hard cap). Scene assets are read in place from their source — they're no longer copied into a cache.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Section {
-                LabeledContent {
+                SettingRow(
+                    icon: "shippingbox",
+                    iconColor: .brown,
+                    title: "Wallpaper Engine assets",
+                    subtitle: "Optional — link a WPE install for extra scene coverage",
+                    info: "Loomscreen bundles clean-room equivalents of the common Wallpaper Engine framework files, so most scenes render without a Wallpaper Engine install. Link one only for scenes that reference uncommon shared assets — read-only access, no files are modified."
+                ) {
                     engineAssetsControl
-                } label: {
-                    Label("Wallpaper Engine assets", systemImage: "shippingbox")
                 }
                 if let error = engineAssets.lastError {
                     Text(error)
@@ -168,17 +207,13 @@ struct WorkshopSettingsView: View {
                 }
             } header: {
                 Text("Scene rendering")
-            } footer: {
-                Text("Optional. Loomscreen bundles clean-room equivalents of the common Wallpaper Engine framework files, so most scenes render without a Wallpaper Engine install. Link one only for extra coverage of scenes that reference uncommon shared assets — read-only access, no files are modified.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .formStyle(.grouped)
-        .padding(.horizontal, DesignTokens.Settings.formHorizontalMargin)
-        .padding(.vertical, DesignTokens.Settings.formVerticalMargin)
-        .background(DesignTokens.Colors.pageBackground)
+        // Use the shared settings chrome (every other tab does) — it hides the
+        // grouped Form's default system background via .scrollContentBackground
+        // and insets via .contentMargins, so this tab no longer shows a
+        // different-colored inset panel.
+        .settingsFormChrome()
         .sheet(isPresented: $showingDoctor) {
             WorkshopDoctorView()
                 .environment(doctorService)
@@ -212,15 +247,18 @@ struct WorkshopSettingsView: View {
                 Button("Change") { Task { _ = await engineAssets.requestAccess() } }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
+                    .fixedSize()
                     .help("Pick a different Wallpaper Engine install folder")
                 Button("Forget", role: .destructive) { engineAssets.clearAccess() }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
+                    .fixedSize()
                     .help("Remove access to the Wallpaper Engine install folder")
             } else {
                 Button("Link folder…") { Task { _ = await engineAssets.requestAccess() } }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
+                    .fixedSize()
                     .help("Grant read-only access to a Wallpaper Engine install for extra scene coverage")
             }
         }

--- a/LiveWallpaperTests/HTMLSchemeIsolationTests.swift
+++ b/LiveWallpaperTests/HTMLSchemeIsolationTests.swift
@@ -182,6 +182,33 @@ struct FolderURLSchemeHandlerIsolationTests {
         #expect(http?.value(forHTTPHeaderField: "Content-Range") == "bytes 10-19/200")
     }
 
+    @Test("Loose files win over same-named package entries (no plain-folder regression)")
+    func packageBackendPrefersLooseFileOverPackageEntry() async throws {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        // Both a loose index.html and a package index.html exist; the loose one
+        // must win so an ordinary HTML folder next to a scene.pkg is unaffected.
+        let looseBytes = Data("<html>loose-wins</html>".utf8)
+        try looseBytes.write(to: folder.appendingPathComponent("index.html"))
+        let pkgURL = folder.appendingPathComponent("scene.pkg")
+        try Self.makePackageData(entries: [
+            ("index.html", Data("<html>packaged</html>".utf8))
+        ]).write(to: pkgURL)
+
+        handler.folderURL = folder
+        handler.setPackageBacking(try Self.packageBacking(at: pkgURL))
+
+        let url = URL(string: "livewallpaper://wallpaper/index.html?n=\(handler.currentSessionNonce ?? "")")!
+        let task = FakeURLSchemeTask(request: URLRequest(url: url))
+        handler.webView(WKWebView(), start: task)
+        try await waitUntil(timeout: .seconds(2)) { task.didFinishCalled || task.failedError != nil }
+
+        #expect(task.failedError == nil)
+        #expect(task.receivedData.reduce(Data(), +) == looseBytes)
+    }
+
     @Test("Package backend falls back to a loose sibling for non-package files")
     func packageBackendFallsBackToLooseFile() async throws {
         let handler = FolderURLSchemeHandler()

--- a/LiveWallpaperTests/HTMLSchemeIsolationTests.swift
+++ b/LiveWallpaperTests/HTMLSchemeIsolationTests.swift
@@ -121,7 +121,134 @@ struct FolderURLSchemeHandlerIsolationTests {
         #expect(task.didFinishCalled)
     }
 
+    @Test("Package backend serves a scene.pkg entry's exact bytes")
+    func packageBackendServesEntryBytes() async throws {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let jsBytes = Data("console.log('pkg-entry')".utf8)
+        let pkgURL = folder.appendingPathComponent("scene.pkg")
+        try Self.makePackageData(entries: [
+            ("index.html", Data("<html>pkg</html>".utf8)),
+            ("app.js", jsBytes)
+        ]).write(to: pkgURL)
+
+        let backing = try Self.packageBacking(at: pkgURL)
+        handler.folderURL = folder
+        handler.setPackageBacking(backing)
+
+        var request = URLRequest(url: URL(string: "livewallpaper://wallpaper/app.js")!)
+        request.mainDocumentURL = URL(string: "livewallpaper://wallpaper/index.html?n=\(handler.currentSessionNonce ?? "")")
+        let task = FakeURLSchemeTask(request: request)
+        handler.webView(WKWebView(), start: task)
+        try await waitUntil(timeout: .seconds(2)) { task.didFinishCalled || task.failedError != nil }
+
+        #expect(task.failedError == nil)
+        #expect(task.didFinishCalled)
+        #expect(task.receivedData.reduce(Data(), +) == jsBytes)
+        let http = task.receivedResponse as? HTTPURLResponse
+        #expect(http?.value(forHTTPHeaderField: "Content-Type")?.contains("javascript") == true)
+        #expect(http?.value(forHTTPHeaderField: "Content-Length") == "\(jsBytes.count)")
+    }
+
+    @Test("Package backend honours a Range request against an entry slice")
+    func packageBackendHonoursRange() async throws {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let full = Data((0..<200).map { UInt8($0 & 0xff) })
+        let pkgURL = folder.appendingPathComponent("scene.pkg")
+        try Self.makePackageData(entries: [
+            ("index.html", Data("<html></html>".utf8)),
+            ("clip.bin", full)
+        ]).write(to: pkgURL)
+
+        handler.folderURL = folder
+        handler.setPackageBacking(try Self.packageBacking(at: pkgURL))
+
+        var request = URLRequest(url: URL(string: "livewallpaper://wallpaper/clip.bin")!)
+        request.mainDocumentURL = URL(string: "livewallpaper://wallpaper/index.html?n=\(handler.currentSessionNonce ?? "")")
+        request.setValue("bytes=10-19", forHTTPHeaderField: "Range")
+        let task = FakeURLSchemeTask(request: request)
+        handler.webView(WKWebView(), start: task)
+        try await waitUntil(timeout: .seconds(2)) { task.didFinishCalled || task.failedError != nil }
+
+        #expect(task.failedError == nil)
+        #expect(task.receivedData.reduce(Data(), +) == full[10...19])
+        let http = task.receivedResponse as? HTTPURLResponse
+        #expect(http?.statusCode == 206)
+        #expect(http?.value(forHTTPHeaderField: "Content-Range") == "bytes 10-19/200")
+    }
+
+    @Test("Package backend falls back to a loose sibling for non-package files")
+    func packageBackendFallsBackToLooseFile() async throws {
+        let handler = FolderURLSchemeHandler()
+        let folder = makeTemporaryFolder()
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let pkgURL = folder.appendingPathComponent("scene.pkg")
+        try Self.makePackageData(entries: [
+            ("index.html", Data("<html></html>".utf8))
+        ]).write(to: pkgURL)
+        // project.json is loose on disk, NOT inside the package.
+        let looseBytes = Data("{\"loose\":true}".utf8)
+        try looseBytes.write(to: folder.appendingPathComponent("project.json"))
+
+        handler.folderURL = folder
+        handler.setPackageBacking(try Self.packageBacking(at: pkgURL))
+
+        var request = URLRequest(url: URL(string: "livewallpaper://wallpaper/project.json")!)
+        request.mainDocumentURL = URL(string: "livewallpaper://wallpaper/index.html?n=\(handler.currentSessionNonce ?? "")")
+        let task = FakeURLSchemeTask(request: request)
+        handler.webView(WKWebView(), start: task)
+        try await waitUntil(timeout: .seconds(2)) { task.didFinishCalled || task.failedError != nil }
+
+        #expect(task.failedError == nil)
+        #expect(task.receivedData.reduce(Data(), +) == looseBytes)
+    }
+
     // MARK: - helpers
+
+    private static func packageBacking(at pkgURL: URL) throws -> FolderURLSchemeHandler.PackageBacking {
+        let handle = try FileHandle(forReadingFrom: pkgURL)
+        defer { try? handle.close() }
+        let package = try WallpaperEnginePackage.parseIndex(streamingFrom: handle)
+        return FolderURLSchemeHandler.PackageBacking(url: pkgURL, package: package)
+    }
+
+    /// Builds a minimal `scene.pkg` blob (`PKGV0022` header) in the same layout
+    /// the real parser reads: `[magicLen|magic][count]({nameLen|name|off|size})*[payload]`.
+    static func makePackageData(entries: [(name: String, bytes: Data)]) -> Data {
+        var payload = Data()
+        var resolved: [(name: String, offset: UInt32, size: UInt32)] = []
+        for entry in entries {
+            resolved.append((entry.name, UInt32(payload.count), UInt32(entry.bytes.count)))
+            payload.append(entry.bytes)
+        }
+
+        var data = Data()
+        func appendU32(_ value: UInt32) {
+            data.append(UInt8(value & 0xff))
+            data.append(UInt8((value >> 8) & 0xff))
+            data.append(UInt8((value >> 16) & 0xff))
+            data.append(UInt8((value >> 24) & 0xff))
+        }
+        let magic = Array("PKGV0022".utf8)
+        appendU32(UInt32(magic.count))
+        data.append(contentsOf: magic)
+        appendU32(UInt32(resolved.count))
+        for entry in resolved {
+            let nameBytes = Array(entry.name.utf8)
+            appendU32(UInt32(nameBytes.count))
+            data.append(contentsOf: nameBytes)
+            appendU32(entry.offset)
+            appendU32(entry.size)
+        }
+        data.append(payload)
+        return data
+    }
 
     private func makeTemporaryFolder() -> URL {
         let url = FileManager.default.temporaryDirectory

--- a/LiveWallpaperTests/ProtocolizedDependenciesTests.swift
+++ b/LiveWallpaperTests/ProtocolizedDependenciesTests.swift
@@ -189,7 +189,7 @@ struct ProtocolizedDependenciesTests {
     }
 
     private static func activeVideoBookmark(_ configuration: ScreenConfiguration?) -> Data? {
-        guard case .video(let bookmark) = configuration?.activeWallpaper else { return nil }
+        guard case .video(let bookmark, _) = configuration?.activeWallpaper else { return nil }
         return bookmark
     }
 

--- a/LiveWallpaperTests/SceneDescriptorCodableTests.swift
+++ b/LiveWallpaperTests/SceneDescriptorCodableTests.swift
@@ -172,7 +172,7 @@ struct SceneDescriptorCodableTests {
 
         let decoded = try JSONDecoder().decode(ScreenConfiguration.self, from: data)
 
-        guard case .video(let bookmarkData) = decoded.activeWallpaper else {
+        guard case .video(let bookmarkData, _) = decoded.activeWallpaper else {
             Issue.record("Expected unsafe legacy scene backfill to fall back to empty video")
             return
         }

--- a/LiveWallpaperTests/WPEDependencyMountResolverTests.swift
+++ b/LiveWallpaperTests/WPEDependencyMountResolverTests.swift
@@ -54,6 +54,41 @@ struct WPEDependencyMountResolverTests {
         #expect(mounts.first?.rootURL == dependency.standardizedFileURL.resolvingSymlinksInPath())
     }
 
+    @Test("Packaged source sibling dependency is mounted in place as a package")
+    func packagedSourceSiblingDependencyIsMountedAsPackage() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+        let workshopRoot = fixture.root.appendingPathComponent("workshop", isDirectory: true)
+        let source = workshopRoot.appendingPathComponent("main", isDirectory: true)
+        let dependency = workshopRoot.appendingPathComponent("456", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dependency, withIntermediateDirectories: true)
+        // Packaged dependency: assets live inside scene.pkg (project.json loose).
+        try Data("{}".utf8).write(to: dependency.appendingPathComponent("project.json"))
+        let pkgURL = dependency.appendingPathComponent("scene.pkg")
+        try Data("PKGV0022".utf8).write(to: pkgURL)
+        let origin = WPEOrigin(
+            workshopID: "main",
+            title: "Main",
+            originalType: .scene,
+            sourceFolderBookmark: try bookmark(for: source),
+            cacheRelativePath: "wpe-cache/main",
+            previewFileName: nil,
+            entryFile: "scene.json",
+            resourceLocation: .cache
+        )
+
+        let mounts = WPEDependencyMountResolver().mounts(
+            dependencyWorkshopIDs: ["456"],
+            origin: origin,
+            applicationSupportRootURL: fixture.appSupportRoot
+        )
+
+        #expect(mounts.map(\.workshopID) == ["456"])
+        #expect(mounts.first?.rootURL == nil)
+        #expect(mounts.first?.backing == .package(pkgURL.standardizedFileURL.resolvingSymlinksInPath()))
+    }
+
     @Test("Undeclared sibling folders are not mounted")
     func undeclaredSiblingFoldersAreNotMounted() throws {
         let fixture = try makeFixture()

--- a/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
+++ b/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
@@ -129,6 +129,14 @@ struct WallpaperEngineImportServiceTests {
         let decoded = try JSONDecoder().decode(ScreenConfiguration.self, from: JSONEncoder().encode(config))
         #expect(decoded.savedVideoPackageEntryName == "video.mp4")
         #expect(decoded.activeWallpaper.packageVideoEntryName == "video.mp4")
+
+        // The WPE-import new-config path builds the config from a packaged-video
+        // wallpaper; the saved entry must be derived (not just the active one).
+        let fromWallpaper = ScreenConfiguration(
+            screenID: 2,
+            wallpaper: .video(bookmarkData: Data([0x05]), packageEntryName: "clip.mp4")
+        )
+        #expect(fromWallpaper.savedVideoPackageEntryName == "clip.mp4")
     }
 
     @Test("Unsupported scene returns unsupported result")

--- a/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
+++ b/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
@@ -55,6 +55,40 @@ struct WallpaperEngineImportServiceTests {
         #expect(origin.entryFile == "index.html")
     }
 
+    @Test("Packaged web imports in place from scene.pkg without extracting to wpe-cache")
+    func packagedWebImportsInPlaceWithoutExtraction() async throws {
+        // index.html lives only inside scene.pkg (project.json stays loose).
+        let fixture = try makeFixture(type: .web, entryFile: "index.html", pkgEntries: [
+            PackageEntrySpec("index.html", Array("<html><body>hi</body></html>".utf8)),
+            PackageEntrySpec("app.js", Array("console.log(1)".utf8))
+        ])
+        defer { fixture.cleanup() }
+
+        let result = try await fixture.service.importProject(folder: fixture.folderURL)
+
+        guard case .ready(let content, let origin) = result else {
+            Issue.record("Expected .ready, got \(result)")
+            return
+        }
+        guard case .html(let source, let config) = content else {
+            Issue.record("Expected .html content, got \(content)")
+            return
+        }
+        guard case .folder(_, let indexFileName) = source else {
+            Issue.record("Expected .folder source, got \(source)")
+            return
+        }
+        #expect(indexFileName == "index.html")
+        #expect(config.physicalPixelLayout)
+        // Package-aware: served in place from the source folder, no cache copy.
+        #expect(origin.cacheRelativePath == nil)
+        #expect(origin.resourceLocation == .sourceFolder)
+        #expect(origin.entryFile == "index.html")
+        // Nothing was extracted into wpe-cache for this id.
+        let extractedDir = fixture.cacheURL.appendingPathComponent(fixture.workshopID, isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: extractedDir.path))
+    }
+
     @Test("Unsupported scene returns unsupported result")
     func unsupportedSceneReturnsUnsupportedResult() async throws {
         let fixture = try makeFixture(type: .scene, entryFile: "scene.json", pkgEntries: nil)

--- a/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
+++ b/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
@@ -105,6 +105,32 @@ struct WallpaperEngineImportServiceTests {
         #expect(legacy.packageVideoEntryName == nil)
     }
 
+    @Test("Packaged-video config keeps its package entry across bookmark refresh and saved-restore")
+    func packagedVideoConfigPreservesPackageEntry() throws {
+        let pkgBookmark = Data([0x01, 0x02])
+        var config = ScreenConfiguration(screenID: 1, videoBookmarkData: pkgBookmark)
+        config.activeWallpaper = .video(bookmarkData: pkgBookmark, packageEntryName: "video.mp4")
+        config.savedVideoBookmarkData = pkgBookmark
+        config.savedVideoPackageEntryName = "video.mp4"
+
+        // A bookmark refresh keeps the entry on the active wallpaper (else the
+        // next apply would treat the scene.pkg as a plain video file).
+        let refreshed = config.withUpdatedActiveBookmark(Data([0x03, 0x04]))
+        #expect(refreshed.activeWallpaper.packageVideoEntryName == "video.mp4")
+
+        // Swap to HTML, then restore the saved primary video → entry survives.
+        var swapped = refreshed
+        swapped.activeWallpaper = .html(source: .inline("<html></html>"), config: .default)
+        let restored = swapped.activateSavedVideoWallpaper()
+        #expect(restored)
+        #expect(swapped.activeWallpaper.packageVideoEntryName == "video.mp4")
+
+        // Codable round trip preserves both the active and saved package entry.
+        let decoded = try JSONDecoder().decode(ScreenConfiguration.self, from: JSONEncoder().encode(config))
+        #expect(decoded.savedVideoPackageEntryName == "video.mp4")
+        #expect(decoded.activeWallpaper.packageVideoEntryName == "video.mp4")
+    }
+
     @Test("Unsupported scene returns unsupported result")
     func unsupportedSceneReturnsUnsupportedResult() async throws {
         let fixture = try makeFixture(type: .scene, entryFile: "scene.json", pkgEntries: nil)

--- a/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
+++ b/LiveWallpaperTests/WallpaperEngineImportServiceTests.swift
@@ -89,6 +89,22 @@ struct WallpaperEngineImportServiceTests {
         #expect(!FileManager.default.fileExists(atPath: extractedDir.path))
     }
 
+    @Test("WallpaperContent.video round-trips packageEntryName and decodes legacy payloads")
+    func videoContentPackageEntryRoundTrips() throws {
+        // New packaged-video payload survives a Codable round trip.
+        let packaged = WallpaperContent.video(bookmarkData: Data([0xAA, 0xBB]), packageEntryName: "video.mp4")
+        let encoded = try JSONEncoder().encode(packaged)
+        let decoded = try JSONDecoder().decode(WallpaperContent.self, from: encoded)
+        #expect(decoded == packaged)
+        #expect(decoded.packageVideoEntryName == "video.mp4")
+
+        // Legacy payload (no packageEntryName key) decodes as a loose video.
+        let legacyJSON = #"{"video":{"bookmarkData":"qrs="}}"#
+        let legacy = try JSONDecoder().decode(WallpaperContent.self, from: Data(legacyJSON.utf8))
+        #expect(legacy.activeVideoBookmarkData != nil)
+        #expect(legacy.packageVideoEntryName == nil)
+    }
+
     @Test("Unsupported scene returns unsupported result")
     func unsupportedSceneReturnsUnsupportedResult() async throws {
         let fixture = try makeFixture(type: .scene, entryFile: "scene.json", pkgEntries: nil)
@@ -117,64 +133,29 @@ struct WallpaperEngineImportServiceTests {
         #expect(origin.originalType == .application)
     }
 
-    @Test("Cache is idempotent")
-    func cacheIsIdempotent() async throws {
+    @Test("Packaged video imports in place from scene.pkg without extracting to wpe-cache")
+    func packagedVideoImportsInPlaceWithoutExtraction() async throws {
         let fixture = try makeFixture(type: .video, entryFile: "video.mp4", pkgEntries: [
-            PackageEntrySpec("video.mp4", [0x01])
-        ])
-        defer { fixture.cleanup() }
-
-        _ = try await fixture.service.importProject(folder: fixture.folderURL)
-        let markerURL = fixture.cacheURL
-            .appendingPathComponent(fixture.workshopID, isDirectory: true)
-            .appendingPathComponent("marker.txt")
-        try Data("marker".utf8).write(to: markerURL)
-
-        _ = try await fixture.service.importProject(folder: fixture.folderURL)
-
-        #expect(FileManager.default.fileExists(atPath: markerURL.path))
-    }
-
-    @Test("Cache invalidates on pkg change")
-    func cacheInvalidatesOnPkgChange() async throws {
-        let fixture = try makeFixture(type: .video, entryFile: "video.mp4", pkgEntries: [
-            PackageEntrySpec("video.mp4", [0x01])
-        ])
-        defer { fixture.cleanup() }
-
-        _ = try await fixture.service.importProject(folder: fixture.folderURL)
-        let extractedURL = fixture.cacheURL
-            .appendingPathComponent(fixture.workshopID, isDirectory: true)
-            .appendingPathComponent("video.mp4")
-        let markerURL = extractedURL.deletingLastPathComponent().appendingPathComponent("marker.txt")
-        try Data("marker".utf8).write(to: markerURL)
-
-        try await Task.sleep(nanoseconds: 1_500_000_000)
-        let changed = makePackage(entries: [PackageEntrySpec("video.mp4", [0x02, 0x03])])
-        try changed.write(to: fixture.folderURL.appendingPathComponent("scene.pkg"), options: .atomic)
-
-        _ = try await fixture.service.importProject(folder: fixture.folderURL)
-
-        #expect(try Data(contentsOf: extractedURL) == Data([0x02, 0x03]))
-        #expect(!FileManager.default.fileExists(atPath: markerURL.path))
-    }
-
-    @Test("Video import sets WPE origin cache path")
-    func videoImportSetsWPEOrigin() async throws {
-        let fixture = try makeFixture(type: .video, entryFile: "video.mp4", pkgEntries: [
-            PackageEntrySpec("video.mp4", [0x01])
+            PackageEntrySpec("video.mp4", [0x01, 0x02, 0x03])
         ])
         defer { fixture.cleanup() }
 
         let result = try await fixture.service.importProject(folder: fixture.folderURL)
 
-        guard case .ready(_, let origin) = result else {
+        guard case .ready(let content, let origin) = result else {
             Issue.record("Expected .ready, got \(result)")
             return
         }
-        #expect(origin.cacheRelativePath == "wpe-cache/\(fixture.workshopID)")
-        #expect(origin.resourceLocation == .cache)
+        // The video plays in place from the package — entry carried, no copy.
+        #expect(content.packageVideoEntryName == "video.mp4")
+        #expect(origin.cacheRelativePath == nil)
+        #expect(origin.resourceLocation == .sourceFolder)
         #expect(origin.entryFile == "video.mp4")
+        // Nothing extracted into wpe-cache for this id.
+        let extractedDir = fixture.cacheURL.appendingPathComponent(fixture.workshopID, isDirectory: true)
+        #expect(!FileManager.default.fileExists(atPath: extractedDir.path))
+        // Cache idempotency / fingerprint-invalidation stay covered directly by
+        // WallpaperEngineCacheTests (the extraction fallback still relies on them).
     }
 
     @Test("Scene import sets origin without cache path")
@@ -814,11 +795,13 @@ struct WallpaperEngineImportServiceTests {
 
         let content = resolver.content(for: origin)
 
-        guard case .video(let bookmarkData) = content else {
+        guard case .video(let bookmarkData, let packageEntryName) = content else {
             Issue.record("Expected cached video content, got \(String(describing: content))")
             return
         }
         #expect(bookmarkData == Data(videoURL.path.utf8))
+        // Extraction-fallback rebuild → loose file, not a package entry.
+        #expect(packageEntryName == nil)
     }
 
     private func makeFixture(

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Persistence/BookmarkStore.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Persistence/BookmarkStore.swift
@@ -166,7 +166,7 @@ public final class BookmarkStore {
 
     public static func defaultSourceDisplayName(for content: WallpaperContent) -> String? {
         switch content {
-        case .video(let bookmarkData):
+        case .video(let bookmarkData, _):
             return ResourceUtilities.resolveBookmarkName(bookmarkData)
         case .html(let source, _):
             return source.displayName

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Persistence/PlayableVideoLoader.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Persistence/PlayableVideoLoader.swift
@@ -27,7 +27,14 @@ public struct PlayableVideoLoader: PlayableVideoLoading, Sendable {
             }
         }
 
-        let asset = AVURLAsset(url: url)
+        try await validatePlayableVideo(asset: AVURLAsset(url: url))
+    }
+
+    /// Validates an already-constructed asset. Used for in-place packaged
+    /// videos, where the asset is a custom-scheme `AVURLAsset` backed by a
+    /// resource loader windowed into a `scene.pkg` (there is no plain file URL
+    /// to open). The caller owns the asset's resource-loader delegate lifetime.
+    public static func validatePlayableVideo(asset: AVURLAsset) async throws {
         let isPlayable = try await asset.load(.isPlayable)
 
         guard isPlayable else {
@@ -46,7 +53,12 @@ public struct PlayableVideoLoader: PlayableVideoLoading, Sendable {
             }
         }
 
-        let asset = AVURLAsset(url: url)
+        return try await detectFormat(asset: AVURLAsset(url: url))
+    }
+
+    /// Probes format info from an already-constructed asset (see
+    /// `validatePlayableVideo(asset:)` for why packaged videos need this).
+    public static func detectFormat(asset: AVURLAsset) async throws -> VideoFormatInfo {
         let videoTracks = try await asset.loadTracks(withMediaType: .video)
         guard let track = videoTracks.first else {
             return VideoFormatInfo()

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Runtime/WallpaperSessionDefinition.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Runtime/WallpaperSessionDefinition.swift
@@ -2,16 +2,24 @@ import Foundation
 
 /// Runtime-ready wallpaper definition derived from persisted configuration.
 public enum WallpaperSessionDefinition: Equatable, Sendable {
-    case video(bookmarkData: Data)
+    /// `packageEntryName` is non-nil for an in-place packaged video, where
+    /// `bookmarkData` resolves to a `scene.pkg` and the player serves the
+    /// entry windowed from the package (mirrors `WallpaperContent.video`).
+    case video(bookmarkData: Data, packageEntryName: String?)
     case html(HTMLSource, HTMLConfig)
     case metalShader(ShaderSource)
     case scene(SceneDescriptor)
 
+    /// Convenience constructor for a loose-file video (no package entry).
+    public static func video(bookmarkData: Data) -> WallpaperSessionDefinition {
+        .video(bookmarkData: bookmarkData, packageEntryName: nil)
+    }
+
     public init?(configuration: ScreenConfiguration) {
         switch configuration.activeWallpaper {
-        case .video(let bookmarkData):
+        case .video(let bookmarkData, let packageEntryName):
             guard !bookmarkData.isEmpty else { return nil }
-            self = .video(bookmarkData: bookmarkData)
+            self = .video(bookmarkData: bookmarkData, packageEntryName: packageEntryName)
         case .html(let source, let config):
             if case .inline(let raw) = source, raw.isEmpty { return nil }
             self = .html(source, config)
@@ -27,7 +35,7 @@ public enum WallpaperSessionDefinition: Equatable, Sendable {
 
     public func displayName(using bookmarkNameResolver: (Data) -> String?) -> String? {
         switch self {
-        case .video(let bookmarkData):
+        case .video(let bookmarkData, _):
             return bookmarkNameResolver(bookmarkData)
         case .html(let source, _):
             return source.displayName

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Schema/ScreenConfiguration.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Schema/ScreenConfiguration.swift
@@ -7,6 +7,11 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
     public var screenID: UInt32
     public var activeWallpaper: WallpaperContent
     public var savedVideoBookmarkData: Data?
+    /// Package entry name paired with `savedVideoBookmarkData` when the saved
+    /// primary is an in-place packaged video (bookmark → `scene.pkg`). Keeps the
+    /// entry across a type swap so restoring the primary doesn't degrade it to a
+    /// raw-package playback. `nil` for a loose saved video.
+    public var savedVideoPackageEntryName: String?
     /// Last applied HTML source — restored on type switch back to HTML.
     public var savedHTMLSource: HTMLSource?
     public var savedHTMLConfig: HTMLConfig?
@@ -64,6 +69,7 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
         case screenID
         case activeWallpaper
         case savedVideoBookmarkData
+        case savedVideoPackageEntryName
         case savedHTMLSource
         case savedHTMLConfig
         case playbackSpeed
@@ -113,11 +119,13 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
         playlistRotationMinutes: Int? = nil,
         playlistCursorIndex: Int? = nil,
         setAsLockScreen: Bool = false,
-        savedVideoBookmarkData: Data? = nil
+        savedVideoBookmarkData: Data? = nil,
+        savedVideoPackageEntryName: String? = nil
     ) {
         self.screenID = screenID
         self.activeWallpaper = wallpaper
         self.savedVideoBookmarkData = savedVideoBookmarkData ?? wallpaper.activeVideoBookmarkData
+        self.savedVideoPackageEntryName = savedVideoPackageEntryName ?? wallpaper.packageVideoEntryName
         if case .html(let source, let config) = wallpaper, source.isRestorableHTMLSource {
             self.savedHTMLSource = source
             self.savedHTMLConfig = config
@@ -343,11 +351,17 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
         savedHTMLConfig = try c.decodeIfPresent(HTMLConfig.self, forKey: .savedHTMLConfig)
         wpeOrigin = (try? c.decodeIfPresent(WPEOrigin.self, forKey: .wpeOrigin)) ?? nil
         displayFingerprint = try c.decodeIfPresent(String.self, forKey: .displayFingerprint)
+        // Absent in legacy / loose-video payloads → nil. Refined below from the
+        // active wallpaper when it is itself a packaged video.
+        savedVideoPackageEntryName = try c.decodeIfPresent(String.self, forKey: .savedVideoPackageEntryName)
 
         if let decodedWallpaper = try c.decodeIfPresent(WallpaperContent.self, forKey: .activeWallpaper) {
             activeWallpaper = decodedWallpaper
             savedVideoBookmarkData = try c.decodeIfPresent(Data.self, forKey: .savedVideoBookmarkData)
                 ?? decodedWallpaper.activeVideoBookmarkData
+            if savedVideoPackageEntryName == nil {
+                savedVideoPackageEntryName = decodedWallpaper.packageVideoEntryName
+            }
             if savedHTMLSource == nil,
                case .html(let source, let config) = decodedWallpaper,
                source.isRestorableHTMLSource {
@@ -431,6 +445,7 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
         try c.encode(screenID, forKey: .screenID)
         try c.encode(activeWallpaper, forKey: .activeWallpaper)
         try c.encodeIfPresent(savedVideoBookmarkData, forKey: .savedVideoBookmarkData)
+        try c.encodeIfPresent(savedVideoPackageEntryName, forKey: .savedVideoPackageEntryName)
         try c.encodeIfPresent(savedHTMLSource, forKey: .savedHTMLSource)
         try c.encodeIfPresent(savedHTMLConfig, forKey: .savedHTMLConfig)
         try c.encode(playbackSpeed, forKey: .playbackSpeed)
@@ -489,12 +504,23 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
 
     @discardableResult
     public mutating func activateSavedVideoWallpaper() -> Bool {
-        guard let bookmarkData = savedVideoBookmarkData ?? activeWallpaper.activeVideoBookmarkData else {
+        // Pair the bookmark with its package entry from the same source so a
+        // restored packaged primary keeps playing windowed (not as raw pkg).
+        let bookmarkData: Data
+        let packageEntryName: String?
+        if let saved = savedVideoBookmarkData {
+            bookmarkData = saved
+            packageEntryName = savedVideoPackageEntryName
+        } else if let active = activeWallpaper.activeVideoBookmarkData {
+            bookmarkData = active
+            packageEntryName = activeWallpaper.packageVideoEntryName
+        } else {
             return false
         }
         preserveCurrentHTMLIfNeeded()
-        activeWallpaper = .video(bookmarkData: bookmarkData)
+        activeWallpaper = .video(bookmarkData: bookmarkData, packageEntryName: packageEntryName)
         savedVideoBookmarkData = bookmarkData
+        savedVideoPackageEntryName = packageEntryName
         playlistCursorIndex = 0
         return true
     }
@@ -515,12 +541,15 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
     public mutating func replacePrimaryVideo(bookmarkData: Data, packageEntryName: String? = nil) {
         preserveCurrentHTMLIfNeeded()
         savedVideoBookmarkData = bookmarkData
+        savedVideoPackageEntryName = packageEntryName
         activeWallpaper = .video(bookmarkData: bookmarkData, packageEntryName: packageEntryName)
         playlistCursorIndex = 0
         playlistPrimaryIndex = nil
     }
 
     /// Activates a schedule slot without replacing the saved primary video.
+    /// Schedule slots store a bare bookmark, so they only carry loose videos;
+    /// a packaged video can't currently round-trip through a slot.
     public mutating func applyScheduledBookmark(_ bookmarkData: Data) {
         activeWallpaper = .video(bookmarkData: bookmarkData)
     }
@@ -528,6 +557,7 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
     private mutating func preserveCurrentVideoBookmarkIfNeeded() {
         if savedVideoBookmarkData == nil {
             savedVideoBookmarkData = activeWallpaper.activeVideoBookmarkData
+            savedVideoPackageEntryName = activeWallpaper.packageVideoEntryName
         }
     }
 
@@ -543,8 +573,10 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
         var copy = self
         let oldActive = copy.activeWallpaper.activeVideoBookmarkData
 
-        if case .video = copy.activeWallpaper {
-            copy.activeWallpaper = .video(bookmarkData: bookmarkData)
+        if case .video(_, let packageEntryName) = copy.activeWallpaper {
+            // Refreshing the bookmark keeps the same logical video — preserve
+            // its package entry so a packaged video isn't downgraded to raw pkg.
+            copy.activeWallpaper = .video(bookmarkData: bookmarkData, packageEntryName: packageEntryName)
         }
 
         guard let oldActive else { return copy }

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Schema/ScreenConfiguration.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Schema/ScreenConfiguration.swift
@@ -510,10 +510,12 @@ public struct ScreenConfiguration: Codable, Equatable, Sendable {
     }
 
     /// Swap primary video while preserving per-screen settings + saved HTML.
-    public mutating func replacePrimaryVideo(bookmarkData: Data) {
+    /// `packageEntryName` is non-nil for an in-place packaged video (bookmark →
+    /// `scene.pkg`); `nil` for a loose video file.
+    public mutating func replacePrimaryVideo(bookmarkData: Data, packageEntryName: String? = nil) {
         preserveCurrentHTMLIfNeeded()
         savedVideoBookmarkData = bookmarkData
-        activeWallpaper = .video(bookmarkData: bookmarkData)
+        activeWallpaper = .video(bookmarkData: bookmarkData, packageEntryName: packageEntryName)
         playlistCursorIndex = 0
         playlistPrimaryIndex = nil
     }

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Schema/WallpaperContent.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Schema/WallpaperContent.swift
@@ -1,10 +1,21 @@
 import Foundation
 
 public enum WallpaperContent: Equatable, Sendable {
-    case video(bookmarkData: Data)
+    /// A video wallpaper.
+    ///
+    /// - `bookmarkData` resolves to a plain video file when `packageEntryName`
+    ///   is `nil` (loose / legacy imports), or to a `scene.pkg` when it is set
+    ///   (in-place packaged video). For the package case the player serves the
+    ///   entry via a resource loader windowed into the package — no extraction.
+    case video(bookmarkData: Data, packageEntryName: String?)
     case html(source: HTMLSource, config: HTMLConfig)
     case metalShader(ShaderSource)
     case scene(SceneDescriptor)
+
+    /// Convenience constructor for the common loose-file video (no package entry).
+    public static func video(bookmarkData: Data) -> WallpaperContent {
+        .video(bookmarkData: bookmarkData, packageEntryName: nil)
+    }
 
     public var wallpaperType: WallpaperType {
         switch self {
@@ -20,8 +31,15 @@ public enum WallpaperContent: Equatable, Sendable {
     }
 
     public var activeVideoBookmarkData: Data? {
-        guard case .video(let bookmarkData) = self else { return nil }
+        guard case .video(let bookmarkData, _) = self else { return nil }
         return bookmarkData
+    }
+
+    /// The `scene.pkg` entry name when this is an in-place packaged video,
+    /// else `nil` (loose video file).
+    public var packageVideoEntryName: String? {
+        guard case .video(_, let entryName) = self else { return nil }
+        return entryName
     }
 
     public var htmlSource: HTMLSource? {
@@ -61,6 +79,7 @@ extension WallpaperContent: Codable {
 
     private enum VideoCodingKeys: String, CodingKey {
         case bookmarkData
+        case packageEntryName
     }
 
     private enum HTMLCodingKeys: String, CodingKey {
@@ -82,7 +101,9 @@ extension WallpaperContent: Codable {
 
         if let videoNested = try? container.nestedContainer(keyedBy: VideoCodingKeys.self, forKey: .video) {
             let bookmark = try videoNested.decode(Data.self, forKey: .bookmarkData)
-            self = .video(bookmarkData: bookmark)
+            // Absent in legacy payloads → loose video file.
+            let packageEntryName = try videoNested.decodeIfPresent(String.self, forKey: .packageEntryName)
+            self = .video(bookmarkData: bookmark, packageEntryName: packageEntryName)
             return
         }
 
@@ -124,9 +145,10 @@ extension WallpaperContent: Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
-        case .video(let bookmarkData):
+        case .video(let bookmarkData, let packageEntryName):
             var nested = container.nestedContainer(keyedBy: VideoCodingKeys.self, forKey: .video)
             try nested.encode(bookmarkData, forKey: .bookmarkData)
+            try nested.encodeIfPresent(packageEntryName, forKey: .packageEntryName)
         case .html(let source, let config):
             var nested = container.nestedContainer(keyedBy: HTMLCodingKeys.self, forKey: .html)
             try nested.encode(source, forKey: .source)

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Runtime/WPEOriginReconciler.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Runtime/WPEOriginReconciler.swift
@@ -27,7 +27,7 @@ public struct WPEOriginReconciler: OriginReconciler {
         }
 
         switch configuration.activeWallpaper {
-        case .video(let bookmarkData):
+        case .video(let bookmarkData, _):
             if !WPEOrigin.matchesBookmark(bookmarkData, origin: origin) {
                 configuration.wpeOrigin = nil
             }

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPEOrigin+Behavior.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPEOrigin+Behavior.swift
@@ -76,8 +76,17 @@ extension WPEOrigin {
 
         switch origin.originalType {
         case .video:
-            guard let expected = origin.sourceEntryURL else { return false }
-            return resolvedPath == expected.path
+            // Loose video: bookmark points at the entry file in the folder.
+            if let expected = origin.sourceEntryURL, resolvedPath == expected.path {
+                return true
+            }
+            // In-place packaged video: bookmark points at the source
+            // `scene.pkg` (the entry is read windowed from it, not extracted).
+            let packagePath = sourceURL
+                .appendingPathComponent("scene.pkg")
+                .standardizedFileURL
+                .path
+            return resolvedPath == packagePath
         case .web:
             return resolvedPath == sourcePath
         case .scene, .application, .unknown:

--- a/design/ui-mockup/scene-library.html
+++ b/design/ui-mockup/scene-library.html
@@ -1,6 +1,12 @@
 <!doctype html><html lang="zh"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>④ Scene 库</title>
-<link rel="stylesheet" href="css/tokens.css"><link rel="stylesheet" href="css/app.css"></head>
+<link rel="stylesheet" href="css/tokens.css"><link rel="stylesheet" href="css/app.css">
+<style>
+  /* per-display Scene = lightweight quick-apply; full library lives in Workshop */
+  .section-head .right { display:flex; align-items:center; gap:12px; }
+  .browse-link { font:600 12px/1 var(--font); color:var(--accent); cursor:default;
+    display:inline-flex; align-items:center; gap:5px; }
+</style></head>
 <body>
 <div class="win">
   <div class="titlebar" data-seg="Video,HTML,Shader,Scene|Scene"></div>
@@ -12,7 +18,7 @@
         <div><div class="ttl">MPG321CX OLED</div><div class="meta"><span>1920×1080</span><span>240 Hz</span></div></div>
       </div>
       <div class="detail-pad">
-        <div class="section-head"><span>RECENT IMPORTED PROJECTS</span><span class="pill-btn" data-ic="plus" data-s="12">&nbsp;Apply Project…</span></div>
+        <div class="section-head"><span>RECENT IMPORTED PROJECTS</span><span class="right"><a class="browse-link">Browse all 24 in Workshop →</a><span class="pill-btn" data-ic="plus" data-s="12">&nbsp;Apply Project…</span></span></div>
         <div class="grid">
           <div class="card"><div class="thumb" style="background:linear-gradient(135deg,#7a8ba8,#3a4a66)"><div class="ov br"><span class="badge">4K</span></div></div><div class="card-foot"><div class="card-title">"日向の幽霊" / "Hyuga の Ghost" byCogecha</div><div class="card-meta"><span class="type-badge">scene</span><span class="sz">90 MB</span></div></div></div>
           <div class="card"><div class="thumb" style="background:linear-gradient(135deg,#dfe3e8,#b6bfca)"><div class="ov tr"><span class="badge success">✓ In Library</span></div></div><div class="card-foot"><div class="card-title">【明日方舟】凯尔希·思衡托 Kal'tsit</div><div class="card-meta"><span class="type-badge">scene</span><span class="sz">120 MB</span></div></div></div>


### PR DESCRIPTION
Reads WPE video/web/scene wallpapers — and their dependencies — in place from `scene.pkg` (windowed AVAssetResourceLoader for video, a package-backed scheme handler for web, package providers for deps). Import no longer extracts into `wpe-cache`, and legacy `.cache` configs rebuild from source, so the extraction cache is now write-dead and no longer load-bearing. Additive: legacy loose/cache paths are untouched, no migration.

Also carries the earlier UI-polish commits (Settings/Scene-tab/empty-state). Deleting the cache actor itself (startup GC, management UI, corpus harness) is a staged follow-up. Build green on both SKUs; unit tests pass. Packaged-video playback still needs on-device validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)