### PR TITLE
perf(wpe): cut scene-load time — async frames + off-main audio

### DIFF
--- a/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
@@ -726,11 +726,15 @@ struct WPERenderGraphBuilder: Sendable {
         textures[1] = textures[1] ?? textureReference(clipMaskName, ownerPath: context.object.imageRelativePath)
         textures[8] = .fbo(clipTargetName)
         #if DEBUG
-        Logger.info(
-            "[WPE clip] builder injected clip-composite bindings for \(context.model.puppetPath ?? "?") "
-                + "(mask=\(clipMaskName), rt=\(clipTargetName))",
-            category: .wpeRender
-        )
+        // Gated behind the scene-debug switch (off by default) so clip-composite
+        // injection doesn't log on every load of a genericimage4 puppet scene.
+        if UserDefaults.standard.bool(forKey: "WPESceneDebugArtifactsEnabled") {
+            Logger.info(
+                "[WPE clip] builder injected clip-composite bindings for \(context.model.puppetPath ?? "?") "
+                    + "(mask=\(clipMaskName), rt=\(clipTargetName))",
+                category: .wpeRender
+            )
+        }
         #endif
         return pass.replacingTextures(textures)
     }

--- a/LiveWallpaper/Infrastructure/WPESceneDebugArtifacts.swift
+++ b/LiveWallpaper/Infrastructure/WPESceneDebugArtifacts.swift
@@ -10,8 +10,10 @@ import Metal
 /// the compiler saw (original/processed GLSL, translated MSL, error text,
 /// scene-info, scene.log mirror, optional first-frame.png).
 ///
-/// Always on in DEBUG; in Release gated by the `WPESceneDebugArtifactsEnabled`
-/// UserDefaults flag (Developer Mode → Developer Tools).
+/// Opt-in in all builds: gated by the `WPESceneDebugArtifactsEnabled`
+/// UserDefaults flag (Developer Mode → Developer Tools). Off by default so a
+/// normal launch never pays for shader dumps / first-frame read-back / per-pass
+/// binding diagnostics; the corpus harness and trace tests flip it on explicitly.
 ///
 /// `@unchecked Sendable`: `session` is guarded by `sessionLock`; I/O via `writeQueue`.
 final class WPESceneDebugArtifacts: @unchecked Sendable {
@@ -71,8 +73,8 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
     }
     #endif
 
-    /// Caps on the scene-debug directory so DEBUG builds (where dumps default on)
-    /// don't accumulate unbounded PNG/MSL artifacts. The oldest session folders
+    /// Caps on the scene-debug directory so builds with dumps enabled don't
+    /// accumulate unbounded PNG/MSL artifacts. The oldest session folders
     /// are pruned first when either bound is exceeded; the newest is always kept.
     private let maxSessionFolders = 40
     private let maxTotalBytes: UInt64 = 512 * 1024 * 1024  // 512 MiB
@@ -90,7 +92,7 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
         let testingOverride = testingEnabledOverride
         testingEnabledOverrideLock.unlock()
         if let testingOverride { return testingOverride }
-        return UserDefaults.standard.object(forKey: Self.defaultsKey) as? Bool ?? true
+        return UserDefaults.standard.bool(forKey: Self.defaultsKey)
         #else
         return UserDefaults.standard.bool(forKey: Self.defaultsKey)
         #endif

--- a/LiveWallpaper/Runtime/WPEMetalCompileTimer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalCompileTimer.swift
@@ -9,9 +9,12 @@ import Foundation
 /// work or texture-upload completion.
 ///
 /// Active only while the `WPEMetalLoadTiming` diagnostic is on, so production
-/// pays nothing. The accumulator is global (compilation happens across the
-/// executor's caches and the shader compiler); a renderer resets it at load
-/// start and reads it once the first frame is done.
+/// pays nothing. The accumulator is global + monotonic (compilation happens
+/// across the executor's caches and the shader compiler); a renderer snapshots
+/// `milliseconds` at load start and reports the delta at first frame rather than
+/// resetting — so a concurrent load on another display can't zero it mid-flight.
+/// Truly concurrent loads still over-count each other's compiles; acceptable for
+/// an opt-in diagnostic usually exercised one scene at a time.
 enum WPEMetalCompileTimer {
     private static let lock = NSLock()
     // Manually serialized by `lock`; the unchecked annotation is the idiomatic
@@ -36,12 +39,7 @@ enum WPEMetalCompileTimer {
         return try body()
     }
 
-    static func reset() {
-        lock.lock()
-        totalNanos = 0
-        lock.unlock()
-    }
-
+    /// Monotonic running total in milliseconds; callers snapshot + diff it.
     static var milliseconds: Double {
         lock.lock()
         defer { lock.unlock() }

--- a/LiveWallpaper/Runtime/WPEMetalCompileTimer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalCompileTimer.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Process-wide accumulator for Metal shader/pipeline COMPILATION time —
+/// `makeLibrary(source:)` (MSL→AIR) plus `makeRenderPipelineState` (pipeline
+/// compile). These run lazily on first encode, so their cost lands inside the
+/// renderer's `render.firstFrame` phase rather than `pipeline.build`. Measuring
+/// them separately tells us how much of the first frame is one-time compilation
+/// — which a binary-archive / MSL cache could eliminate — versus genuine GPU
+/// work or texture-upload completion.
+///
+/// Active only while the `WPEMetalLoadTiming` diagnostic is on, so production
+/// pays nothing. The accumulator is global (compilation happens across the
+/// executor's caches and the shader compiler); a renderer resets it at load
+/// start and reads it once the first frame is done.
+enum WPEMetalCompileTimer {
+    private static let lock = NSLock()
+    // Manually serialized by `lock`; the unchecked annotation is the idiomatic
+    // escape hatch for lock-guarded global state under strict concurrency.
+    nonisolated(unsafe) private static var totalNanos: UInt64 = 0
+
+    private static var isActive: Bool {
+        UserDefaults.standard.bool(forKey: "WPEMetalLoadTiming")
+    }
+
+    /// Times `body` and adds it to the running total when the diagnostic is on;
+    /// otherwise calls through with no measurement overhead.
+    static func measure<T>(_ body: () throws -> T) rethrows -> T {
+        guard isActive else { return try body() }
+        let start = DispatchTime.now()
+        defer {
+            let elapsed = DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds
+            lock.lock()
+            totalNanos &+= elapsed
+            lock.unlock()
+        }
+        return try body()
+    }
+
+    static func reset() {
+        lock.lock()
+        totalNanos = 0
+        lock.unlock()
+    }
+
+    static var milliseconds: Double {
+        lock.lock()
+        defer { lock.unlock() }
+        return Double(totalNanos) / 1_000_000
+    }
+}

--- a/LiveWallpaper/Runtime/WPEMetalPipelineCache.swift
+++ b/LiveWallpaper/Runtime/WPEMetalPipelineCache.swift
@@ -52,7 +52,7 @@ final class WPEMetalPipelineCache {
 
         let state: MTLRenderPipelineState
         do {
-            state = try device.makeRenderPipelineState(descriptor: descriptor)
+            state = try WPEMetalCompileTimer.measure { try device.makeRenderPipelineState(descriptor: descriptor) }
         } catch {
             let detail = """
             vertex: \(vertexName)

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -201,17 +201,39 @@ final class WPEMetalRenderExecutor {
     /// Scene-output ring: per-frame outputs are recycled instead of freshly
     /// allocated every `render()` (~32 MB alloc/free per frame at 4K). A slot
     /// is reused only when (a) no async present of it is still in flight and
-    /// (b) it is not one of the two most recently vended outputs — the
-    /// renderer re-presents the latest output for static scenes, and
-    /// `previousFrameHistory` may still read the prior one.
+    /// (b) it is not among the most recently vended outputs (`maxFramesInFlight`,
+    /// min 2) — the renderer re-presents the latest output for static scenes,
+    /// `previousFrameHistory` may still read the prior one, and under async
+    /// submission an in-flight render may still be writing it.
     private var outputTexturePool: [MTLTexture] = []
-    /// The two most recently vended output textures (newest last).
+    /// The most recently vended output textures (newest last); retained count is
+    /// `max(2, maxFramesInFlight)` — see `noteVendedOutputTexture`.
     private var recentOutputTextureIDs: [ObjectIdentifier] = []
     private let presentTracker = PresentInFlightTracker()
     /// Diagnostics that hold several successive frame textures at once
     /// (`debugRenderSuccessiveFrameTextures`) disable recycling so each frame
     /// keeps distinct storage.
     var isOutputPoolingEnabled = true
+
+    /// Max frames whose command buffers may be in flight at once when submitting
+    /// asynchronously. MUST equal the `recentOutputTextureIDs` retention: a vended
+    /// output target stays out of the reuse set for exactly that many subsequent
+    /// vends, and the semaphore guarantees its render has completed by the time it
+    /// falls out — so a target is never recycled while its GPU write is in flight.
+    /// (See `isOutputTextureReusable` / `noteVendedOutputTexture`.)
+    static let maxFramesInFlight = 2
+    /// Backpressure for asynchronous frame submission: blocks the render caller
+    /// once `maxFramesInFlight` frames are queued so the CPU cannot outrun the GPU
+    /// (which would starve the output ring and grow latency unboundedly).
+    private let inFlightSemaphore = DispatchSemaphore(value: maxFramesInFlight)
+    /// When true, `render()` and the text passes block on GPU completion
+    /// (`waitUntilCompleted`) so a CPU read-back of the frame (scene-debug
+    /// first-frame snapshot, visual-stats, GPU capture, test pixel diffs) observes
+    /// finished pixels. When false — the production live path — frames submit
+    /// asynchronously and the CPU only stalls via `inFlightSemaphore`, letting
+    /// frame N+1's setup overlap frame N's GPU work. The live renderer sets this
+    /// per scene; defaults to the safe synchronous behavior for any other caller.
+    var synchronizeFrameCompletion = true
     /// Cleared `.previous` bootstrap textures, one per (target, size, format).
     /// They are only ever read (seeded before the target's first write of the
     /// frame), so the creation-time clear stays valid for the cache lifetime.
@@ -371,6 +393,15 @@ final class WPEMetalRenderExecutor {
         particleTextures: [ObjectIdentifier: MTLTexture] = [:],
         particleParallax: WPECameraParallaxFrame = .neutral
     ) throws -> MTLTexture {
+        // Async submission: take a permit up front so the CPU blocks here (rather
+        // than queuing another frame) once `maxFramesInFlight` are outstanding.
+        // The matching signal is emitted from the command buffer's completion
+        // handler on success; the `defer` releases it on any early throw so a
+        // permit is never lost.
+        let asyncSubmission = !synchronizeFrameCompletion
+        if asyncSubmission { inFlightSemaphore.wait() }
+        var didCommitAsync = false
+        defer { if asyncSubmission && !didCommitAsync { inFlightSemaphore.signal() } }
         #if DEBUG
         scenePassDumps.removeAll()
         let dumpScenePasses = sceneID.map { !$0.isEmpty && UserDefaults.standard.string(forKey: "WPEDumpScenePasses") == $0 } ?? false
@@ -560,10 +591,32 @@ final class WPEMetalRenderExecutor {
             throw WPEMetalRenderExecutorError.noRenderablePasses
         }
 
-        commandBuffer.commit()
-        commandBuffer.waitUntilCompleted()
-        if commandBuffer.status == .error {
-            throw WPEMetalRenderExecutorError.commandBufferFailed
+        if asyncSubmission {
+            // Bound in-flight depth (signal mirrors the wait above) and surface
+            // GPU errors from the handler — they land after we've returned, so we
+            // log rather than throw; the wallpaper just renders the next frame.
+            // GPU-side ordering on the shared queue still guarantees the text and
+            // present buffers (committed later) observe this frame's writes.
+            let semaphore = inFlightSemaphore
+            commandBuffer.addCompletedHandler { cb in
+                semaphore.signal()
+                #if DEBUG
+                if cb.status == .error {
+                    Logger.warning(
+                        "[WPE async-frame] command buffer error: \(cb.error?.localizedDescription ?? "unknown")",
+                        category: .wpeRender
+                    )
+                }
+                #endif
+            }
+            commandBuffer.commit()
+            didCommitAsync = true
+        } else {
+            commandBuffer.commit()
+            commandBuffer.waitUntilCompleted()
+            if commandBuffer.status == .error {
+                throw WPEMetalRenderExecutorError.commandBufferFailed
+            }
         }
         previousFrameHistory = PreviousFrameHistory(
             sceneSize: size,
@@ -753,7 +806,9 @@ final class WPEMetalRenderExecutor {
         }
         encoder.endEncoding()
         commandBuffer.commit()
-        commandBuffer.waitUntilCompleted()
+        // Same queue as the scene render, so this composites after it GPU-side
+        // without a CPU stall; only block when a read-back needs finished pixels.
+        if synchronizeFrameCompletion { commandBuffer.waitUntilCompleted() }
     }
 
     /// Draw GPU MSDF text: compile the translated `font.frag` (cached per combo
@@ -821,7 +876,9 @@ final class WPEMetalRenderExecutor {
         }
         encoder.endEncoding()
         commandBuffer.commit()
-        commandBuffer.waitUntilCompleted()
+        // Same queue as the scene render, so this composites after it GPU-side
+        // without a CPU stall; only block when a read-back needs finished pixels.
+        if synchronizeFrameCompletion { commandBuffer.waitUntilCompleted() }
     }
 
     private func compileMSDFFontShader(_ request: WPEShaderCompileRequest) throws -> WPEShaderCompileResult {
@@ -3153,8 +3210,14 @@ final class WPEMetalRenderExecutor {
         let id = ObjectIdentifier(texture)
         recentOutputTextureIDs.removeAll { $0 == id }
         recentOutputTextureIDs.append(id)
-        if recentOutputTextureIDs.count > 2 {
-            recentOutputTextureIDs.removeFirst(recentOutputTextureIDs.count - 2)
+        // Keep the last `maxFramesInFlight` vended targets out of the reuse set:
+        // under async submission their render may still be running, and the
+        // in-flight semaphore guarantees it has finished by the time the target
+        // ages out of this window. Keep at least 2 for the static-scene re-present
+        // + `previousFrameHistory` reads even when only 1 frame is in flight.
+        let retain = max(2, Self.maxFramesInFlight)
+        if recentOutputTextureIDs.count > retain {
+            recentOutputTextureIDs.removeFirst(recentOutputTextureIDs.count - retain)
         }
     }
 

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -922,7 +922,7 @@ final class WPEMetalRenderExecutor {
         attachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
         attachment.sourceAlphaBlendFactor = .one
         attachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
-        let state = try device.makeRenderPipelineState(descriptor: pipelineDescriptor)
+        let state = try WPEMetalCompileTimer.measure { try device.makeRenderPipelineState(descriptor: pipelineDescriptor) }
         msdfTextPipelineCache[key] = state
         return state
     }
@@ -1020,7 +1020,7 @@ final class WPEMetalRenderExecutor {
         attachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
         attachment.sourceAlphaBlendFactor = .one
         attachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
-        let state = try device.makeRenderPipelineState(descriptor: descriptor)
+        let state = try WPEMetalCompileTimer.measure { try device.makeRenderPipelineState(descriptor: descriptor) }
         textOverlayPipelineCache[colorPixelFormat.rawValue] = state
         return state
     }
@@ -1075,7 +1075,7 @@ final class WPEMetalRenderExecutor {
             attachment.sourceAlphaBlendFactor = .sourceAlpha
             attachment.destinationAlphaBlendFactor = .one
         }
-        let state = try device.makeRenderPipelineState(descriptor: descriptor)
+        let state = try WPEMetalCompileTimer.measure { try device.makeRenderPipelineState(descriptor: descriptor) }
         particlePipelineCache[key] = state
         return state
     }
@@ -3617,7 +3617,7 @@ final class WPEMetalRenderExecutor {
         Self.applyBlendMode(blendMode.lowercased(), to: colorAttachment)
         let state: MTLRenderPipelineState
         do {
-            state = try device.makeRenderPipelineState(descriptor: descriptor)
+            state = try WPEMetalCompileTimer.measure { try device.makeRenderPipelineState(descriptor: descriptor) }
         } catch {
             throw WPEMetalRenderExecutorError.pipelineStateBuildFailed(
                 name: result.fragmentFunctionName,

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -2524,6 +2524,9 @@ final class WPEMetalRenderExecutor {
     /// Release so the clip path adds no log noise to shipped builds.
     private static func clipDiagnosticLog(_ message: @autoclosure () -> String) {
         #if DEBUG
+        // Gated behind the scene-debug switch (off by default) so genericimage4
+        // puppet scenes don't print clip-detection lines on every load.
+        guard UserDefaults.standard.bool(forKey: "WPESceneDebugArtifactsEnabled") else { return }
         Logger.info(message(), category: .wpeRender)
         #endif
     }

--- a/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/WPEMetalRenderExecutor.swift
@@ -600,14 +600,14 @@ final class WPEMetalRenderExecutor {
             let semaphore = inFlightSemaphore
             commandBuffer.addCompletedHandler { cb in
                 semaphore.signal()
-                #if DEBUG
+                // Logged in every build (the old synchronous path threw on error,
+                // which the caller logged) so a GPU failure isn't silent in release.
                 if cb.status == .error {
                     Logger.warning(
                         "[WPE async-frame] command buffer error: \(cb.error?.localizedDescription ?? "unknown")",
                         category: .wpeRender
                     )
                 }
-                #endif
             }
             commandBuffer.commit()
             didCommitAsync = true

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -139,6 +139,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// The in-flight off-main audio-startup task, tracked so `reload`/`cleanup`
     /// can cancel it.
     private var deferredAudioStartupTask: Task<Void, Never>?
+    /// `WPEMetalCompileTimer.milliseconds` snapshot at load start; the per-load
+    /// metal-compile figure is reported as a delta against this (no global reset).
+    private var compileMillisecondsAtLoadStart: Double = 0
 
     #if DEBUG
     /// Test-only: audio startup is deferred (waiting on the first present), not yet started.
@@ -303,7 +306,11 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             descriptor: descriptorSummary
         )
         #endif
-        WPEMetalCompileTimer.reset()
+        // Snapshot the global compile accumulator and report a delta (instead of
+        // resetting it), so a concurrent scene load on another display can't zero
+        // it mid-flight. (Truly concurrent loads still over-count by each other's
+        // compiles — a known limit of this opt-in diagnostic.)
+        compileMillisecondsAtLoadStart = WPEMetalCompileTimer.milliseconds
         loadGeneration &+= 1
         loadTiming = WPESceneLoadTiming.isEnabled
             ? WPESceneLoadTiming(workshopID: descriptor.workshopID)
@@ -551,7 +558,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             // How much of render.firstFrame was one-time shader/pipeline
             // compilation (cacheable via a binary archive) vs GPU work.
             Logger.notice(
-                "[load-timing] scene=\(descriptor.workshopID) metal-compile=\(String(format: "%.1f", WPEMetalCompileTimer.milliseconds))ms (shader+pipeline, lands inside render.firstFrame)",
+                "[load-timing] scene=\(descriptor.workshopID) metal-compile=\(String(format: "%.1f", WPEMetalCompileTimer.milliseconds - compileMillisecondsAtLoadStart))ms (shader+pipeline, lands inside render.firstFrame)",
                 category: .performance
             )
         }
@@ -606,14 +613,14 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     }
 
     /// Boot the sound runtime once the first frame has actually presented (called
-    /// from `draw(in:)` after the first successful `present`). The runtime is
-    /// built on the main actor — cheap — but the expensive `start(sounds:)`
-    /// (file loads + AVAudioEngine spin-up, ~300-900ms) runs OFF the main actor
-    /// so the wallpaper never stalls, then the live runtime is published back.
-    /// Bails (and stops the runtime) if the scene reloaded or tore down while
-    /// audio was starting (generation guard + cancellation). Mute/volume intent
-    /// is applied before start and re-applied after, so a toggle during the
-    /// off-main window is not lost.
+    /// from `draw(in:)` after the first successful `present`). The expensive
+    /// `prepare(sounds:)` (file loads + buffer decode, ~300-900ms) runs OFF the
+    /// main actor so the wallpaper never stalls but produces NO audio. Playback
+    /// (`play()`) only starts back on the main actor, AFTER confirming the scene
+    /// is still current — so a reload/cleanup during preparation can never let a
+    /// stale scene's audio play (it just releases the prepared engine). Mute and
+    /// volume are re-applied with the latest values immediately before `play()`,
+    /// so a toggle during the off-main window is honored before any sound.
     private func beginDeferredAudioStartup() {
         guard let document = pendingAudioStartupDocument else { return }
         pendingAudioStartupDocument = nil
@@ -630,16 +637,21 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         deferredAudioStartupTask?.cancel()
         deferredAudioStartupTask = Task.detached(priority: .userInitiated) { [weak self] in
             let start = DispatchTime.now()
-            _ = runtime.start(sounds: sounds)
+            _ = runtime.prepare(sounds: sounds)   // off-main, decodes files; nothing audible yet
             let ms = Double(DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds) / 1_000_000
             await MainActor.run {
                 guard let self, !Task.isCancelled, self.loadGeneration == generation else {
+                    // Scene reloaded / torn down while we were preparing. play()
+                    // never ran, so no stale audio leaked; release the engine.
                     runtime.stop()
                     return
                 }
-                self.soundRuntime = runtime
+                // Apply the latest mute/volume (may have changed during prepare),
+                // THEN start playback, THEN publish.
                 runtime.setMuted(self.pendingAudioMuted)
                 runtime.setMasterVolume(self.pendingAudioVolume)
+                runtime.play()
+                self.soundRuntime = runtime
                 if WPESceneLoadTiming.isEnabled {
                     Logger.notice(
                         "[load-timing] scene=\(workshopID) deferred-audio=\(String(format: "%.1f", ms))ms (off main, after first present)",
@@ -1286,7 +1298,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         // .tex decode + dynamic-source refresh) vs GPU render (encode + upload
         // completion + draw + wait), so we can tell which dominates render.firstFrame
         // on heavy scenes. Only the load-time first frame, only when timing is on.
-        let splitFirstFrame = WPESceneLoadTiming.isEnabled && !didLoad
+        // `!didLoad` first: it short-circuits the UserDefaults read on every
+        // steady-state frame (only the load-time first frame ever gets past it).
+        let splitFirstFrame = !didLoad && WPESceneLoadTiming.isEnabled
         let texPrepStart = splitFirstFrame ? DispatchTime.now() : nil
         let currentTextures = texturesForCurrentFrame(time: uniforms.time)
         let gpuRenderStart = splitFirstFrame ? DispatchTime.now() : nil

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -102,6 +102,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// "cursor sampled but force feels wrong".
     private let cursorDebugLogEnabled = UserDefaults.standard.bool(forKey: "WPEParticleCursorDebug")
     private var cursorDiagCounter = 0
+    /// Per-load stage profiler; non-nil only while `WPEMetalLoadTiming` is set.
+    /// Fed by `debugStage`, it logs a per-phase load breakdown at first-frame.
+    private var loadTiming: WPESceneLoadTiming?
     /// Last throttle state we logged, so a focus/unfocus transition (which
     /// flips the scene between 60 FPS and `throttledPreferredFPS` = 1) emits a
     /// line immediately instead of waiting out the per-60-frame cadence. This
@@ -281,6 +284,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             descriptor: descriptorSummary
         )
         #endif
+        loadTiming = WPESceneLoadTiming.isEnabled
+            ? WPESceneLoadTiming(workshopID: descriptor.workshopID)
+            : nil
         debugStage("load.begin", descriptorSummary)
         do {
             try await performLoad()
@@ -964,6 +970,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// even builds the (per-stage, per-pass) interpolated strings. Flip the
     /// switch on to get the full console + scene.log stage trace back.
     private func debugStage(_ stage: String, _ detail: @autoclosure () -> String) {
+        // Feed the load profiler first — it's gated independently of scene-debug,
+        // so load timing can be gathered without enabling the dump machinery.
+        loadTiming?.mark(stage)
         guard WPESceneDebugArtifacts.shared.isEnabled else { return }
         let detail = detail()
         Logger.debug(

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -281,14 +281,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             descriptor: descriptorSummary
         )
         #endif
-        WPESceneDebugArtifacts.shared.appendLog(
-            "load() began for \(descriptorSummary)",
-            level: .info
-        )
-        Logger.debug(
-            "[WPE-DEBUG][scene:\(descriptor.workshopID)][stage:load.begin] \(descriptorSummary)",
-            category: .wpeRender
-        )
+        debugStage("load.begin", descriptorSummary)
         do {
             try await performLoad()
             loadDiagnostics = nil
@@ -965,10 +958,16 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// the `wpeRender` os.Logger category AND mirrors into the per-scene
     /// `scene.log` so the file artifact stays self-contained without the
     /// reader having to cross-reference Console.app.
-    private func debugStage(_ stage: String, _ detail: String) {
-        let id = descriptor.workshopID
+    /// Per-load stage breadcrumb. Gated on the scene-debug switch (Developer
+    /// Tools → "Scene debug artifacts"), which is off by default — so a normal
+    /// run emits none of these and, because `detail` is `@autoclosure`, never
+    /// even builds the (per-stage, per-pass) interpolated strings. Flip the
+    /// switch on to get the full console + scene.log stage trace back.
+    private func debugStage(_ stage: String, _ detail: @autoclosure () -> String) {
+        guard WPESceneDebugArtifacts.shared.isEnabled else { return }
+        let detail = detail()
         Logger.debug(
-            "[WPE-DEBUG][scene:\(id)][stage:\(stage)] \(detail)",
+            "[WPE-DEBUG][scene:\(descriptor.workshopID)][stage:\(stage)] \(detail)",
             category: .wpeRender
         )
         WPESceneDebugArtifacts.shared.appendLog("[\(stage)] \(detail)")

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -1282,7 +1282,14 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
                 }
             }
         }
+        // Split the (synchronous) first load frame into CPU texture prep (lazy
+        // .tex decode + dynamic-source refresh) vs GPU render (encode + upload
+        // completion + draw + wait), so we can tell which dominates render.firstFrame
+        // on heavy scenes. Only the load-time first frame, only when timing is on.
+        let splitFirstFrame = WPESceneLoadTiming.isEnabled && !didLoad
+        let texPrepStart = splitFirstFrame ? DispatchTime.now() : nil
         let currentTextures = texturesForCurrentFrame(time: uniforms.time)
+        let gpuRenderStart = splitFirstFrame ? DispatchTime.now() : nil
         let frame = try executor.render(
             pipeline: pipeline,
             size: sceneRenderSize,
@@ -1294,6 +1301,14 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             particleTextures: particleTextures,
             particleParallax: parallaxFrame
         )
+        if let texPrepStart, let gpuRenderStart {
+            let prepMs = Double(gpuRenderStart.uptimeNanoseconds &- texPrepStart.uptimeNanoseconds) / 1_000_000
+            let renderMs = Double(DispatchTime.now().uptimeNanoseconds &- gpuRenderStart.uptimeNanoseconds) / 1_000_000
+            Logger.notice(
+                "[load-timing] scene=\(descriptor.workshopID) firstFrame-split: texture-prep=\(String(format: "%.1f", prepMs))ms gpu-render=\(String(format: "%.1f", renderMs))ms",
+                category: .performance
+            )
+        }
         if let textRenderer, !textObjects.isEmpty {
             // CoreText draws for objects that don't take the MSDF path this frame.
             var draws: [WPETextOverlayDraw] = []

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -520,9 +520,12 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         debugStage("render.firstFrame", "begin")
         onProgress?("Rendering scene")
 
-        // Production submits frames asynchronously (no per-frame CPU stall on the
-        // GPU); fall back to synchronous only when a read-back needs finished pixels.
-        executor.synchronizeFrameCompletion = shouldSynchronizeFrames()
+        // Render the FIRST frame synchronously: it is read back on the CPU right
+        // after load() by the scene-debug snapshot, the corpus harness, and the
+        // `renderedTexture` accessor (tests) — an async submission would let those
+        // read-backs race the GPU and sample an unfinished frame. It is a one-time
+        // cost; the steady-state draw loop switches to async below.
+        executor.synchronizeFrameCompletion = true
         let capture = beginGPUCaptureIfRequested()
         outputTexture = try renderCurrentFrame()
         capture?.stop()
@@ -557,6 +560,10 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         }
         hasPresentedFrame = true
         didLoad = true
+        // Steady-state draw loop: async in production (no per-frame CPU stall on
+        // the GPU); stay synchronous only when a per-frame read-back is active
+        // (scene-debug / GPU capture / pass dumps) or pinned via WPEMetalSerializeFrames.
+        executor.synchronizeFrameCompletion = shouldSynchronizeFrames()
         applyPerformanceProfile(currentProfile)
         mtkView.setNeedsDisplay(mtkView.bounds)
         debugStage("render.firstFrame.done", "size=\(outputTexture?.width ?? 0)x\(outputTexture?.height ?? 0) snapshot=\(cachedSnapshot == nil ? "none" : "saved")")

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -520,6 +520,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         debugStage("render.firstFrame", "begin")
         onProgress?("Rendering scene")
 
+        // Production submits frames asynchronously (no per-frame CPU stall on the
+        // GPU); fall back to synchronous only when a read-back needs finished pixels.
+        executor.synchronizeFrameCompletion = shouldSynchronizeFrames()
         let capture = beginGPUCaptureIfRequested()
         outputTexture = try renderCurrentFrame()
         capture?.stop()
@@ -964,6 +967,22 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         WPESceneDebugArtifacts.shared.appendLog("[\(stage)] \(detail)")
     }
 
+    /// Whether the executor should submit frames synchronously (block on GPU
+    /// completion) for this scene. True only when a CPU read-back of the rendered
+    /// frame will happen — scene-debug artifacts (first-frame snapshot / stats),
+    /// GPU capture, per-pass dumps — or the operator pins it via
+    /// `WPEMetalSerializeFrames`. Production has none of these, so frames submit
+    /// asynchronously and the CPU never stalls on the GPU per frame.
+    private func shouldSynchronizeFrames() -> Bool {
+        if UserDefaults.standard.bool(forKey: "WPEMetalSerializeFrames") { return true }
+        if WPESceneDebugArtifacts.shared.isEnabled { return true }
+        #if DEBUG
+        if gpuCaptureRequestedForCurrentScene() { return true }
+        if !(UserDefaults.standard.string(forKey: "WPEDumpScenePasses") ?? "").isEmpty { return true }
+        #endif
+        return false
+    }
+
     /// Computes one frame's runtime uniforms (clock, daytime, brightness, pointer) and submits the render pipeline with both runtime and camera uniforms.
     #if DEBUG
     /// Test-only: render the loaded scene but keep only the first `passLimit`
@@ -974,6 +993,11 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         guard let pipeline = renderPipeline else {
             throw WPEMetalRenderExecutorError.noRenderablePasses
         }
+        // The returned texture is read back on the CPU for bisection, so force the
+        // synchronous path regardless of the scene's live submission mode.
+        let previousSync = executor.synchronizeFrameCompletion
+        executor.synchronizeFrameCompletion = true
+        defer { executor.synchronizeFrameCompletion = previousSync }
         let truncated = WPEPreparedRenderPipeline(
             layers: pipeline.layers.map { layer in
                 WPEPreparedRenderLayer(
@@ -1009,7 +1033,14 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         // This diagnostic holds every frame's texture for after-the-fact pixel
         // comparison; output recycling would alias frame N with frame N+3.
         executor.isOutputPoolingEnabled = false
-        defer { executor.isOutputPoolingEnabled = true }
+        // Each frame's texture is held + pixel-diffed on the CPU afterwards, so it
+        // must be fully rendered before the next iteration overwrites GPU state.
+        let previousSync = executor.synchronizeFrameCompletion
+        executor.synchronizeFrameCompletion = true
+        defer {
+            executor.isOutputPoolingEnabled = true
+            executor.synchronizeFrameCompletion = previousSync
+        }
         var out: [MTLTexture] = []
         out.reserveCapacity(frames)
         for _ in 0..<frames {

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -128,6 +128,10 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     private let snapshotter: WPEMetalTextureSnapshotter
     private var cachedSnapshot: NSImage?
     private var didLoad = false
+    /// Bumped on every load and on teardown (`reload`/`cleanup`) so a deferred
+    /// task — e.g. the off-critical-path audio startup — can detect that the
+    /// renderer has since reloaded or torn down and bail on a stale scene.
+    private var loadGeneration = 0
     private var isThrottled = false
     /// Scene-level camera parallax: the parsed settings plus the per-frame
     /// exponential smoother that drives every layer's depth shift. Neutral when
@@ -285,6 +289,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         )
         #endif
         WPEMetalCompileTimer.reset()
+        loadGeneration &+= 1
         loadTiming = WPESceneLoadTiming.isEnabled
             ? WPESceneLoadTiming(workshopID: descriptor.workshopID)
             : nil
@@ -511,12 +516,10 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         debugStage("text.load.done", "objects=\(textObjects.count)")
         try Task.checkCancellation()
 
-        debugStage("audio.start", "begin")
-        onProgress?("Starting audio runtime")
-        startSoundRuntime(from: document)
-        debugStage("audio.start.done", "runtime=\(soundRuntime == nil ? "absent" : "active")")
-        try Task.checkCancellation()
-
+        // Audio startup is deferred to after the first frame (see below): the
+        // synchronous `runtime.start(sounds:)` is a 300-900ms hit that does not
+        // gate any pixels, so keeping it on the load path only inflates perceived
+        // load time.
         debugStage("render.firstFrame", "begin")
         onProgress?("Rendering scene")
 
@@ -575,7 +578,34 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         applyPerformanceProfile(currentProfile)
         mtkView.setNeedsDisplay(mtkView.bounds)
         debugStage("render.firstFrame.done", "size=\(outputTexture?.width ?? 0)x\(outputTexture?.height ?? 0) snapshot=\(cachedSnapshot == nil ? "none" : "saved")")
+        scheduleDeferredAudioStartup(from: document)
         _ = id
+    }
+
+    /// Start the sound runtime off the load critical path. The wallpaper is
+    /// already on screen by the time this runs, so the synchronous
+    /// `runtime.start(sounds:)` (300-900ms of file load + engine spin-up) no
+    /// longer inflates perceived load time. Pending mute/volume intent set before
+    /// load completes is preserved by `startSoundRuntime`. Bails if the renderer
+    /// reloaded or tore down before the task ran (generation guard + `weak self`).
+    private func scheduleDeferredAudioStartup(from document: WPESceneDocument) {
+        guard !document.soundObjects.isEmpty else {
+            soundRuntime = nil
+            return
+        }
+        let generation = loadGeneration
+        Task { @MainActor [weak self] in
+            guard let self, self.loadGeneration == generation else { return }
+            let start = DispatchTime.now()
+            self.startSoundRuntime(from: document)
+            if WPESceneLoadTiming.isEnabled {
+                let ms = Double(DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds) / 1_000_000
+                Logger.notice(
+                    "[load-timing] scene=\(self.descriptor.workshopID) deferred-audio=\(String(format: "%.1f", ms))ms (off critical path, after first frame)",
+                    category: .performance
+                )
+            }
+        }
     }
 
     #if DEBUG
@@ -1698,6 +1728,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     }
 
     func reload() async throws {
+        loadGeneration &+= 1
         didLoad = false
         hasPresentedFrame = false
         outputTexture = nil
@@ -1907,6 +1938,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     }
 
     func cleanup() {
+        loadGeneration &+= 1
         mtkView.delegate = nil
         outputTexture = nil
         scenePropertyBindings = [:]

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -132,6 +132,20 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// task — e.g. the off-critical-path audio startup — can detect that the
     /// renderer has since reloaded or torn down and bail on a stale scene.
     private var loadGeneration = 0
+    /// Set at the end of `performLoad` for scenes with sound; consumed by the
+    /// first successful `present` in `draw(in:)`, so audio startup begins only
+    /// after the first frame is actually on screen.
+    private var pendingAudioStartupDocument: WPESceneDocument?
+    /// The in-flight off-main audio-startup task, tracked so `reload`/`cleanup`
+    /// can cancel it.
+    private var deferredAudioStartupTask: Task<Void, Never>?
+
+    #if DEBUG
+    /// Test-only: audio startup is deferred (waiting on the first present), not yet started.
+    var debugAudioStartupPending: Bool { pendingAudioStartupDocument != nil }
+    /// Test-only: the sound runtime has been published (audio actually started).
+    var debugSoundRuntimeActive: Bool { soundRuntime != nil }
+    #endif
     private var isThrottled = false
     /// Scene-level camera parallax: the parsed settings plus the per-frame
     /// exponential smoother that drives every layer's depth shift. Neutral when
@@ -155,9 +169,10 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// whenever the renderer is not throttled / suspended. Defaults to the
     /// WPE-compatible 30 FPS until `setFrameRateLimit(_:)` overrides it.
     private var userPreferredFPS: Int = WPEMetalSceneRenderer.defaultPreferredFPS
-    /// Inspector mute state cached here so callers that arrive before
-    /// `startSoundRuntime` can still record intent; `startSoundRuntime`
-    /// reads these to seed `WPESoundRuntime` at the right level.
+    /// Inspector mute state cached here so callers that arrive before the
+    /// deferred audio startup can still record intent; `beginDeferredAudioStartup`
+    /// reads these to seed `WPESoundRuntime` at the right level (and re-applies
+    /// them once the off-main start finishes, in case they changed meanwhile).
     private var pendingAudioMuted: Bool = false
     private var pendingAudioVolume: Double = 1.0
 
@@ -578,32 +593,59 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         applyPerformanceProfile(currentProfile)
         mtkView.setNeedsDisplay(mtkView.bounds)
         debugStage("render.firstFrame.done", "size=\(outputTexture?.width ?? 0)x\(outputTexture?.height ?? 0) snapshot=\(cachedSnapshot == nil ? "none" : "saved")")
-        scheduleDeferredAudioStartup(from: document)
+        // Defer audio startup to the first actual present (handled in draw(in:))
+        // so it never blocks the first visible frame. Empty-sound scenes clear
+        // any prior runtime now.
+        if document.soundObjects.isEmpty {
+            soundRuntime = nil
+            pendingAudioStartupDocument = nil
+        } else {
+            pendingAudioStartupDocument = document
+        }
         _ = id
     }
 
-    /// Start the sound runtime off the load critical path. The wallpaper is
-    /// already on screen by the time this runs, so the synchronous
-    /// `runtime.start(sounds:)` (300-900ms of file load + engine spin-up) no
-    /// longer inflates perceived load time. Pending mute/volume intent set before
-    /// load completes is preserved by `startSoundRuntime`. Bails if the renderer
-    /// reloaded or tore down before the task ran (generation guard + `weak self`).
-    private func scheduleDeferredAudioStartup(from document: WPESceneDocument) {
-        guard !document.soundObjects.isEmpty else {
+    /// Boot the sound runtime once the first frame has actually presented (called
+    /// from `draw(in:)` after the first successful `present`). The runtime is
+    /// built on the main actor — cheap — but the expensive `start(sounds:)`
+    /// (file loads + AVAudioEngine spin-up, ~300-900ms) runs OFF the main actor
+    /// so the wallpaper never stalls, then the live runtime is published back.
+    /// Bails (and stops the runtime) if the scene reloaded or tore down while
+    /// audio was starting (generation guard + cancellation). Mute/volume intent
+    /// is applied before start and re-applied after, so a toggle during the
+    /// off-main window is not lost.
+    private func beginDeferredAudioStartup() {
+        guard let document = pendingAudioStartupDocument else { return }
+        pendingAudioStartupDocument = nil
+        let sounds = document.soundObjects
+        guard !sounds.isEmpty else {
             soundRuntime = nil
             return
         }
+        let runtime = WPESoundRuntime(resolver: resourceResolver)
+        runtime.setMuted(pendingAudioMuted)
+        runtime.setMasterVolume(pendingAudioVolume)
         let generation = loadGeneration
-        Task { @MainActor [weak self] in
-            guard let self, self.loadGeneration == generation else { return }
+        let workshopID = descriptor.workshopID
+        deferredAudioStartupTask?.cancel()
+        deferredAudioStartupTask = Task.detached(priority: .userInitiated) { [weak self] in
             let start = DispatchTime.now()
-            self.startSoundRuntime(from: document)
-            if WPESceneLoadTiming.isEnabled {
-                let ms = Double(DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds) / 1_000_000
-                Logger.notice(
-                    "[load-timing] scene=\(self.descriptor.workshopID) deferred-audio=\(String(format: "%.1f", ms))ms (off critical path, after first frame)",
-                    category: .performance
-                )
+            _ = runtime.start(sounds: sounds)
+            let ms = Double(DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds) / 1_000_000
+            await MainActor.run {
+                guard let self, !Task.isCancelled, self.loadGeneration == generation else {
+                    runtime.stop()
+                    return
+                }
+                self.soundRuntime = runtime
+                runtime.setMuted(self.pendingAudioMuted)
+                runtime.setMasterVolume(self.pendingAudioVolume)
+                if WPESceneLoadTiming.isEnabled {
+                    Logger.notice(
+                        "[load-timing] scene=\(workshopID) deferred-audio=\(String(format: "%.1f", ms))ms (off main, after first present)",
+                        category: .performance
+                    )
+                }
             }
         }
     }
@@ -1341,22 +1383,6 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     }
 
     /// Phase 2D-O: spin up the audio runtime and start playback if the scene declared sound objects.
-    private func startSoundRuntime(from document: WPESceneDocument) {
-        guard !document.soundObjects.isEmpty else {
-            soundRuntime = nil
-            return
-        }
-        let runtime = WPESoundRuntime(resolver: resourceResolver)
-        // Seed the runtime with whatever pending inspector state arrived
-        // before load completed — otherwise muting a scene before it
-        // finishes loading would silently revert to the scene-declared
-        // sound.volume the moment audio starts.
-        runtime.setMuted(pendingAudioMuted)
-        runtime.setMasterVolume(pendingAudioVolume)
-        _ = runtime.start(sounds: document.soundObjects)
-        soundRuntime = runtime
-    }
-
     /// Phase 2D-N: build the WPETextRenderer + cache the parsed text object list.
     private func loadTextOverlays(from document: WPESceneDocument) {
         textObjects = document.textObjects
@@ -1729,6 +1755,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
 
     func reload() async throws {
         loadGeneration &+= 1
+        deferredAudioStartupTask?.cancel()
+        deferredAudioStartupTask = nil
+        pendingAudioStartupDocument = nil
         didLoad = false
         hasPresentedFrame = false
         outputTexture = nil
@@ -1862,9 +1891,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     }
 
     /// Forwards the inspector's mute toggle into the scene's audio
-    /// runtime. Cached so calls that arrive before `startSoundRuntime`
-    /// (which only fires from `performLoad`) still take effect once the
-    /// runtime exists.
+    /// runtime. Cached so calls that arrive before the deferred audio
+    /// startup (which fires after the first present) still take effect once
+    /// the runtime exists.
     func setAudioMuted(_ muted: Bool) {
         pendingAudioMuted = muted
         soundRuntime?.setMuted(muted)
@@ -1873,7 +1902,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
     /// Forwards the inspector's audio slider into the scene's audio
     /// runtime as a master gain multiplied into each scene-declared
     /// `sound.volume`. Cached so pre-load calls survive across the
-    /// `startSoundRuntime` boundary.
+    /// deferred audio-startup boundary.
     func setAudioVolume(_ volume: Double) {
         pendingAudioVolume = volume
         soundRuntime?.setMasterVolume(volume)
@@ -1939,6 +1968,9 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
 
     func cleanup() {
         loadGeneration &+= 1
+        deferredAudioStartupTask?.cancel()
+        deferredAudioStartupTask = nil
+        pendingAudioStartupDocument = nil
         mtkView.delegate = nil
         outputTexture = nil
         scenePropertyBindings = [:]
@@ -1989,7 +2021,12 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
                     textureToPresent = outputTexture
                 }
                 guard let texture = textureToPresent else { return }
-                _ = try executor.present(texture: texture, in: view)
+                let presented = try executor.present(texture: texture, in: view)
+                // Start audio only after the first frame is actually on screen, so
+                // the synchronous engine spin-up can never delay the first pixels.
+                if presented, pendingAudioStartupDocument != nil {
+                    beginDeferredAudioStartup()
+                }
             } catch {
                 Logger.warning("Experimental Metal scene present failed: \(error.localizedDescription)", category: .screenManager)
             }

--- a/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/WPEMetalSceneRenderer.swift
@@ -284,6 +284,7 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
             descriptor: descriptorSummary
         )
         #endif
+        WPEMetalCompileTimer.reset()
         loadTiming = WPESceneLoadTiming.isEnabled
             ? WPESceneLoadTiming(workshopID: descriptor.workshopID)
             : nil
@@ -528,6 +529,14 @@ final class WPEMetalSceneRenderer: NSObject, WallpaperPerformanceConfigurable, W
         let capture = beginGPUCaptureIfRequested()
         outputTexture = try renderCurrentFrame()
         capture?.stop()
+        if WPESceneLoadTiming.isEnabled {
+            // How much of render.firstFrame was one-time shader/pipeline
+            // compilation (cacheable via a binary archive) vs GPU work.
+            Logger.notice(
+                "[load-timing] scene=\(descriptor.workshopID) metal-compile=\(String(format: "%.1f", WPEMetalCompileTimer.milliseconds))ms (shader+pipeline, lands inside render.firstFrame)",
+                category: .performance
+            )
+        }
 
         if let outputTexture {
             // Capture per-pass scene-target RT hashes BEFORE finishFrame latches

--- a/LiveWallpaper/Runtime/WPESceneLoadTiming.swift
+++ b/LiveWallpaper/Runtime/WPESceneLoadTiming.swift
@@ -1,0 +1,78 @@
+#if !LITE_BUILD
+import Foundation
+import LiveWallpaperCore
+
+/// Lightweight per-load stage profiler. It records monotonic timestamps at the
+/// stage breadcrumbs the renderer already emits via `debugStage`, and once the
+/// first frame is done logs one compact per-phase breakdown line — so scene load
+/// cost can be measured and compared (e.g. before/after the pipeline cache).
+///
+/// Opt-in via the `WPEMetalLoadTiming` UserDefault (Developer Tools → "Load
+/// timing"); the renderer only allocates a probe when it is set, so a normal run
+/// pays nothing. Independent of the scene-debug switch so timing can be gathered
+/// without the PNG/shader dump machinery.
+///
+/// Phase durations pair every stage `X` with its `X.done` marker. Sub-event
+/// markers without a `.done` counterpart (`pipeline.pass`, `particle`,
+/// `tex.lazy.*`) are sub-steps of a phase and are ignored in the summary.
+final class WPESceneLoadTiming {
+    static let defaultsKey = "WPEMetalLoadTiming"
+    static var isEnabled: Bool { UserDefaults.standard.bool(forKey: defaultsKey) }
+
+    /// The stage whose marker closes the load window and triggers the summary.
+    /// Markers recorded after it (e.g. the playback `heartbeat`) are ignored.
+    static let terminalStage = "render.firstFrame.done"
+
+    private let workshopID: String
+    private let clock: () -> DispatchTime
+    private var marks: [(stage: String, time: DispatchTime)] = []
+    private var emitted = false
+
+    init(workshopID: String, clock: @escaping () -> DispatchTime = { DispatchTime.now() }) {
+        self.workshopID = workshopID
+        self.clock = clock
+    }
+
+    func mark(_ stage: String) {
+        guard !emitted else { return }
+        marks.append((stage, clock()))
+        if stage == Self.terminalStage {
+            emitted = true
+            if let summary = Self.summarize(workshopID: workshopID, marks: marks) {
+                Logger.notice(summary, category: .performance)
+            }
+        }
+    }
+
+    /// Pure summary builder (no logging) so the format is unit-testable with an
+    /// injected clock. Returns nil when there is nothing to report.
+    static func summarize(workshopID: String, marks: [(stage: String, time: DispatchTime)]) -> String? {
+        guard let first = marks.first?.time, let last = marks.last?.time, marks.count > 1 else {
+            return nil
+        }
+        // First occurrence of each stage name (a phase's begin/done are unique;
+        // repeated sub-event markers collapse to their first sighting).
+        var firstSeen: [String: DispatchTime] = [:]
+        for mark in marks where firstSeen[mark.stage] == nil {
+            firstSeen[mark.stage] = mark.time
+        }
+        var phases: [(stage: String, ms: Double)] = []
+        for (stage, begin) in firstSeen where !stage.hasSuffix(".done") {
+            guard let done = firstSeen["\(stage).done"] else { continue }
+            phases.append((stage, milliseconds(from: begin, to: done)))
+        }
+        phases.sort { $0.ms > $1.ms }
+        let breakdown = phases.map { "\($0.stage)=\(format($0.ms))ms" }.joined(separator: " ")
+        let total = format(milliseconds(from: first, to: last))
+        return "[load-timing] scene=\(workshopID) total=\(total)ms | \(breakdown)"
+    }
+
+    private static func milliseconds(from a: DispatchTime, to b: DispatchTime) -> Double {
+        Double(b.uptimeNanoseconds &- a.uptimeNanoseconds) / 1_000_000
+    }
+
+    private static func format(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/WPESoundRuntime.swift
+++ b/LiveWallpaper/Runtime/WPESoundRuntime.swift
@@ -54,8 +54,22 @@ final class WPESoundRuntime: @unchecked Sendable {
         self.imagBuffer = [Float](repeating: 0, count: Self.fftSize / 2)
     }
 
-    /// Boot the engine.
+    /// Convenience: `prepare` + `play` in one call (used by tests). The renderer
+    /// splits the two so the expensive `prepare` runs off the main actor and
+    /// `play` only happens once the scene is confirmed current.
+    @discardableResult
     func start(sounds: [WPESceneSoundObject]) -> Int {
+        let attached = prepare(sounds: sounds)
+        play()
+        return attached
+    }
+
+    /// Resolve + decode the sound files and wire up the engine WITHOUT starting
+    /// playback. This is the expensive part (file I/O + PCM buffer load,
+    /// ~300-900ms) and is safe to run off the main actor; nothing is audible
+    /// until `play()`. Returns the number of attached players.
+    @discardableResult
+    func prepare(sounds: [WPESceneSoundObject]) -> Int {
         let mainMixer = engine.mainMixerNode
         let outputFormat = mainMixer.outputFormat(forBus: 0)
 
@@ -88,18 +102,26 @@ final class WPESoundRuntime: @unchecked Sendable {
         mainMixer.installTap(onBus: 0, bufferSize: bufferSize, format: outputFormat) { [weak self] buffer, _ in
             self?.processTap(buffer: buffer)
         }
+        engine.prepare()
+        return attached
+    }
 
+    /// Start the engine and begin looping playback. Fast — call only after the
+    /// caller has confirmed the scene is still current. No-op-safe when nothing
+    /// was prepared. Returns false (and removes the tap) if the engine won't start.
+    @discardableResult
+    func play() -> Bool {
+        guard !players.isEmpty else { return false }
         do {
             try engine.start()
         } catch {
-            mainMixer.removeTap(onBus: 0)
-            return 0
+            engine.mainMixerNode.removeTap(onBus: 0)
+            return false
         }
-
         for player in players {
             player.play()
         }
-        return attached
+        return true
     }
 
     func stop() {

--- a/LiveWallpaper/Runtime/WPESwiftShaderCompiler.swift
+++ b/LiveWallpaper/Runtime/WPESwiftShaderCompiler.swift
@@ -62,7 +62,7 @@ struct WPESwiftShaderCompiler: WPEShaderCompiling {
         do {
             let options = MTLCompileOptions()
             options.languageVersion = .version3_0
-            library = try device.makeLibrary(source: translation.mslSource, options: options)
+            library = try WPEMetalCompileTimer.measure { try device.makeLibrary(source: translation.mslSource, options: options) }
         } catch {
             WPESceneDebugArtifacts.shared.recordShaderFailure(
                 shaderName: request.shaderName,

--- a/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
+++ b/LiveWallpaper/Views/Settings/DeveloperToolsView.swift
@@ -251,6 +251,8 @@ struct DeveloperToolsView: View {
         var flags: [DiagnosticBoolFlag] = [
             .init(key: "WPESceneDebugArtifactsEnabled", title: "Scene debug artifacts",
                   help: "Write per-scene logs, first-frame snapshot, and texture metadata to scene-debug."),
+            .init(key: "WPEMetalLoadTiming", title: "Load timing",
+                  help: "Log a per-phase scene-load time breakdown ([load-timing] …) at first frame, for measuring + comparing load cost."),
             .init(key: "WPEAudioCaptureProbe", title: "Audio capture probe",
                   help: "Probe the Core Audio process tap under the sandbox (audio-reactive bring-up)."),
             .init(key: "WPEAudioDebugLog", title: "Audio debug log",

--- a/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
+++ b/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
@@ -1786,6 +1786,11 @@ struct WPEMetalRenderExecutorTests {
             0, 0, 0, 0
         ]))
         mask.label = "mask-texture"
+        // recordTextureBinding only records while scene-debug is enabled (now
+        // opt-in by default), so force it on for the duration of this diagnostic
+        // test rather than depending on the global default or test run order.
+        WPESceneDebugArtifacts.shared.setEnabledForTesting(true)
+        defer { WPESceneDebugArtifacts.shared.setEnabledForTesting(nil) }
         _ = WPESceneDebugArtifacts.shared.drainBindingDiagnosticsForTesting()
         defer { _ = WPESceneDebugArtifacts.shared.drainBindingDiagnosticsForTesting() }
 
@@ -1857,6 +1862,11 @@ struct WPEMetalRenderExecutorTests {
             0, 255, 0, 255
         ]))
         primary.label = "base-texture"
+        // recordTextureBinding only records while scene-debug is enabled (now
+        // opt-in by default), so force it on for the duration of this diagnostic
+        // test rather than depending on the global default or test run order.
+        WPESceneDebugArtifacts.shared.setEnabledForTesting(true)
+        defer { WPESceneDebugArtifacts.shared.setEnabledForTesting(nil) }
         _ = WPESceneDebugArtifacts.shared.drainBindingDiagnosticsForTesting()
         defer { _ = WPESceneDebugArtifacts.shared.drainBindingDiagnosticsForTesting() }
 

--- a/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
+++ b/LiveWallpaperTests/WPEMetalRenderExecutorTests.swift
@@ -35,6 +35,47 @@ struct WPEMetalRenderExecutorTests {
         #expect(pixel.a >= 250)
     }
 
+    @Test("Async submission renders past the in-flight bound without deadlock")
+    func asyncSubmissionDoesNotDeadlock() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let executor = try WPEMetalRenderExecutor(device: device)
+        func makePipeline() -> WPEPreparedRenderPipeline {
+            let pass = solidPass()
+            return WPEPreparedRenderPipeline(layers: [
+                WPEPreparedRenderLayer(
+                    graphLayer: graphLayer(pass: pass),
+                    passes: [WPEPreparedRenderPass(
+                        pass: pass,
+                        shader: WPEShaderProgram(name: "solidcolor", vertexSource: "", fragmentSource: "", isBuiltin: true),
+                        textureBindings: [:],
+                        comboValues: [:],
+                        uniformValues: ["g_Color": .vector([1, 0, 0, 1])]
+                    )]
+                )
+            ])
+        }
+
+        // Submit more frames than the in-flight bound. If a completion handler
+        // failed to signal the semaphore, the (maxFramesInFlight+1)th call would
+        // block here forever — so reaching the end proves the permit accounting
+        // balances under async submission.
+        executor.synchronizeFrameCompletion = false
+        let size = CGSize(width: 4, height: 4)
+        for _ in 0..<(WPEMetalRenderExecutor.maxFramesInFlight + 3) {
+            let output = try executor.render(pipeline: makePipeline(), size: size, textures: [:])
+            #expect(output.width == 4)
+        }
+
+        // Back on the synchronous path the same executor still renders correct
+        // pixels (semaphore balanced, output ring intact after the async run).
+        executor.synchronizeFrameCompletion = true
+        let output = try executor.render(pipeline: makePipeline(), size: size, textures: [:])
+        let pixel = try readPixel(output, x: 2, y: 2)
+        #expect(pixel.r >= 250)
+        #expect(pixel.g <= 5)
+        #expect(pixel.b <= 5)
+    }
+
     @Test("Custom shader without recognizable main surfaces a precise translator error")
     func rejectsUntranslatableCustomShader() throws {
         let device = try #require(MTLCreateSystemDefaultDevice())

--- a/LiveWallpaperTests/WPEMetalSceneRendererTests.swift
+++ b/LiveWallpaperTests/WPEMetalSceneRendererTests.swift
@@ -369,10 +369,38 @@ struct WPEMetalSceneRendererTests {
         )
 
         // Before load: soundRuntime is nil, the calls should not crash
-        // and the state is cached for later application during startSoundRuntime.
+        // and the state is cached for later application by the deferred audio startup.
         renderer.setAudioMuted(true)
         renderer.setAudioVolume(0.4)
         #expect(true)
+    }
+
+    @Test("Audio startup is deferred until the first present, not started during load")
+    func audioStartupIsDeferredUntilPresent() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try MetalSceneFixture.soundScene()
+        defer { fixture.cleanup() }
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.root,
+            dependencyMounts: [],
+            frame: CGRect(x: 0, y: 0, width: 64, height: 64),
+            device: device
+        )
+
+        try await renderer.load()
+
+        // load() rendered the first frame, but audio must NOT have started
+        // synchronously — it is deferred to the first present, which a headless
+        // test never triggers. The scene's sound objects leave it pending.
+        #expect(renderer.debugSoundRuntimeActive == false)
+        #expect(renderer.debugAudioStartupPending == true)
+
+        // Tearing down (cleanup) clears the pending startup + cancels the task so
+        // a late present can't boot a stale scene's audio. (reload(), by contrast,
+        // re-loads and legitimately re-defers, so it is not the invalidation case.)
+        renderer.cleanup()
+        #expect(renderer.debugAudioStartupPending == false)
     }
 }
 
@@ -508,6 +536,44 @@ private struct MetalSceneFixture {
                 capabilityTier: .imageOnly
             ),
             dependencyRoot: dependencyRoot
+        )
+    }
+
+    /// An image layer plus a sound object. The sound file need not exist: audio
+    /// startup is deferred to the first present (never triggered in a headless
+    /// test), so `start()` — the only thing that reads the file — is never called.
+    static func soundScene() throws -> MetalSceneFixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WPEMetalSceneRenderer-\(UUID().uuidString)", isDirectory: true)
+        let models = root.appendingPathComponent("models", isDirectory: true)
+        let materials = root.appendingPathComponent("materials", isDirectory: true)
+        try FileManager.default.createDirectory(at: models, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: materials, withIntermediateDirectories: true)
+        try writePNG(at: materials.appendingPathComponent("base.png"), color: CGColor(red: 0, green: 0, blue: 1, alpha: 1))
+        try Data(#"{ "material": "materials/base.json" }"#.utf8)
+            .write(to: models.appendingPathComponent("base.json"))
+        try Data(#"{ "passes": [{ "shader": "genericimage2", "textures": ["materials/base.png"] }] }"#.utf8)
+            .write(to: materials.appendingPathComponent("base.json"))
+        let scene = """
+        {
+          "camera": { "center": "0 0 0" },
+          "general": { "orthogonalprojection": { "width": 64, "height": 64, "auto": true } },
+          "objects": [
+            { "id": "img", "name": "Img", "type": "image", "image": "models/base.json", "origin": "0.5 0.5 0", "scale": "1 1 1", "alpha": 1 },
+            { "id": "snd", "name": "Loop", "type": "sound", "sound": ["sounds/loop.mp3"] }
+          ]
+        }
+        """
+        try Data(scene.utf8).write(to: root.appendingPathComponent("scene.json"))
+        return MetalSceneFixture(
+            root: root,
+            descriptor: SceneDescriptor(
+                workshopID: UUID().uuidString,
+                cacheRelativePath: "wpe-cache/test",
+                entryFile: "scene.json",
+                capabilityTier: .imageOnly
+            ),
+            dependencyRoot: nil
         )
     }
 

--- a/LiveWallpaperTests/WPESceneLoadTimingTests.swift
+++ b/LiveWallpaperTests/WPESceneLoadTimingTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+@Suite("WPE scene load timing")
+struct WPESceneLoadTimingTests {
+    private func t(_ msFromZero: Double) -> DispatchTime {
+        DispatchTime(uptimeNanoseconds: UInt64(msFromZero * 1_000_000))
+    }
+
+    @Test("Summary pairs X/X.done, sorts phases descending, totals the window")
+    func summarizesPhases() throws {
+        let marks: [(stage: String, time: DispatchTime)] = [
+            ("load.begin", t(0)),
+            ("read.entry", t(0)),
+            ("read.entry.done", t(10)),
+            ("graph.build", t(10)),
+            ("graph.build.done", t(40)),
+            ("pipeline.build", t(40)),
+            ("pipeline.pass", t(50)),   // per-pass sub-event: no `.done`, excluded
+            ("pipeline.pass", t(60)),
+            ("pipeline.build.done", t(440)),
+            ("render.firstFrame", t(440)),
+            ("render.firstFrame.done", t(500)),
+        ]
+        let summary = try #require(WPESceneLoadTiming.summarize(workshopID: "123", marks: marks))
+
+        #expect(summary.contains("scene=123"))
+        #expect(summary.contains("total=500.0ms"))
+        #expect(summary.contains("pipeline.build=400.0ms"))
+        #expect(summary.contains("graph.build=30.0ms"))
+        #expect(summary.contains("read.entry=10.0ms"))
+        #expect(summary.contains("render.firstFrame=60.0ms"))
+        #expect(!summary.contains("pipeline.pass"))
+
+        // Phases are sorted by descending cost: pipeline.build (400) precedes render.firstFrame (60).
+        let pipeline = try #require(summary.range(of: "pipeline.build="))
+        let firstFrame = try #require(summary.range(of: "render.firstFrame="))
+        #expect(pipeline.lowerBound < firstFrame.lowerBound)
+    }
+
+    @Test("Returns nil with fewer than two marks")
+    func nilWhenInsufficientMarks() {
+        #expect(WPESceneLoadTiming.summarize(workshopID: "x", marks: []) == nil)
+        #expect(WPESceneLoadTiming.summarize(workshopID: "x", marks: [("load.begin", t(0))]) == nil)
+    }
+}

--- a/LiveWallpaperTests/WPESoundRuntimeTests.swift
+++ b/LiveWallpaperTests/WPESoundRuntimeTests.swift
@@ -128,4 +128,35 @@ struct WPESoundRuntimeTests {
         // does not throw on out-of-range input.
         #expect(true)
     }
+
+    @Test("prepare() attaches without playing; play() is a no-op when nothing prepared")
+    func prepareDefersPlayback() throws {
+        let resolver = WPEMultiRootResourceResolver(
+            primaryRootURL: FileManager.default.temporaryDirectory,
+            dependencyMounts: []
+        )
+        let runtime = WPESoundRuntime(resolver: resolver)
+        defer { runtime.stop() }
+        // No resolvable sound files → nothing attaches. prepare must not throw,
+        // and play() returns false (no players) — the empty/guard path the
+        // deferred-audio fix relies on so nothing ever plays prematurely.
+        let attached = runtime.prepare(sounds: [])
+        #expect(attached == 0)
+        #expect(runtime.play() == false)
+    }
+
+    @Test("prepare() then stop() without play() (stale-scene teardown) is safe")
+    func prepareThenStopWithoutPlayIsSafe() throws {
+        let resolver = WPEMultiRootResourceResolver(
+            primaryRootURL: FileManager.default.temporaryDirectory,
+            dependencyMounts: []
+        )
+        let runtime = WPESoundRuntime(resolver: resolver)
+        // Simulates the deferred-audio path bailing on reload/cleanup: prepared
+        // off-main, but the generation changed so play() never ran. stop() must
+        // release the engine cleanly without a prior play().
+        _ = runtime.prepare(sounds: [])
+        runtime.stop()
+        #expect(true)
+    }
 }


### PR DESCRIPTION
Speeds up WPE scene load and lowers steady-state CPU/GPU cost. Headline changes: per-frame `waitUntilCompleted` → async, semaphore-bounded submission (revertible via `WPEMetalSerializeFrames`); and the synchronous audio-engine startup moved off the load critical path — off-main, triggered after the first present, with a load-generation/cancellation guard (codex-reviewed).

Also: opt-in load-timing + compile-split diagnostics (`WPEMetalLoadTiming`), debug-log/clip-log gating behind the scene-debug switch, and the first-frame readback-race fix. Validated on-device — typical scenes load ~4× faster (1.6s→0.36–0.56s); heavy scenes hit an intrinsic first-frame GPU floor (caching ruled out by measurement). 88 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)