### PR TITLE
fix(wpe-puppet): variant visibility inheritance + refuse unsupported MDLV0019 scenes

### DIFF
--- a/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderGraphBuilder.swift
@@ -82,6 +82,7 @@ struct WPERenderGraphBuilder: Sendable {
         let liveVisibilityIDs = Self.userToggleableVisibilityIDs(in: document)
         let visibleLayerIDs = Set(document.imageObjects
             .filter { Self.compositesToScene($0, liveVisibilityIDs: liveVisibilityIDs) }
+            .filter { !Self.hasHiddenAncestor($0, objectByID: objectByID, liveVisibilityIDs: liveVisibilityIDs) }
             .map(\.id))
         var layerIDsToBuild = visibleLayerIDs
         var pendingIDs = Array(visibleLayerIDs)
@@ -351,12 +352,44 @@ struct WPERenderGraphBuilder: Sendable {
         return object.visible || liveVisibilityIDs.contains(object.id)
     }
 
+    /// True when any ancestor up the `parentObjectID` chain is explicitly hidden
+    /// (`visible == false`). WPE propagates a parent's visibility to its children, so a
+    /// body-split rig's face/mask/body child layers (authored `visible: true`) must inherit
+    /// the hidden state of a conditionally-hidden variant parent. Without this, the visible
+    /// children of a hidden style variant still composited — 3226487183 drew its 默认/面具/抬头
+    /// poses (and their masks) all at once. A container that is merely alpha-0 keeps
+    /// `visible == true`, so a transparent grouping layer never suppresses its own subtree.
+    static func hasHiddenAncestor(
+        _ object: WPESceneImageObject,
+        objectByID: [String: WPESceneImageObject],
+        liveVisibilityIDs: Set<String>
+    ) -> Bool {
+        var seen: Set<String> = []
+        var current = object.parentObjectID
+        while let id = current, seen.insert(id).inserted, let parent = objectByID[id] {
+            // A user-toggleable (condition-less) hidden parent stays in the graph so a live
+            // visibility toggle can re-show it — its authored-visible children must stay too,
+            // or toggling the parent back on would reveal an empty subtree. Only an ancestor
+            // that is hidden AND not live-toggleable (e.g. a resolved style-selector variant)
+            // suppresses its subtree.
+            if !parent.visible && !liveVisibilityIDs.contains(parent.id) { return true }
+            current = parent.parentObjectID
+        }
+        return false
+    }
+
     /// Image-object IDs that have an incremental (`visible`) property binding —
     /// i.e. their on-screen visibility can be toggled live from project settings.
     private static func userToggleableVisibilityIDs(in document: WPESceneDocument) -> Set<String> {
         var ids = Set<String>()
         for bindings in document.propertyBindings.values {
-            for binding in bindings where binding.kind == .visible && binding.action == .incremental {
+            // Condition-form (style-selector / combo) visibility is resolved from the combo
+            // value at build time, not a live boolean toggle. Treating it as live-toggleable
+            // put conditionally-hidden variant layers into the always-composite set, so every
+            // style variant (默认/面具/抬头) rendered at once (3226487183). Only simple,
+            // condition-less `visible` bindings are genuine live toggles.
+            for binding in bindings
+            where binding.kind == .visible && binding.action == .incremental && binding.condition == nil {
                 if case .imageObject(let id) = binding.target {
                     ids.insert(id)
                 }

--- a/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
+++ b/LiveWallpaper/Infrastructure/WPERenderPipelineBuilder.swift
@@ -52,32 +52,46 @@ struct WPERenderPipelineBuilder: Sendable {
             }
             return WPEPreparedRenderLayer(
                 graphLayer: layer,
-                puppetModel: loadPuppetModel(for: layer),
+                puppetModel: try loadPuppetModel(for: layer),
                 passes: passes
             )
         }
         return WPEPreparedRenderPipeline(layers: layers)
     }
 
-    private func loadPuppetModel(for layer: WPERenderLayer) -> WPEPuppetModel? {
+    private func loadPuppetModel(for layer: WPERenderLayer) throws -> WPEPuppetModel? {
         guard let puppetPath = layer.puppetPath else { return nil }
+        let model: WPEPuppetModel
         do {
             let data = try resolver.data(relativePath: puppetPath)
-            let model = try WPEMdlParser.parse(data: data)
-            // Only the modern pre-assembled puppet generations (MDLV0021/0023)
-            // ship MDLV vertices already in assembled object space, which the
-            // renderer can draw directly. Older generations (e.g. MDLV0019)
-            // store an *exploded* "pieces" mesh whose assembled pose is produced
-            // by WPE's editor-side puppet solver and is not recoverable from the
-            // file (the bind/tp/MDLA data does not encode it). The reference
-            // linux-wallpaperengine likewise renders only MDLV0021/0023 and
-            // rejects older meshes. Degrade those objects to their flat material
-            // image rather than drawing scattered pieces.
-            guard model.version >= 21 else { return nil }
-            return model
+            model = try WPEMdlParser.parse(data: data)
         } catch {
+            // Missing / corrupt .mdl → degrade to the flat material image (unchanged).
             return nil
         }
+        // Only the modern pre-assembled puppet generations (MDLV0021/0023) ship MDLV
+        // vertices already in assembled object space, which the renderer can draw
+        // directly. Older generations (MDLV0019 and below) store an *exploded* "pieces"
+        // mesh whose assembled pose is produced by WPE's closed editor-side puppet solver
+        // and is NOT recoverable from the file (verified 2026-06-22 via vertex-occupancy
+        // analysis: the mesh is genuinely disjoint clusters; linux-wallpaperengine also
+        // rejects <21). Drawing them — as a mesh or as the flat atlas — yields scattered,
+        // misaligned puppets. Per the product decision, refuse the whole scene with a
+        // warning instead of shipping a misaligned wallpaper, rather than silently
+        // degrading to a broken flat render.
+        guard model.version >= 21 else {
+            let generation = String(format: "MDLV%04d", model.version)
+            Logger.warning(
+                "WPE scene uses unsupported puppet generation \(generation) "
+                    + "('\(puppetPath)'); refusing to render to avoid a misaligned wallpaper.",
+                category: .wpeRender
+            )
+            throw SceneRenderingError.metalRendererUnsupported(
+                reason: "this wallpaper uses the legacy \(generation) puppet format, "
+                    + "which this renderer cannot assemble correctly"
+            )
+        }
+        return model
     }
 
     private func preparedPass(for pass: WPERenderPass) throws -> WPEPreparedRenderPass {

--- a/LiveWallpaperTests/WPERenderGraphBuilderTests.swift
+++ b/LiveWallpaperTests/WPERenderGraphBuilderTests.swift
@@ -783,6 +783,91 @@ struct WPERenderGraphBuilderTests {
         #expect(geometry.brightness == 1.25)
     }
 
+    @Test("A hidden parent suppresses its visible children from the scene (variant visibility inheritance)")
+    func hiddenAncestorSuppressesVisibleChildren() throws {
+        func image(_ id: String, visible: Bool, parent: String?) -> WPESceneImageObject {
+            WPESceneImageObject(
+                id: id,
+                name: id,
+                imageRelativePath: "materials/\(id).png",
+                materialRelativePath: nil,
+                parentObjectID: parent,
+                origin: SIMD3<Double>(0, 0, 0),
+                scale: SIMD3<Double>(1, 1, 1),
+                angles: SIMD3<Double>(0, 0, 0),
+                visible: visible,
+                alpha: 1,
+                color: SIMD3<Double>(1, 1, 1),
+                brightness: 1,
+                blendMode: .normal,
+                alignment: .center,
+                size: nil,
+                effects: [],
+                animationLayers: [],
+                parallaxDepth: SIMD2<Double>(0, 0)
+            )
+        }
+        // A body-split style variant: a hidden variant background with an authored-visible
+        // child body, alongside the shown variant. Only the shown variant's subtree should
+        // composite — the hidden variant's visible child must inherit the hidden state.
+        let document = WPESceneDocument(
+            camera: .defaultCamera,
+            general: .defaultGeneral,
+            imageObjects: [
+                image("hiddenVariant", visible: false, parent: nil),
+                image("hiddenChildBody", visible: true, parent: "hiddenVariant"),
+                image("hiddenGrandchildMask", visible: true, parent: "hiddenChildBody"),
+                image("shownVariant", visible: true, parent: nil),
+                image("shownChildBody", visible: true, parent: "shownVariant")
+            ],
+            diagnostics: []
+        )
+
+        let graph = try WPERenderGraphBuilder(
+            cacheRootURL: FileManager.default.temporaryDirectory
+        ).build(document: document)
+
+        let built = Set(graph.layers.map(\.objectID))
+        // Hidden variant and its (authored-visible) descendants are dropped from the graph.
+        #expect(!built.contains("hiddenVariant"))
+        #expect(!built.contains("hiddenChildBody"))
+        #expect(!built.contains("hiddenGrandchildMask"))
+        // The shown variant subtree is unaffected.
+        #expect(built.contains("shownVariant"))
+        #expect(built.contains("shownChildBody"))
+    }
+
+    @Test("A visible child of a user-toggleable (condition-less) hidden parent stays in the graph")
+    func liveToggleableHiddenParentKeepsVisibleChildren() throws {
+        // Parser-driven so the real property-binding → live-visibility flow runs: the parent
+        // resolves hidden (toggle == false) but its `visible` binding is a condition-less live
+        // toggle, so it stays in the graph — and so must its authored-visible child, otherwise
+        // toggling the parent back on at runtime would reveal an empty subtree.
+        let payload: [String: Any] = [
+            "camera": ["center": "0 0 0"],
+            "general": ["orthogonalprojection": ["width": 1920, "height": 1080, "auto": true]],
+            "objects": [
+                [
+                    "id": 1, "name": "toggleParent", "image": "models/util/solidlayer.json",
+                    "visible": ["user": "toggle", "value": true]
+                ],
+                [
+                    "id": 2, "name": "child", "image": "models/util/solidlayer.json",
+                    "parent": 1, "visible": true
+                ]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        let document = try WPESceneDocumentParser.parse(data: data, userValues: ["toggle": .bool(false)])
+        #expect(document.imageObjects.first(where: { $0.id == "1" })?.visible == false)
+
+        let graph = try WPERenderGraphBuilder(
+            cacheRootURL: FileManager.default.temporaryDirectory
+        ).build(document: document)
+
+        #expect(Set(graph.layers.map(\.objectID)).contains("2"))
+    }
+
     @Test("Underscore-prefixed texture refs route through .fbo regardless of suffix")
     func underscorePrefixTexturesRouteToFBO() throws {
         let root = FileManager.default.temporaryDirectory

--- a/LiveWallpaperTests/WPERenderPipelineBuilderTests.swift
+++ b/LiveWallpaperTests/WPERenderPipelineBuilderTests.swift
@@ -214,6 +214,57 @@ struct WPERenderPipelineBuilderTests {
         #expect(mesh.parts == [WPEPuppetMeshPart(id: 7, start: 0, count: 3)])
     }
 
+    @Test("A legacy MDLV<21 puppet refuses the whole scene instead of rendering it misaligned")
+    func legacyPuppetGenerationRefusesScene() throws {
+        // Same parseable puppet, but tagged MDLV0019 (the exploded-pieces generation we
+        // cannot assemble). loadPuppetModel must throw so the scene is skipped + warned,
+        // not silently degraded to a scattered render.
+        var legacyMDL = makeSingleTrianglePuppetMDL()
+        legacyMDL.replaceSubrange(0..<8, with: "MDLV0019".utf8)
+        let fixture = try makeFixture(dataFiles: [
+            "models/layer_puppet.mdl": legacyMDL
+        ])
+        defer { fixture.cleanup() }
+
+        let graph = WPERenderGraph(layers: [
+            WPERenderLayer(
+                objectID: "7",
+                objectName: "Layer",
+                imagePath: "models/layer.json",
+                materialPath: "materials/layer.json",
+                puppetPath: "models/layer_puppet.mdl",
+                geometry: .identity,
+                compositeA: "_rt_imageLayerComposite_7_a",
+                compositeB: "_rt_imageLayerComposite_7_b",
+                localFBOs: [],
+                passes: [
+                    WPERenderPass(
+                        id: "7.0",
+                        phase: .material,
+                        shader: "genericimage4",
+                        source: .image("materials/layer.png"),
+                        target: .layerComposite(name: "_rt_imageLayerComposite_7_a"),
+                        textures: [:],
+                        binds: [:],
+                        constants: [:],
+                        combos: [:],
+                        blending: "normal",
+                        cullMode: "nocull",
+                        depthTest: "disabled",
+                        depthWrite: "disabled"
+                    )
+                ]
+            )
+        ])
+
+        #expect {
+            _ = try WPERenderPipelineBuilder(cacheRootURL: fixture.root).build(graph: graph)
+        } throws: { error in
+            guard case SceneRenderingError.metalRendererUnsupported(let reason) = error else { return false }
+            return reason.contains("MDLV0019")
+        }
+    }
+
     @Test("Loads puppet model through dependency mounts")
     func loadsPuppetModelThroughDependencyMounts() throws {
         let fixture = try makeFixture()


### PR DESCRIPTION
Body-split puppet scenes rendered as scattered/overlapping characters. This propagates parent visibility so only the active style variant composites (instead of all variants at once), and refuses unsupported MDLV0019 "exploded-pieces" puppet scenes with a clear warning rather than shipping a misaligned wallpaper.

Build + affected test suites green (89 tests across graph/pipeline/parser/mdl), incl. new regression tests. Note: a known trade-off — live style-selector switching is deferred for selector scenes (static render is correct); see review discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)