### PR TITLE
fix(ui): destructive buttons drop the red plate behind red text

### DIFF
--- a/Packages/LiveWallpaperSharedUI/Sources/LiveWallpaperSharedUI/Components/DestructiveControlTint.swift
+++ b/Packages/LiveWallpaperSharedUI/Sources/LiveWallpaperSharedUI/Components/DestructiveControlTint.swift
@@ -5,9 +5,13 @@ public struct DestructiveControlTint: ViewModifier {
 
     public func body(content: Content) -> some View {
         content
+            // Destructive cue lives in the red label + glyph. The surface stays
+            // NEUTRAL — a red-tinted plate behind red text is same-hue on
+            // same-hue and reads as low-contrast (worst under Reduce
+            // Transparency, where the tint wash is opaque).
             .foregroundStyle(DesignTokens.Colors.Status.danger)
             .tint(DesignTokens.Colors.Status.danger)
-            .adaptiveGlassSurface(.roundedRectangle(8), tint: DesignTokens.Colors.Status.danger, interactive: true)
+            .adaptiveGlassSurface(.roundedRectangle(8), interactive: true)
             .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 }


### PR DESCRIPTION
`destructiveControlTint()` tinted its glass surface with the same danger red as the label, so red text sat on a red plate — same-hue/low-contrast (worst under Reduce Transparency, where the wash is opaque). The fix keeps the red label + glyph as the destructive cue and makes the surface neutral, fixing every destructive control (Remove/Clear/Forget/etc.) in one place. Builds green on both SKUs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)