### PR TITLE
Cut scene-runtime memory and CPU, and stop shipping the Metal capture layer

### DIFF
--- a/LiveWallpaper/App/LiveWallpaperApp.swift
+++ b/LiveWallpaper/App/LiveWallpaperApp.swift
@@ -76,6 +76,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @ObservationIgnored private let runtimeOptions = AppRuntimeOptions()
     @ObservationIgnored private var settingsWindowController: NSWindowController?
+    /// Lifecycle-probe seam for SettingsWindowLifecycleTests; production code
+    /// must not present or mutate through this.
+    var settingsWindowControllerForTesting: NSWindowController? { settingsWindowController }
     @ObservationIgnored private var settingsOwnsSystemMonitorLease = false
     @ObservationIgnored private var onboardingWindowController: NSWindowController?
     /// See `WeatherReactiveService.preferenceObserver` — same pattern.
@@ -322,23 +325,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Settings Window
 
-    /// No launch-time caller anymore (the automatic prewarm kept the whole
-    /// SwiftUI tree resident in a background app); the window is built on first
-    /// `showSettings`. Kept because SamplerOwnershipTests slices this function.
-    func prewarmSettingsWindow() {
-        guard lifecycle.allowsWork,
-              settingsWindowController == nil,
-              let manager = screenManager
-        else { return }
-
-        settingsWindowController = makeSettingsWindowController(
-            manager: manager,
-            initialNavigation: nil,
-            initialAddWallpaperPromptKind: nil
-        )
-        Logger.info("Settings window prewarmed", category: .ui)
-    }
-
     func showSettings(
         initialScreenID: CGDirectDisplayID? = nil,
         initialAddWallpaperPromptKind: String? = nil,
@@ -406,7 +392,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         window.titleVisibility = .hidden
         window.backgroundColor = .windowBackgroundColor
         window.isMovableByWindowBackground = false
-        // Pair with `windowShouldClose` returning false: the close button only `orderOut`s the window so the warmed NavigationSplitView state survives.
+        // ARC owns the window through the controller; `windowWillClose` drops
+        // both so closing destroys the whole hierarchy instead of AppKit
+        // double-releasing it.
         window.isReleasedWhenClosed = false
         window.center()
         window.contentView = NSHostingView(rootView: contentView)
@@ -554,13 +542,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 }
 
 extension AppDelegate: NSWindowDelegate {
-    /// Hides the settings window on close so its warmed split-view state survives reopening.
     func windowShouldClose(_ sender: NSWindow) -> Bool {
-        if sender == settingsWindowController?.window {
-            releaseSettingsSystemMonitorLeaseIfNeeded()
-            sender.orderOut(nil)
-            return false
-        }
         if sender == onboardingWindowController?.window {
             // Closing is an intentional skip. Respect it on future launches;
             // the tour remains available from About.
@@ -569,11 +551,23 @@ extension AppDelegate: NSWindowDelegate {
         return true
     }
 
+    /// Destroys the settings window on close: a background app must not keep
+    /// the whole SwiftUI settings tree (previews, Workshop pages, caches)
+    /// resident. Long-running work (Workshop downloads, SteamCMD installs)
+    /// lives in app-lifetime services and survives; `showSettings` cold-builds
+    /// the next window.
     func windowWillClose(_ notification: Notification) {
         guard let closingWindow = notification.object as? NSWindow else { return }
 
         if closingWindow == settingsWindowController?.window {
             releaseSettingsSystemMonitorLeaseIfNeeded()
+            closingWindow.delegate = nil
+            // Detaching the hosting view before dropping the controller is what
+            // deterministically fires SwiftUI `onDisappear` (audio consumer
+            // release, preview teardown); a plain dealloc is not guaranteed to.
+            closingWindow.contentView = nil
+            settingsWindowController = nil
+            Logger.info("Settings window destroyed on close", category: .ui)
             return
         }
 

--- a/LiveWallpaper/App/LiveWallpaperApp.swift
+++ b/LiveWallpaper/App/LiveWallpaperApp.swift
@@ -170,8 +170,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             lifecycle.schedule { [weak self] in
                 self?.showOnboarding()
             }
-        } else {
-            scheduleSettingsWindowPrewarm()
         }
 
         #if !LITE_BUILD
@@ -324,14 +322,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Settings Window
 
-    private func scheduleSettingsWindowPrewarm() {
-        guard !runtimeOptions.isTesting, lifecycle.allowsWork else { return }
-
-        lifecycle.schedule(after: .milliseconds(1_200)) { [weak self] in
-            self?.prewarmSettingsWindow()
-        }
-    }
-
+    /// No launch-time caller anymore (the automatic prewarm kept the whole
+    /// SwiftUI tree resident in a background app); the window is built on first
+    /// `showSettings`. Kept because SamplerOwnershipTests slices this function.
     func prewarmSettingsWindow() {
         guard lifecycle.allowsWork,
               settingsWindowController == nil,

--- a/LiveWallpaper/App/ScreenManager+MemoryPressure.swift
+++ b/LiveWallpaper/App/ScreenManager+MemoryPressure.swift
@@ -16,6 +16,18 @@ extension ScreenManager {
     private func applyMemoryPressureLevel(_ level: SystemMemoryPressureLevel) {
         guard !isTerminating else { return }
         setMemoryPressure(level != .normal)
+        #if !LITE_BUILD
+        // Critical pressure skips the hibernate dwell: the refresh above has
+        // already suspended every session, so release scene renderer resources
+        // now instead of waiting out a countdown the system may not survive.
+        // Pushed on EVERY level change, not just the critical edge — the
+        // session's retry cadence has to be revoked when the pressure clears.
+        let isCritical = level == .critical
+        for screen in screens {
+            (screen.runtimeSession as? SceneWallpaperSession)?
+                .setCriticalMemoryPressureActive(isCritical)
+        }
+        #endif
     }
 
     /// Suspends all wallpaper types while memory pressure holds without changing

--- a/LiveWallpaper/App/ScreenManager+Observers.swift
+++ b/LiveWallpaper/App/ScreenManager+Observers.swift
@@ -284,6 +284,13 @@ extension ScreenManager {
                         || fullScreenDetector.isDesktopHidden(for: screen.id)
                         || fullScreenDetector.isDesktopOccluded(for: screen.id))
             )
+            // Reconciled from the watcher's live level on every refresh, not only
+            // on a level change: a session installed (restore-at-launch, swap-in)
+            // while pressure is ALREADY critical would otherwise never hear about
+            // it and stay fully resident for the whole emergency.
+            scene.setCriticalMemoryPressureActive(
+                memoryPressureWatcher.currentLevel() == .critical
+            )
         }
         #endif
         return profile

--- a/LiveWallpaper/App/ScreenManager+Observers.swift
+++ b/LiveWallpaper/App/ScreenManager+Observers.swift
@@ -278,11 +278,18 @@ extension ScreenManager {
         // full-screen cover/occlusion) — an app-rule or battery pause stays a
         // warm suspend for fast resume. The session owns the dwell countdown.
         if let scene = screen.runtimeSession as? SceneWallpaperSession {
+            // Coverage inputs are only usable while the detector is actually
+            // rescanning: with fallback polling off, its space/app-activation
+            // rescans are demand-gated too, so hidden/occluded would be frozen
+            // at whatever the last scan saw. Absence stays authoritative either
+            // way — it is tracked independently of the detector.
+            let coverageIsLive = fullScreenDetector.isFallbackPollingEnabled
             scene.setHibernationEligible(
                 profile == .suspended
                     && (isUserAbsent
-                        || fullScreenDetector.isDesktopHidden(for: screen.id)
-                        || fullScreenDetector.isDesktopOccluded(for: screen.id))
+                        || (coverageIsLive
+                            && (fullScreenDetector.isDesktopHidden(for: screen.id)
+                                || fullScreenDetector.isDesktopOccluded(for: screen.id))))
             )
             // Reconciled from the watcher's live level on every refresh, not only
             // on a level change: a session installed (restore-at-launch, swap-in)

--- a/LiveWallpaper/App/ScreenManager+Observers.swift
+++ b/LiveWallpaper/App/ScreenManager+Observers.swift
@@ -111,6 +111,16 @@ extension ScreenManager {
                 self?.handleScreenUnlocked()
             }
             .store(in: &cleanupTasks)
+
+        // Global play/pause (`togglePlayback()` in ScreenManager+Wallpaper.swift)
+        // flips every session's intent without a policy refresh, leaving the
+        // assertion stale until some unrelated refresh; the session-state
+        // commit's isAnyPlaying edge is the signal that reaches this file.
+        playbackStateSubject
+            .sink { [weak self] _ in
+                self?.refreshAppNapAssertion()
+            }
+            .store(in: &cleanupTasks)
     }
 
     private func handleScreenLocked() {
@@ -334,7 +344,8 @@ extension ScreenManager {
         commitWallpaperSessionState()
     }
 
-    /// Hold an activity assertion whenever ≥1 wallpaper session is actively rendering, so macOS doesn't App-Nap our background render loop down to ~1fps when the user focuses another window.
+    /// Hold an activity assertion while ≥1 wallpaper session may be doing real work — producing frames, playing audio, or loading — so macOS doesn't App-Nap our background render loop down to ~1fps when the user focuses another window.
+    /// The release states are the provable idle ones only: no session, policy-suspended, or user-paused (each drives the session's effective profile to `.suspended`, which pauses the display link and the audio engine). A *playing static scene* still holds the assertion: the true frames signal (`WPEMetalSceneRenderer.needsContinuousFrames` → the render actor's `linkPaused`) is render-actor-isolated with no synchronous main-thread mirror, and ambiguity errs on holding.
     func refreshAppNapAssertion() {
         let isRendering = screens.contains {
             $0.runtimeSession != nil

--- a/LiveWallpaper/App/ScreenManager+Observers.swift
+++ b/LiveWallpaper/App/ScreenManager+Observers.swift
@@ -273,6 +273,19 @@ extension ScreenManager {
             suspendedScreenIDs.remove(screen.id)
         }
         applyAdaptiveFrameRate(to: screen, settings: settings)
+        #if !LITE_BUILD
+        // Deep hibernate is reserved for absence-like suspensions (lock, sleep,
+        // full-screen cover/occlusion) — an app-rule or battery pause stays a
+        // warm suspend for fast resume. The session owns the dwell countdown.
+        if let scene = screen.runtimeSession as? SceneWallpaperSession {
+            scene.setHibernationEligible(
+                profile == .suspended
+                    && (isUserAbsent
+                        || fullScreenDetector.isDesktopHidden(for: screen.id)
+                        || fullScreenDetector.isDesktopOccluded(for: screen.id))
+            )
+        }
+        #endif
         return profile
     }
 
@@ -345,12 +358,18 @@ extension ScreenManager {
     }
 
     /// Hold an activity assertion while ≥1 wallpaper session may be doing real work — producing frames, playing audio, or loading — so macOS doesn't App-Nap our background render loop down to ~1fps when the user focuses another window.
-    /// The release states are the provable idle ones only: no session, policy-suspended, or user-paused (each drives the session's effective profile to `.suspended`, which pauses the display link and the audio engine). A *playing static scene* still holds the assertion: the true frames signal (`WPEMetalSceneRenderer.needsContinuousFrames` → the render actor's `linkPaused`) is render-actor-isolated with no synchronous main-thread mirror, and ambiguity errs on holding.
+    /// The release states: no session, policy-suspended, user-paused, or a scene session whose renderer reported it is provably idle (static scene, no audio) through the session's runtime-activity mirror (`SceneWallpaperSession.mayPerformRuntimeWork`, pushed from the render actor on change). Non-scene sessions and scenes that have not reported yet err on holding.
     func refreshAppNapAssertion() {
-        let isRendering = screens.contains {
-            $0.runtimeSession != nil
-                && !suspendedScreenIDs.contains($0.id)
-                && ($0.playbackController?.userIntendsToPlay ?? true)
+        let isRendering = screens.contains { screen in
+            guard screen.runtimeSession != nil,
+                  !suspendedScreenIDs.contains(screen.id),
+                  screen.playbackController?.userIntendsToPlay ?? true else { return false }
+            #if !LITE_BUILD
+            if let scene = screen.runtimeSession as? SceneWallpaperSession {
+                return scene.mayPerformRuntimeWork
+            }
+            #endif
+            return true
         }
         if isRendering {
             guard renderingActivityToken == nil else { return }

--- a/LiveWallpaper/App/ScreenManager+SceneMutation.swift
+++ b/LiveWallpaper/App/ScreenManager+SceneMutation.swift
@@ -182,7 +182,8 @@ extension ScreenManager {
                         let committedRevision = configurationStore.revision(for: screen.id)
                         let didCommit = await sceneSession.commitScenePropertyPatch(
                             preparedPatch,
-                            posterCommit: posterCommit
+                            posterCommit: posterCommit,
+                            updatedDescriptor: descriptor
                         )
                         if !didCommit {
                             restorePersistedSceneAfterFailedPatchDelivery(

--- a/LiveWallpaper/App/ScreenManager+Wallpaper.swift
+++ b/LiveWallpaper/App/ScreenManager+Wallpaper.swift
@@ -154,6 +154,11 @@ extension ScreenManager {
         #if !LITE_BUILD
         if let session = session as? SceneWallpaperSession {
             session.onRuntimeErrorChange = notify
+            // A static scene reports idle after load: re-fold the App Nap
+            // assertion on the renderer's own transitions, not only on policy events.
+            session.onRuntimeActivityChange = { [weak self] in
+                self?.refreshAppNapAssertion()
+            }
         }
         #endif
     }

--- a/LiveWallpaper/Infrastructure/Assets/SceneResourceResolver.swift
+++ b/LiveWallpaper/Infrastructure/Assets/SceneResourceResolver.swift
@@ -43,9 +43,9 @@ struct SceneResourceResolver: Sendable {
     }
 
     /// Opt-in TEXI/TEXB header dump for scene-debug sessions.
-    private func dumpRawTexMetadataIfActive(payload: Data, targetName: String) {
+    private func dumpRawTexMetadataIfActive(payload: WPEMappedByteSpan, targetName: String) {
         guard WPESceneDebugArtifacts.shared.activeSessionFolder != nil else { return }
-        guard case .success(let metadata) = decoder.extractRawMetadata(data: payload) else { return }
+        guard case .success(let metadata) = decoder.extractRawMetadata(span: payload) else { return }
         WPESceneDebugArtifacts.shared.dumpRawTexMetadata(
             name: (targetName as NSString).lastPathComponent,
             info: metadata.info,
@@ -71,9 +71,9 @@ struct SceneResourceResolver: Sendable {
         let resolvedPath = try resolveImageReference(relativePath: relativePath, depth: 0)
 
         if (resolvedPath as NSString).pathExtension.lowercased() == "tex" {
-            let payload: Data
+            let payload: WPEMappedByteSpan
             do {
-                payload = try providerData(resolvedPath)
+                payload = try providerWindow(resolvedPath)
             } catch ResolveError.fileMissing {
                 if let image = try resolveRasterSiblingImage(forMissingTexPath: resolvedPath) {
                     return image
@@ -81,7 +81,7 @@ struct SceneResourceResolver: Sendable {
                 throw ResolveError.fileMissing
             }
             dumpRawTexMetadataIfActive(payload: payload, targetName: resolvedPath)
-            switch decoder.decode(data: payload) {
+            switch decoder.decode(span: payload) {
             case .success(let image):
                 return image
             case .failure(let error):
@@ -141,9 +141,9 @@ struct SceneResourceResolver: Sendable {
             throw ResolveError.unsupportedTexture
         }
 
-        let payload = try providerData(resolvedPath)
+        let payload = try providerWindow(resolvedPath)
         dumpRawTexMetadataIfActive(payload: payload, targetName: resolvedPath)
-        switch decoder.extractTexturePayload(data: payload) {
+        switch decoder.extractTexturePayload(span: payload) {
         case .success(let texture):
             return texture
         case .failure(let error):
@@ -159,9 +159,9 @@ struct SceneResourceResolver: Sendable {
             throw ResolveError.unsupportedTexture
         }
 
-        let payload = try providerData(resolvedPath)
+        let payload = try providerWindow(resolvedPath)
         dumpRawTexMetadataIfActive(payload: payload, targetName: resolvedPath)
-        switch decoder.extractStreamingPayload(data: payload) {
+        switch decoder.extractStreamingPayload(span: payload) {
         case .success(let streaming):
             return streaming
         case .failure(let error):
@@ -238,18 +238,18 @@ struct SceneResourceResolver: Sendable {
         guard (relativePath as NSString).pathExtension.lowercased() == "tex" else {
             return .failure(.unsupportedTexture)
         }
-        let data: Data
+        let span: WPEMappedByteSpan
         do {
-            data = try provider.data(atRelativePath: relativePath)
+            span = try provider.mappedWindow(atRelativePath: relativePath)
         } catch {
             return .failure(.fileMissing)
         }
-        switch decoder.probe(data: data) {
+        switch decoder.probe(span: span) {
         case .success(let info):
             guard info.format?.isPhase21Decodable == true else {
                 return .success(info)
             }
-            switch decoder.decode(data: data) {
+            switch decoder.decode(span: span) {
             case .success:
                 break
             case .failure(let error):
@@ -315,6 +315,16 @@ struct SceneResourceResolver: Sendable {
     private func providerData(_ relativePath: String) throws -> Data {
         do {
             return try provider.data(atRelativePath: relativePath)
+        } catch WPESceneAssetProviderError.invalidRelativePath {
+            throw ResolveError.pathEscape
+        } catch {
+            throw ResolveError.fileMissing
+        }
+    }
+
+    private func providerWindow(_ relativePath: String) throws -> WPEMappedByteSpan {
+        do {
+            return try provider.mappedWindow(atRelativePath: relativePath)
         } catch WPESceneAssetProviderError.invalidRelativePath {
             throw ResolveError.pathEscape
         } catch {

--- a/LiveWallpaper/Infrastructure/Assets/WPEPackageSceneAssetProvider.swift
+++ b/LiveWallpaper/Infrastructure/Assets/WPEPackageSceneAssetProvider.swift
@@ -109,6 +109,15 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
         let entry = try packageEntry(for: relativePath)
         lock.lock()
         defer { lock.unlock() }
+        return try entryDataLocked(entry, relativePath: relativePath)
+    }
+
+    /// Per-entry read: big entries stage to their own file and map from there,
+    /// so residency is bounded by the entry rather than the package.
+    private func entryDataLocked(
+        _ entry: WallpaperEnginePackage.Entry,
+        relativePath: String
+    ) throws -> Data {
         if entry.dataSize > Self.mmapThreshold {
             // Big entry: stage once, then memory-map — never resident in full.
             let url = try stageEntryLocked(entry, relativePath: relativePath)
@@ -125,6 +134,22 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
         }
     }
 
+    /// `.mappedIfSafe` is advisory: Foundation refuses to map files on network
+    /// and removable volumes and silently reads them onto the heap instead.
+    /// Whole-package mapping is only worth it when the mapping really happens —
+    /// otherwise the entire pkg would sit resident, pinned by every span, which
+    /// inverts the point of the mapping.
+    private static func isPackageVolumeMappable(_ url: URL) -> Bool {
+        guard let values = try? url.resourceValues(
+            forKeys: [.volumeIsLocalKey, .volumeIsRemovableKey]
+        ) else {
+            // Unknown volume: keep the mapping path rather than silently
+            // changing behaviour for ordinary local libraries.
+            return true
+        }
+        return (values.volumeIsLocal ?? true) && !(values.volumeIsRemovable ?? false)
+    }
+
     /// Windows the entry inside a single whole-package mapping: no per-entry
     /// heap copy, and every span from this package shares one mmap owner.
     ///
@@ -138,6 +163,14 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
         let entry = try packageEntry(for: relativePath)
         lock.lock()
         defer { lock.unlock() }
+        // On a volume that cannot actually be mapped, fall back to the
+        // per-entry path: same bytes, but residency stays bounded by the entry
+        // instead of pinning the whole package on the heap for the session.
+        guard Self.isPackageVolumeMappable(packageURL) else {
+            return WPEMappedByteSpan(
+                data: try entryDataLocked(entry, relativePath: relativePath)
+            )
+        }
         let mapped: Data
         if let existing = mappedPackageData {
             mapped = existing

--- a/LiveWallpaper/Infrastructure/Assets/WPEPackageSceneAssetProvider.swift
+++ b/LiveWallpaper/Infrastructure/Assets/WPEPackageSceneAssetProvider.swift
@@ -1,6 +1,7 @@
 #if !LITE_BUILD
 import Foundation
 import LiveWallpaperCore
+import LiveWallpaperProWPE
 
 /// Reads packed scene assets in place with serialized seeks and mapped staging for large entries.
 /// A launch-time sweep reclaims staging directories left by abnormal termination.
@@ -14,9 +15,13 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
 
     private let package: WallpaperEnginePackage
     private let handle: FileHandle
+    private let packageURL: URL
     private let lock = NSLock()
     private let stagingRoot: URL
     private var stagedPaths: [String: URL] = [:]
+    /// Lazy whole-package mapping backing `mappedWindow`. Costs address space,
+    /// not resident memory; clean pages are kernel-reclaimable.
+    private var mappedPackageData: Data?
 
     init(packageURL: URL) throws {
         self.stagingRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -29,6 +34,7 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
             throw error
         }
         self.handle = handle
+        self.packageURL = packageURL
     }
 
     /// Async construction seam for MainActor import/session paths. Blocking
@@ -45,14 +51,15 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
             try? prepared.handle.close()
             throw error
         }
-        return WPEPackageSceneAssetProvider(prepared: prepared)
+        return WPEPackageSceneAssetProvider(prepared: prepared, packageURL: packageURL)
     }
 
-    private init(prepared: WPEPackageIndexLoader.PreparedPackage) {
+    private init(prepared: WPEPackageIndexLoader.PreparedPackage, packageURL: URL) {
         self.stagingRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("\(Self.stagingDirectoryNamePrefix)\(UUID().uuidString)", isDirectory: true)
         self.package = prepared.package
         self.handle = prepared.handle
+        self.packageURL = packageURL
     }
 
     deinit {
@@ -116,6 +123,38 @@ final class WPEPackageSceneAssetProvider: WPESceneAssetProvider, @unchecked Send
         } catch {
             throw WPESceneAssetProviderError.unreadable(relativePath)
         }
+    }
+
+    /// Windows the entry inside a single whole-package mapping: no per-entry
+    /// heap copy, and every span from this package shares one mmap owner.
+    ///
+    /// Lifetime contract: spans keep the mapping alive for the whole session
+    /// (lazy animated sources decompress out of it every frame). Deleting or
+    /// rename-replacing the pkg is safe on APFS; truncating or rewriting it IN
+    /// PLACE while a scene plays would SIGBUS on the next page fault. The pkg
+    /// reclaimer already skips in-use packages (its in-playback deletion bug
+    /// was fixed); any future writer must swap by rename.
+    func mappedWindow(atRelativePath relativePath: String) throws -> WPEMappedByteSpan {
+        let entry = try packageEntry(for: relativePath)
+        lock.lock()
+        defer { lock.unlock() }
+        let mapped: Data
+        if let existing = mappedPackageData {
+            mapped = existing
+        } else {
+            do {
+                mapped = try Data(contentsOf: packageURL, options: [.mappedIfSafe])
+            } catch {
+                throw WPESceneAssetProviderError.unreadable(relativePath)
+            }
+            mappedPackageData = mapped
+        }
+        let start = Int(package.dataStart + entry.dataOffset)
+        let end = start + Int(entry.dataSize)
+        guard start >= 0, end <= mapped.count else {
+            throw WPESceneAssetProviderError.unreadable(relativePath)
+        }
+        return WPEMappedByteSpan(owner: mapped, range: start..<end)
     }
 
     func stagedURL(atRelativePath relativePath: String) throws -> URL {

--- a/LiveWallpaper/Infrastructure/Assets/WPESceneAssetProvider.swift
+++ b/LiveWallpaper/Infrastructure/Assets/WPESceneAssetProvider.swift
@@ -1,5 +1,6 @@
 #if !LITE_BUILD
 import Foundation
+import LiveWallpaperProWPE
 
 enum WPESceneAssetProviderError: Error, Equatable, Sendable {
     case invalidRelativePath(String)
@@ -21,8 +22,19 @@ protocol WPESceneAssetProvider: Sendable {
     /// the entry into the provider's session-lifetime temp dir (cleaned on deinit).
     func stagedURL(atRelativePath relativePath: String) throws -> URL
     func exists(atRelativePath relativePath: String) -> Bool
+    /// Zero-copy byte window for `.tex` payload parsing. A package backend maps
+    /// the whole `scene.pkg` once and windows the entry; a directory backend's
+    /// `data` is already `.mappedIfSafe`, so the default (full-range wrap of
+    /// `data`) is correct for it.
+    func mappedWindow(atRelativePath relativePath: String) throws -> WPEMappedByteSpan
     /// Diagnostic / enumeration use only — not on the hot path.
     var entryNames: [String] { get }
+}
+
+extension WPESceneAssetProvider {
+    func mappedWindow(atRelativePath relativePath: String) throws -> WPEMappedByteSpan {
+        WPEMappedByteSpan(data: try data(atRelativePath: relativePath))
+    }
 }
 
 /// Wraps a provider whose bytes live under a security-scoped source URL (a
@@ -56,6 +68,10 @@ final class WPESecurityScopedSceneAssetProvider: WPESceneAssetProvider, @uncheck
 
     func exists(atRelativePath relativePath: String) -> Bool {
         wrapped.exists(atRelativePath: relativePath)
+    }
+
+    func mappedWindow(atRelativePath relativePath: String) throws -> WPEMappedByteSpan {
+        try wrapped.mappedWindow(atRelativePath: relativePath)
     }
 
     var entryNames: [String] {

--- a/LiveWallpaper/Infrastructure/Assets/WPETexByteReader.swift
+++ b/LiveWallpaper/Infrastructure/Assets/WPETexByteReader.swift
@@ -13,13 +13,21 @@ import LiveWallpaperProWPE
 struct WPETexByteReader {
     let data: Data
     private(set) var cursor: Int
+    /// Exclusive end bound (buffer-relative). Lets the reader walk a window of
+    /// a larger mapping (a `scene.pkg` entry) without slicing a new `Data`.
+    let endBound: Int
 
-    init(data: Data, cursor: Int = 0) {
+    init(data: Data, cursor: Int = 0, endBound: Int? = nil) {
         self.data = data
         self.cursor = cursor
+        self.endBound = min(endBound ?? data.count, data.count)
     }
 
-    var isAtEnd: Bool { cursor >= data.count }
+    init(span: WPEMappedByteSpan) {
+        self.init(data: span.owner, cursor: span.range.lowerBound, endBound: span.range.upperBound)
+    }
+
+    var isAtEnd: Bool { cursor >= endBound }
 
     mutating func readUInt32(blockName: String = "?") throws -> UInt32 {
         try ensure(byteCount: 4, blockName: blockName)
@@ -58,12 +66,12 @@ struct WPETexByteReader {
         return asciiString
     }
 
-    mutating func readBytes(count: Int, blockName: String) throws -> Data {
+    /// Zero-copy view of the next `count` bytes; the span keeps `data` alive.
+    mutating func readSpan(count: Int, blockName: String) throws -> WPEMappedByteSpan {
         try ensure(byteCount: count, blockName: blockName)
-        let start = data.startIndex + cursor
-        let slice = data.subdata(in: start..<(start + count))
+        let span = WPEMappedByteSpan(owner: data, range: cursor..<(cursor + count))
         cursor += count
-        return slice
+        return span
     }
 
     /// Reads a NUL-terminated ASCII run, advancing past the terminator.
@@ -71,10 +79,11 @@ struct WPETexByteReader {
     /// for dump fidelity (older code path discarded it via skip-only).
     mutating func readNullTerminatedString(blockName: String) throws -> String {
         let absoluteCursor = data.startIndex + cursor
-        guard absoluteCursor <= data.endIndex else {
+        let absoluteEnd = data.startIndex + endBound
+        guard absoluteCursor <= absoluteEnd else {
             throw WPETexDecodeError.truncatedBlock(block: blockName, offset: cursor)
         }
-        guard let terminator = data[absoluteCursor...].firstIndex(of: 0) else {
+        guard let terminator = data[absoluteCursor..<absoluteEnd].firstIndex(of: 0) else {
             throw WPETexDecodeError.truncatedBlock(block: blockName, offset: cursor)
         }
         let slice = data.subdata(in: absoluteCursor..<terminator)
@@ -83,7 +92,7 @@ struct WPETexByteReader {
     }
 
     private func ensure(byteCount: Int, blockName: String) throws {
-        guard byteCount >= 0, cursor + byteCount <= data.count else {
+        guard byteCount >= 0, cursor + byteCount <= endBound else {
             throw WPETexDecodeError.truncatedBlock(block: blockName, offset: cursor)
         }
     }

--- a/LiveWallpaper/Infrastructure/Assets/WPETexDecoder.swift
+++ b/LiveWallpaper/Infrastructure/Assets/WPETexDecoder.swift
@@ -10,8 +10,12 @@ struct WPETexDecoder: Sendable {
 
     /// Cheap header probe — used by `WallpaperEngineImportService` during capability tier classification.
     func probe(data: Data) -> Result<WPETexInfo, WPETexDecodeError> {
+        probe(span: WPEMappedByteSpan(data: data))
+    }
+
+    func probe(span: WPEMappedByteSpan) -> Result<WPETexInfo, WPETexDecodeError> {
         do {
-            return .success(try parseHeader(data: data))
+            return .success(try parseHeader(span: span))
         } catch let error as WPETexDecodeError {
             return .failure(error)
         } catch {
@@ -21,8 +25,12 @@ struct WPETexDecoder: Sendable {
 
     /// Hot path.
     func decode(data: Data) -> Result<CGImage, WPETexDecodeError> {
+        decode(span: WPEMappedByteSpan(data: data))
+    }
+
+    func decode(span: WPEMappedByteSpan) -> Result<CGImage, WPETexDecodeError> {
         do {
-            let parsed = try parse(data: data)
+            let parsed = try parse(span: span)
             return .success(try makeCGImage(from: parsed))
         } catch let error as WPETexDecodeError {
             return .failure(error)
@@ -33,8 +41,12 @@ struct WPETexDecoder: Sendable {
 
     /// Headers + TEXS schedule only; leave compressed mipmaps for lazy playback.
     func extractStreamingPayload(data: Data) -> Result<WPETexStreamingPayload, WPETexDecodeError> {
+        extractStreamingPayload(span: WPEMappedByteSpan(data: data))
+    }
+
+    func extractStreamingPayload(span: WPEMappedByteSpan) -> Result<WPETexStreamingPayload, WPETexDecodeError> {
         do {
-            let parsed = try parse(data: data)
+            let parsed = try parse(span: span)
             return .success(try makeStreamingPayload(from: parsed))
         } catch let error as WPETexDecodeError {
             return .failure(error)
@@ -45,8 +57,12 @@ struct WPETexDecoder: Sendable {
 
     /// Header-only TEXI/TEXB probe for scene-debug dumps (no GPU/decompress).
     func extractRawMetadata(data: Data) -> Result<WPETexRawMetadata, WPETexDecodeError> {
+        extractRawMetadata(span: WPEMappedByteSpan(data: data))
+    }
+
+    func extractRawMetadata(span: WPEMappedByteSpan) -> Result<WPETexRawMetadata, WPETexDecodeError> {
         do {
-            let parsed = try parse(data: data)
+            let parsed = try parse(span: span)
             return .success(WPETexRawMetadata(info: parsed.info, bitmap: parsed.bitmap))
         } catch let error as WPETexDecodeError {
             return .failure(error)
@@ -57,8 +73,12 @@ struct WPETexDecoder: Sendable {
 
     /// Metal path.
     func extractTexturePayload(data: Data) -> Result<WPETexTexturePayload, WPETexDecodeError> {
+        extractTexturePayload(span: WPEMappedByteSpan(data: data))
+    }
+
+    func extractTexturePayload(span: WPEMappedByteSpan) -> Result<WPETexTexturePayload, WPETexDecodeError> {
         do {
-            let parsed = try parse(data: data)
+            let parsed = try parse(span: span)
 
             if let videoPayload = makeVideoPayload(from: parsed) {
                 return .success(WPETexTexturePayload(
@@ -177,7 +197,9 @@ struct WPETexDecoder: Sendable {
         guard parsed.bitmap.isVideoPayload || looksLikeMP4Payload(mip.payload) else {
             return nil
         }
-        return WPETexVideoPayload(bytes: mip.payload)
+        // Video bytes head straight to the disk cache; a one-shot copy here
+        // matches the pre-span behavior (readBytes subdata).
+        return WPETexVideoPayload(bytes: mip.payload.materializedData())
     }
 
     private func makeStreamingPayload(from parsed: ParsedTex) throws -> WPETexStreamingPayload {
@@ -298,8 +320,8 @@ struct WPETexDecoder: Sendable {
         }
     }
 
-    private func parseHeader(data: Data) throws -> WPETexInfo {
-        var reader = WPETexByteReader(data: data)
+    private func parseHeader(span: WPEMappedByteSpan) throws -> WPETexInfo {
+        var reader = WPETexByteReader(span: span)
         let containerMagic = try reader.readMagic()
         guard containerMagic.hasPrefix("TEXV") else {
             throw WPETexDecodeError.unsupportedContainer(magic: containerMagic)
@@ -317,8 +339,8 @@ struct WPETexDecoder: Sendable {
         )
     }
 
-    private func parse(data: Data) throws -> ParsedTex {
-        var reader = WPETexByteReader(data: data)
+    private func parse(span: WPEMappedByteSpan) throws -> ParsedTex {
+        var reader = WPETexByteReader(span: span)
         let containerMagic = try reader.readMagic()
         guard containerMagic.hasPrefix("TEXV") else {
             throw WPETexDecodeError.unsupportedContainer(magic: containerMagic)
@@ -577,7 +599,7 @@ struct WPETexDecoder: Sendable {
         }
 
         let storedSize = Int(try reader.readUInt32(blockName: "TEXB.mipSize"))
-        let payload = try reader.readBytes(count: storedSize, blockName: "TEXB.mipPayload")
+        let payload = try reader.readSpan(count: storedSize, blockName: "TEXB.mipPayload")
 
         return WPETexMipmap(
             index: index,
@@ -664,12 +686,12 @@ struct WPETexDecoder: Sendable {
         return try decoded.makeCGImage()
     }
 
-    private func looksLikeMP4Payload(_ data: Data) -> Bool {
-        guard data.count >= 12 else { return false }
-        return data[4] == 0x66
-            && data[5] == 0x74
-            && data[6] == 0x79
-            && data[7] == 0x70
+    private func looksLikeMP4Payload(_ span: WPEMappedByteSpan) -> Bool {
+        guard span.count >= 12 else { return false }
+        return span.byte(at: 4) == 0x66
+            && span.byte(at: 5) == 0x74
+            && span.byte(at: 6) == 0x79
+            && span.byte(at: 7) == 0x70
     }
 
     private func makeEncodedCGImage(from data: Data, mipmap: Int) throws -> CGImage {
@@ -907,7 +929,7 @@ struct WPETexDecoder: Sendable {
     }
 
     private func inflateIfNeeded(
-        payload: Data,
+        payload: WPEMappedByteSpan,
         expectedByteCount: Int?,
         decompressedByteCount: Int?,
         isCompressed: Bool,
@@ -930,16 +952,15 @@ struct WPETexDecoder: Sendable {
             return inflated
         }
 
-        guard let expectedByteCount else { return payload }
-        if payload.count == expectedByteCount { return payload }
-        if payload.count > expectedByteCount {
-            return payload.prefix(expectedByteCount)
+        guard let expectedByteCount else { return payload.materializedData() }
+        if payload.count >= expectedByteCount {
+            return payload.prefix(expectedByteCount).materializedData()
         }
 
         return try lz4Inflate(payload: payload, outputCount: expectedByteCount, mipmap: mipmap)
     }
 
-    private func lz4Inflate(payload: Data, outputCount: Int, mipmap: Int) throws -> Data {
+    private func lz4Inflate(payload: WPEMappedByteSpan, outputCount: Int, mipmap: Int) throws -> Data {
         var output = Data(count: outputCount)
         let written = output.withUnsafeMutableBytes { (out: UnsafeMutableRawBufferPointer) -> Int in
             payload.withUnsafeBytes { (input: UnsafeRawBufferPointer) -> Int in
@@ -949,7 +970,7 @@ struct WPETexDecoder: Sendable {
                 }
                 return compression_decode_buffer(
                     dst, outputCount,
-                    src, payload.count,
+                    src, input.count,
                     nil,
                     COMPRESSION_LZ4_RAW
                 )

--- a/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
+++ b/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
@@ -131,6 +131,15 @@ final class WPEMetalTextureSnapshotter: @unchecked Sendable {
         } else if let view = texture.makeTextureView(pixelFormat: workingFormat) {
             source = view
         } else {
+            // Apple documents `.pixelFormatView` as required for a differing-format
+            // view, and the renderer's output textures are `[.renderTarget,
+            // .shaderRead]`. Measured on this GPU family the view is vended anyway
+            // (probe: both usages return non-nil), so the sRGB poster path really
+            // does reach the GPU downsample here — but that is undocumented
+            // tolerance. The output pool is per-frame 4K on the hot path, and
+            // adding a usage flag there can cost lossless compression, so the
+            // spec-legal degradation is this nil: the caller falls back to the
+            // full-resolution readback, which is slower but correct.
             return nil
         }
 

--- a/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
+++ b/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
@@ -2,6 +2,7 @@
 import AppKit
 import LiveWallpaperCore
 import Metal
+import MetalPerformanceShaders
 
 /// Reads back the renderer's offscreen `MTLTexture` into an `NSImage` for
 /// `SceneDetailView` (without it the detail view falls into
@@ -22,21 +23,37 @@ final class WPEMetalTextureSnapshotter: @unchecked Sendable {
         self.queue = DispatchQueue(label: label, qos: .utility)
     }
 
+    /// Posters render at pane size, so a 4K rgba16Float readback (~63 MiB) is
+    /// pure waste; frames are GPU-scaled to this max dimension before `getBytes`.
+    static let posterMaxDimension = 1440
+
+    /// Full-resolution path: debug-artifacts first-frame capture
+    /// (`WPEMetalSceneRenderer+Load.swift`) and format tests.
     func snapshot(from texture: MTLTexture) -> NSImage? {
-        Self.makeImage(from: texture)
+        Self.makeImage(from: texture, maxDimension: nil)
     }
 
+    /// Poster path (`SceneRenderer+LivePoster`): downsampled before readback.
     func snapshotAsync(from source: SnapshotSource) async -> NSImage? {
         await withCheckedContinuation { continuation in
             queue.async {
-                continuation.resume(returning: Self.makeImage(from: source.texture))
+                continuation.resume(
+                    returning: Self.makeImage(from: source.texture, maxDimension: Self.posterMaxDimension)
+                )
             }
         }
     }
 
-    private static func makeImage(from texture: MTLTexture) -> NSImage? {
+    private static func makeImage(from texture: MTLTexture, maxDimension: Int?) -> NSImage? {
         guard texture.width > 0, texture.height > 0 else {
             return nil
+        }
+
+        var texture = texture
+        if let maxDimension,
+           max(texture.width, texture.height) > maxDimension,
+           let scaled = downsampleOnGPU(texture, maxDimension: maxDimension) {
+            texture = scaled
         }
 
         let bytes: [UInt8]
@@ -89,6 +106,75 @@ final class WPEMetalTextureSnapshotter: @unchecked Sendable {
             cgImage: cgImage,
             size: CGSize(width: texture.width, height: texture.height)
         )
+    }
+
+    /// Bilinear-scales on GPU so the CPU readback and conversion touch a
+    /// pane-sized frame instead of the full render target. Returns nil on any
+    /// failure so the caller falls back to the full-resolution readback.
+    /// sRGB variants are scaled through non-sRGB views (raw encoded bytes):
+    /// sRGB stores are not writable on every Mac GPU family, and the downstream
+    /// switch reads raw bytes as sRGB-encoded either way.
+    private static func downsampleOnGPU(_ texture: MTLTexture, maxDimension: Int) -> MTLTexture? {
+        let device = texture.device
+        guard MPSSupportsMTLDevice(device) else { return nil }
+
+        let workingFormat: MTLPixelFormat
+        switch texture.pixelFormat {
+        case .rgba8Unorm_srgb: workingFormat = .rgba8Unorm
+        case .bgra8Unorm_srgb: workingFormat = .bgra8Unorm
+        default: workingFormat = texture.pixelFormat
+        }
+        let source: MTLTexture
+        if workingFormat == texture.pixelFormat {
+            source = texture
+        } else if let view = texture.makeTextureView(pixelFormat: workingFormat) {
+            source = view
+        } else {
+            return nil
+        }
+
+        let scale = Double(maxDimension) / Double(max(texture.width, texture.height))
+        let width = max(1, Int((Double(texture.width) * scale).rounded()))
+        let height = max(1, Int((Double(texture.height) * scale).rounded()))
+
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: workingFormat,
+            width: width,
+            height: height,
+            mipmapped: false
+        )
+        descriptor.usage = [.shaderRead, .shaderWrite]
+        descriptor.storageMode = device.hasUnifiedMemory ? .shared : .managed
+        guard let destination = device.makeTexture(descriptor: descriptor),
+              let commandQueue = device.makeCommandQueue(),
+              let commandBuffer = commandQueue.makeCommandBuffer() else {
+            return nil
+        }
+        destination.label = "WPE Metal poster downsample"
+
+        var transform = MPSScaleTransform(
+            scaleX: Double(width) / Double(texture.width),
+            scaleY: Double(height) / Double(texture.height),
+            translateX: 0,
+            translateY: 0
+        )
+        let kernel = MPSImageBilinearScale(device: device)
+        withUnsafePointer(to: &transform) { pointer in
+            kernel.scaleTransform = pointer
+            kernel.encode(
+                commandBuffer: commandBuffer,
+                sourceTexture: source,
+                destinationTexture: destination
+            )
+        }
+        if destination.storageMode == .managed, let blit = commandBuffer.makeBlitCommandEncoder() {
+            blit.synchronize(resource: destination)
+            blit.endEncoding()
+        }
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        guard commandBuffer.status == .completed else { return nil }
+        return destination
     }
 
     private static func readRGBA8(_ texture: MTLTexture) -> [UInt8] {

--- a/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
+++ b/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
@@ -185,10 +185,15 @@ final class WPEMetalTextureSnapshotter: @unchecked Sendable {
     private static let downsampleQueues =
         OSAllocatedUnfairLock<[ObjectIdentifier: MTLCommandQueue]>(initialState: [:])
 
-    private static func commandQueue(for device: MTLDevice) -> MTLCommandQueue? {
+    /// Cache-miss count. Test seam (internal, not private, like `commandQueue(for:)`):
+    /// lets tests prove repeated poster downsamples reuse one queue per device.
+    static let downsampleQueueCreationsForTesting = OSAllocatedUnfairLock<Int>(initialState: 0)
+
+    static func commandQueue(for device: MTLDevice) -> MTLCommandQueue? {
         downsampleQueues.withLock { cache in
             let key = ObjectIdentifier(device)
             if let cached = cache[key] { return cached }
+            downsampleQueueCreationsForTesting.withLock { $0 += 1 }
             let queue = device.makeCommandQueue()
             queue?.label = "com.livewallpaper.wpe-metal.poster-downsample"
             cache[key] = queue

--- a/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
+++ b/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
@@ -3,6 +3,7 @@ import AppKit
 import LiveWallpaperCore
 import Metal
 import MetalPerformanceShaders
+import os
 
 /// Reads back the renderer's offscreen `MTLTexture` into an `NSImage` for
 /// `SceneDetailView` (without it the detail view falls into
@@ -146,7 +147,7 @@ final class WPEMetalTextureSnapshotter: @unchecked Sendable {
         descriptor.usage = [.shaderRead, .shaderWrite]
         descriptor.storageMode = device.hasUnifiedMemory ? .shared : .managed
         guard let destination = device.makeTexture(descriptor: descriptor),
-              let commandQueue = device.makeCommandQueue(),
+              let commandQueue = commandQueue(for: device),
               let commandBuffer = commandQueue.makeCommandBuffer() else {
             return nil
         }
@@ -175,6 +176,24 @@ final class WPEMetalTextureSnapshotter: @unchecked Sendable {
         commandBuffer.waitUntilCompleted()
         guard commandBuffer.status == .completed else { return nil }
         return destination
+    }
+
+    /// Poster refreshes downsample on every capture; creating an MTLCommandQueue
+    /// per capture is measurable churn, so one queue per device is cached for the
+    /// process lifetime. Lock-protected because `makeImage` is callable from any
+    /// thread (poster path runs on the readback queue, tests call it directly).
+    private static let downsampleQueues =
+        OSAllocatedUnfairLock<[ObjectIdentifier: MTLCommandQueue]>(initialState: [:])
+
+    private static func commandQueue(for device: MTLDevice) -> MTLCommandQueue? {
+        downsampleQueues.withLock { cache in
+            let key = ObjectIdentifier(device)
+            if let cached = cache[key] { return cached }
+            let queue = device.makeCommandQueue()
+            queue?.label = "com.livewallpaper.wpe-metal.poster-downsample"
+            cache[key] = queue
+            return queue
+        }
     }
 
     private static func readRGBA8(_ texture: MTLTexture) -> [UInt8] {

--- a/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
+++ b/LiveWallpaper/Infrastructure/Diagnostics/WPEMetalTextureSnapshotter.swift
@@ -193,9 +193,12 @@ final class WPEMetalTextureSnapshotter: @unchecked Sendable {
         downsampleQueues.withLock { cache in
             let key = ObjectIdentifier(device)
             if let cached = cache[key] { return cached }
+            // Count and cache only a real queue: assigning nil to the subscript
+            // would erase the key, so a failed creation must not pretend to be
+            // a cache entry (and must not inflate the creation seam).
+            guard let queue = device.makeCommandQueue() else { return nil }
             downsampleQueueCreationsForTesting.withLock { $0 += 1 }
-            let queue = device.makeCommandQueue()
-            queue?.label = "com.livewallpaper.wpe-metal.poster-downsample"
+            queue.label = "com.livewallpaper.wpe-metal.poster-downsample"
             cache[key] = queue
             return queue
         }

--- a/LiveWallpaper/Infrastructure/Diagnostics/WPESceneDebugArtifacts.swift
+++ b/LiveWallpaper/Infrastructure/Diagnostics/WPESceneDebugArtifacts.swift
@@ -60,6 +60,9 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
         if let testingOverride { return testingOverride }
         // The render oracle needs the canonical trace recorder to run, so enabling
         // oracle mode implies artifacts are enabled (no need to set both defaults).
+        // Both stay live reads: WPEMetalSceneRendererTests flips the defaults key
+        // at runtime, and WPEOracleMode's testingOverride flips too. DEBUG-only
+        // cost — Release compiles isEnabled to a constant false.
         return UserDefaults.standard.bool(forKey: Self.defaultsKey) || WPEOracleMode.isEnabled
         #else
         return false
@@ -199,6 +202,12 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
         }
     }
 
+    /// Shared instead of one formatter per log line. Only ever touched inside
+    /// `writeQueue` (serial), because `ISO8601DateFormatter` — unlike
+    /// `DateFormatter`, which the SDK marks `NS_SWIFT_SENDABLE` — carries no
+    /// documented thread-safety guarantee.
+    private nonisolated(unsafe) static let logTimestampFormatter = ISO8601DateFormatter()
+
     /// Append a single line to the per-scene log (in addition to the global
     /// runtime.log mirror Logger already handles).
     func appendLog(_ message: String, level: Logger.Level = .info) {
@@ -207,9 +216,10 @@ final class WPESceneDebugArtifacts: @unchecked Sendable {
         let url = session?.logURL
         sessionLock.unlock()
         guard let url else { return }
-        let prefix = "[\(ISO8601DateFormatter().string(from: Date()))][\(levelTag(level))]"
-        let line = "\(prefix) \(message)\n"
+        let timestamp = Date()
+        let tag = levelTag(level)
         writeQueue.async {
+            let line = "[\(Self.logTimestampFormatter.string(from: timestamp))][\(tag)] \(message)\n"
             guard let data = line.data(using: .utf8) else { return }
             if let handle = try? FileHandle(forWritingTo: url) {
                 defer { try? handle.close() }

--- a/LiveWallpaper/Monitor/Runtime.swift
+++ b/LiveWallpaper/Monitor/Runtime.swift
@@ -499,7 +499,12 @@ actor Runtime {
             ane: kinds.contains(.aiEngine),
             accessories: kinds.contains(.power),
             sensors: kinds.contains(.cpu) || kinds.contains(.gpu) || kinds.contains(.power),
-            processIO: kinds.contains(.disk)
+            processIO: kinds.contains(.disk),
+            cpu: kinds.contains(.cpu),
+            memory: kinds.contains(.memory),
+            network: kinds.contains(.network),
+            disk: kinds.contains(.disk),
+            power: kinds.contains(.power)
         )
     }
 

--- a/LiveWallpaper/Monitor/Sources/NetworkPathObserver.swift
+++ b/LiveWallpaper/Monitor/Sources/NetworkPathObserver.swift
@@ -43,6 +43,13 @@ final class NetworkPathObserver: Sendable {
         latest.withLock { $0 }
     }
 
+    #if DEBUG
+    // Test-only introspection; no production reader.
+    var debugIsStarted: Bool {
+        started.withLock { $0 }
+    }
+    #endif
+
     private static func snapshot(from path: NWPath) -> Snapshot {
         let status: String
         switch path.status {

--- a/LiveWallpaper/Monitor/Sources/SystemMetricsSource.swift
+++ b/LiveWallpaper/Monitor/Sources/SystemMetricsSource.swift
@@ -32,10 +32,27 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
         static let `default` = Options()
     }
 
+    typealias TopProcessesSampler = @Sendable (
+        _ previous: [Int32: SystemMetricsSamplers.ProcessCPUCounters],
+        _ interval: TimeInterval,
+        _ includeIO: Bool
+    ) -> SystemMetricsSamplers.TopProcessesResult
+
+    static let defaultTopProcessesSampler: TopProcessesSampler = { previous, interval, includeIO in
+        SystemMetricsSamplers.sampleTopProcesses(
+            previous: previous,
+            interval: interval,
+            limit: 12,
+            includeIO: includeIO
+        )
+    }
+
     private let interval: TimeInterval
     private let gpuSampleCadence: Int
+    private let topProcessSampleSeconds: TimeInterval
     private let options: Options
     private let loadAverageSampler: @Sendable () -> [Double]?
+    private let topProcessesSampler: TopProcessesSampler
     private let pressure: any MemoryPressureReading
     private let state = MetricsState()
     private let netPath = NetworkPathObserver()
@@ -54,7 +71,9 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
         self.options = options
         self.interval = interval
         self.gpuSampleCadence = gpuSampleCadence
+        self.topProcessSampleSeconds = 5.0
         self.loadAverageSampler = loadAverageSampler
+        self.topProcessesSampler = Self.defaultTopProcessesSampler
         pressure = memoryPressureReader
     }
 
@@ -62,15 +81,19 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
         options: Options,
         interval: TimeInterval = 2.0,
         gpuSampleCadence: Int = 3,
+        topProcessSampleSeconds: TimeInterval = 5.0,
         loadAverageSampler: @escaping @Sendable () -> [Double]? = {
             SystemMetricsSamplers.sampleLoadAverages()
         },
+        topProcessesSampler: @escaping TopProcessesSampler = SystemMetricsSource.defaultTopProcessesSampler,
         memoryPressureReader: any MemoryPressureReading = SystemMemoryPressureWatcher.shared
     ) {
         self.options = options
         self.interval = interval
         self.gpuSampleCadence = gpuSampleCadence
+        self.topProcessSampleSeconds = topProcessSampleSeconds
         self.loadAverageSampler = loadAverageSampler
+        self.topProcessesSampler = topProcessesSampler
         pressure = memoryPressureReader
     }
 
@@ -90,8 +113,10 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
         await state.startLoop(
             interval: interval,
             gpuSampleCadence: gpuSampleCadence,
+            topProcessSampleSeconds: topProcessSampleSeconds,
             options: options,
             loadAverageSampler: loadAverageSampler,
+            topProcessesSampler: topProcessesSampler,
             pressure: pressure,
             netPath: netPath,
             sink: sink
@@ -117,6 +142,9 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
         private var lastGPU: SystemMetricsSamplers.GPUSample?
         private var lastGPUSampledAt: Double?
         private var prevProcessCounters: [Int32: SystemMetricsSamplers.ProcessCPUCounters] = [:]
+        private var lastTopProcesses: [MonitorProcessSample]?
+        private var lastTopIOProcesses: [MonitorProcessSample]?
+        private var lastTopProcessesSampledAt: Date?
         private var lastANE: SystemMetricsSamplers.ANESample?
         private var lastANESampledAt: Date?
         /// Lazily opened on the first sensors-enabled tick; caches its SMC connection.
@@ -127,8 +155,10 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
         func startLoop(
             interval: TimeInterval,
             gpuSampleCadence: Int,
+            topProcessSampleSeconds: TimeInterval,
             options: Options,
             loadAverageSampler: @escaping @Sendable () -> [Double]?,
+            topProcessesSampler: @escaping TopProcessesSampler,
             pressure: any MemoryPressureReading,
             netPath: NetworkPathObserver,
             sink: any MonitorSnapshotSink
@@ -140,8 +170,10 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
                     await tick(
                         interval: interval,
                         gpuSampleCadence: gpuSampleCadence,
+                        topProcessSampleSeconds: topProcessSampleSeconds,
                         options: options,
                         loadAverageSampler: loadAverageSampler,
+                        topProcessesSampler: topProcessesSampler,
                         pressure: pressure,
                         netPath: netPath,
                         sink: sink
@@ -167,8 +199,10 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
         private func tick(
             interval: TimeInterval,
             gpuSampleCadence: Int,
+            topProcessSampleSeconds: TimeInterval,
             options: Options,
             loadAverageSampler: @Sendable () -> [Double]?,
+            topProcessesSampler: TopProcessesSampler,
             pressure: any MemoryPressureReading,
             netPath: NetworkPathObserver,
             sink: any MonitorSnapshotSink
@@ -245,18 +279,27 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
                 accessories = read.isEmpty ? nil : read
             }
 
+            // The full process-table walk rivals ANE as the priciest probe, so it
+            // shares ANE's wall-clock cadence pattern instead of running every base
+            // tick. CPU%/IO deltas must divide by the span since the *last walk*,
+            // not the base tick, or skipping would inflate them by the skip factor.
             var topProcesses: [MonitorProcessSample]?
             var topIOProcesses: [MonitorProcessSample]?
             if options.topProcesses || options.processIO {
-                let result = SystemMetricsSamplers.sampleTopProcesses(
-                    previous: prevProcessCounters,
-                    interval: elapsed,
-                    limit: 12,
-                    includeIO: options.processIO
-                )
-                prevProcessCounters = result.counters
-                topProcesses = result.samples.isEmpty ? nil : result.samples
-                topIOProcesses = result.ioSamples.isEmpty ? nil : result.ioSamples
+                if shouldSampleTopProcesses(now: now, cadenceSeconds: topProcessSampleSeconds) {
+                    let walkElapsed = lastTopProcessesSampledAt.map { now.timeIntervalSince($0) } ?? elapsed
+                    let result = topProcessesSampler(
+                        prevProcessCounters,
+                        walkElapsed,
+                        options.processIO
+                    )
+                    prevProcessCounters = result.counters
+                    lastTopProcesses = result.samples.isEmpty ? nil : result.samples
+                    lastTopIOProcesses = result.ioSamples.isEmpty ? nil : result.ioSamples
+                    lastTopProcessesSampledAt = now
+                }
+                topProcesses = lastTopProcesses
+                topIOProcesses = lastTopIOProcesses
             }
 
             // ANE's per-PID rusage walk is the priciest probe → ≥5s cadence, gated.
@@ -332,6 +375,11 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
                 detail: nil,
                 lastUpdateAt: now.timeIntervalSince1970
             ))
+        }
+
+        private func shouldSampleTopProcesses(now: Date, cadenceSeconds: TimeInterval) -> Bool {
+            guard let last = lastTopProcessesSampledAt else { return true }
+            return now.timeIntervalSince(last) >= cadenceSeconds
         }
 
         private func shouldSampleANE(now: Date) -> Bool {

--- a/LiveWallpaper/Monitor/Sources/SystemMetricsSource.swift
+++ b/LiveWallpaper/Monitor/Sources/SystemMetricsSource.swift
@@ -15,6 +15,20 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
         /// Per-app disk I/O attribution (rusage deltas inside the top-processes walk; needs the `process-info-rusage` sbpl exception).
         var processIO: Bool = false
 
+        // Base metric groups, keyed by whether any placed widget reads them.
+        // Default true: the legacy no-widget-info init must keep sampling
+        // everything (fail open — a missing demand must never starve a widget).
+        /// Host CPU ticks, per-core loads, CPU identity, and load averages (CPU widget).
+        var cpu: Bool = true
+        /// VM stats, breakdown, swap, and pressure (Memory widget).
+        var memory: Bool = true
+        /// Interface counters and the NWPathMonitor (Network widget).
+        var network: Bool = true
+        /// Block-storage read/write counters (Disk widget).
+        var disk: Bool = true
+        /// Battery/adapter state (Power widget).
+        var power: Bool = true
+
         static let `default` = Options()
     }
 
@@ -65,8 +79,14 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
         reader.currentLevel().rawValue
     }
 
+    #if DEBUG
+    // Test-only introspection: proves the path monitor is demand-gated, not
+    // merely its snapshot dropped.
+    var debugNetPathStarted: Bool { netPath.debugIsStarted }
+    #endif
+
     func start(sink: any MonitorSnapshotSink) async {
-        netPath.start()
+        if options.network { netPath.start() }
         await state.startLoop(
             interval: interval,
             gpuSampleCadence: gpuSampleCadence,
@@ -158,35 +178,55 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
             let elapsed = lastSampleTime.map { now.timeIntervalSince($0) } ?? interval
             lastSampleTime = now
 
-            if cpuInfo == nil {
-                cpuInfo = SystemMetricsSamplers.sampleCPUInfo()
+            // Base metric groups only run when a placed widget still reads
+            // them: the probe is skipped, not just its result hidden.
+            var cpuSample: SystemMetricsSamplers.CPUSample?
+            if options.cpu {
+                if cpuInfo == nil {
+                    cpuInfo = SystemMetricsSamplers.sampleCPUInfo()
+                }
+                let cpu = SystemMetricsSamplers.sampleCPU(previous: prevCPU)
+                prevCPU = cpu.counters
+                cpuSample = cpu.sample
             }
 
-            let cpu = SystemMetricsSamplers.sampleCPU(previous: prevCPU)
-            prevCPU = cpu.counters
+            var memory: SystemMetricsSamplers.MemorySample?
+            var swapUsedBytes: UInt64?
+            if options.memory {
+                memory = SystemMetricsSamplers.sampleMemory()
+                swapUsedBytes = SystemMetricsSamplers.sampleSwapUsedBytes()
+            }
 
-            let memory = SystemMetricsSamplers.sampleMemory()
+            var netRx: Double = 0
+            var netTx: Double = 0
+            var netInterfaces: [MonitorNetworkInterface] = []
+            var pathSnapshot: NetworkPathObserver.Snapshot?
+            if options.network {
+                let netRaw = SystemMetricsSamplers.sampleNetworkCounters()
+                netRx = SystemMetricsSamplers.rate(current: netRaw.rx, previous: prevNet?.rx ?? netRaw.rx, interval: elapsed)
+                netTx = SystemMetricsSamplers.rate(current: netRaw.tx, previous: prevNet?.tx ?? netRaw.tx, interval: elapsed)
+                pathSnapshot = netPath.currentSnapshot()
+                netInterfaces = SystemMetricsSamplers.networkInterfaces(
+                    previous: prevNetInterfaces,
+                    current: netRaw.interfaces,
+                    interval: elapsed,
+                    activeName: pathSnapshot?.activeInterfaceName
+                )
+                prevNet = (netRaw.rx, netRaw.tx)
+                prevNetInterfaces = Dictionary(
+                    netRaw.interfaces.map { ($0.name, $0) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+            }
 
-            let netRaw = SystemMetricsSamplers.sampleNetworkCounters()
-            let netRx = SystemMetricsSamplers.rate(current: netRaw.rx, previous: prevNet?.rx ?? netRaw.rx, interval: elapsed)
-            let netTx = SystemMetricsSamplers.rate(current: netRaw.tx, previous: prevNet?.tx ?? netRaw.tx, interval: elapsed)
-            let pathSnapshot = netPath.currentSnapshot()
-            let netInterfaces = SystemMetricsSamplers.networkInterfaces(
-                previous: prevNetInterfaces,
-                current: netRaw.interfaces,
-                interval: elapsed,
-                activeName: pathSnapshot?.activeInterfaceName
-            )
-            prevNet = (netRaw.rx, netRaw.tx)
-            prevNetInterfaces = Dictionary(
-                netRaw.interfaces.map { ($0.name, $0) },
-                uniquingKeysWith: { first, _ in first }
-            )
-
-            let diskRaw = SystemMetricsSamplers.sampleDiskCounters()
-            let diskRead = SystemMetricsSamplers.rate(current: diskRaw.read, previous: prevDisk?.read ?? diskRaw.read, interval: elapsed)
-            let diskWrite = SystemMetricsSamplers.rate(current: diskRaw.written, previous: prevDisk?.written ?? diskRaw.written, interval: elapsed)
-            prevDisk = diskRaw
+            var diskRead: Double = 0
+            var diskWrite: Double = 0
+            if options.disk {
+                let diskRaw = SystemMetricsSamplers.sampleDiskCounters()
+                diskRead = SystemMetricsSamplers.rate(current: diskRaw.read, previous: prevDisk?.read ?? diskRaw.read, interval: elapsed)
+                diskWrite = SystemMetricsSamplers.rate(current: diskRaw.written, previous: prevDisk?.written ?? diskRaw.written, interval: elapsed)
+                prevDisk = diskRaw
+            }
 
             if options.gpu, MonitoringCadence.shouldSampleGPU(updateCount: updateCount, cadence: gpuSampleCadence) {
                 lastGPU = SystemMetricsSamplers.sampleGPU()
@@ -196,7 +236,8 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
                 }
             }
 
-            let power = SystemMetricsSamplers.samplePower()
+            let power: SystemMetricsSamplers.PowerSample? =
+                options.power ? SystemMetricsSamplers.samplePower() : nil
 
             var accessories: [MonitorAccessoryBattery]?
             if options.accessories {
@@ -234,30 +275,32 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
                 sensors = sensorSampler?.sample()
             }
 
-            let loadAverages = loadAverageSampler()
+            let loadAverages = options.cpu ? loadAverageSampler() : nil
 
             let snapshot = MonitorSystemSnapshot(
-                cpuTotal: cpu.sample.total,
-                cpuUser: cpu.sample.user,
-                cpuSystem: cpu.sample.system,
-                perCore: cpu.sample.perCore.isEmpty ? nil : cpu.sample.perCore,
-                memUsedBytes: memory.usedBytes,
-                memTotalBytes: memory.totalBytes,
-                memPressure: SystemMetricsSource.memoryPressureWireValue(from: pressure),
-                swapUsedBytes: SystemMetricsSamplers.sampleSwapUsedBytes(),
+                cpuTotal: cpuSample?.total ?? 0,
+                cpuUser: cpuSample?.user ?? 0,
+                cpuSystem: cpuSample?.system ?? 0,
+                perCore: (cpuSample?.perCore).flatMap { $0.isEmpty ? nil : $0 },
+                memUsedBytes: memory?.usedBytes ?? 0,
+                memTotalBytes: memory?.totalBytes ?? 0,
+                memPressure: options.memory
+                    ? SystemMetricsSource.memoryPressureWireValue(from: pressure)
+                    : "normal",
+                swapUsedBytes: swapUsedBytes,
                 gpuUsage: lastGPU?.deviceUtil,
                 thermalState: SystemMetricsSamplers.thermalString(ProcessInfo.processInfo.thermalState),
                 netRxBytesPerSec: netRx,
                 netTxBytesPerSec: netTx,
                 diskReadBytesPerSec: diskRead,
                 diskWriteBytesPerSec: diskWrite,
-                batteryLevel: power.battery?.level,
-                batteryCharging: power.battery?.charging,
+                batteryLevel: power?.battery?.level,
+                batteryCharging: power?.battery?.charging,
                 loadAverage1: loadAverages?.first,
                 topProcesses: topProcesses,
                 cpuInfo: cpuInfo,
                 cpuLoadAvg: loadAverages,
-                memBreakdown: memory.breakdown,
+                memBreakdown: memory?.breakdown,
                 gpuDeviceName: gpuDeviceName,
                 gpuCoreCount: lastGPU?.coreCount,
                 gpuSampledAt: lastGPUSampledAt,
@@ -265,11 +308,11 @@ final class SystemMetricsSource: MonitorDataSource, Sendable {
                 gpuTilerUtil: lastGPU?.tilerUtil,
                 netInterfaces: netInterfaces.isEmpty ? nil : netInterfaces,
                 netPath: pathSnapshot?.path,
-                batteryIsCharged: power.battery?.isCharged,
-                powerSource: power.powerSource,
-                batteryMinutesRemaining: power.battery?.minutesRemaining,
-                batteryMinutesToFull: power.battery?.minutesToFull,
-                lowPowerMode: power.lowPowerMode,
+                batteryIsCharged: power?.battery?.isCharged,
+                powerSource: power?.powerSource,
+                batteryMinutesRemaining: power?.battery?.minutesRemaining,
+                batteryMinutesToFull: power?.battery?.minutesToFull,
+                lowPowerMode: power?.lowPowerMode,
                 accessories: accessories,
                 aneProcesses: lastANE.flatMap { $0.processes.isEmpty ? nil : $0.processes },
                 aneFootprintPresent: lastANE?.hasFootprint,

--- a/LiveWallpaper/Runtime/Assets/WPEAnimatedFrameByteCache.swift
+++ b/LiveWallpaper/Runtime/Assets/WPEAnimatedFrameByteCache.swift
@@ -1,0 +1,236 @@
+#if !LITE_BUILD
+import Foundation
+import os
+
+/// Process-wide byte-budget LRU for decoded animation frame bytes, shared by
+/// every `WPETexLazyAnimatedTextureSource` across scenes and displays. This
+/// replaces the former per-source "4 decoded frames" cap, whose worst case
+/// scaled with the number of concurrent animations, not with a budget.
+///
+/// Eviction policy (WebKit MemoryCache-style):
+/// 1. speculative (prefetched, never yet consumed) entries evict first, LRU;
+/// 2. then consumed entries, LRU;
+/// 3. per-source pinned image IDs (the frame currently on screen) are skipped;
+/// 4. prune runs to ~80% of budget so admission doesn't thrash at the edge;
+/// 5. frames above the admission cap are never stored (callers hold them
+///    transiently for upload only).
+///
+/// Thread-safe: prefetch queues store from worker threads while render actors
+/// look up. All state sits behind one unfair lock; entries are `Data` values.
+final class WPEAnimatedFrameByteCache: @unchecked Sendable {
+    struct SourceToken: Hashable, Sendable {
+        fileprivate let id: UInt64
+    }
+
+    private struct Key: Hashable {
+        let source: UInt64
+        let imageID: Int
+    }
+
+    private struct Entry {
+        let bytes: Data
+        var lastAccess: UInt64
+        var speculative: Bool
+    }
+
+    private struct State {
+        var entries: [Key: Entry] = [:]
+        var pinnedImageIDBySource: [UInt64: Int] = [:]
+        var totalBytes = 0
+        var tick: UInt64 = 0
+        var nextSourceID: UInt64 = 1
+    }
+
+    static let shared = WPEAnimatedFrameByteCache(
+        budgetBytes: WPEMemoryTier.current.animatedFrameCacheBudgetBytes,
+        admissionByteCap: WPEMemoryTier.current.animatedFrameAdmissionByteCap,
+        respondsToMemoryPressure: true
+    )
+
+    let budgetBytes: Int
+    let admissionByteCap: Int
+    /// Hysteresis target — prune to 80% so the next admissions don't re-trigger.
+    private var pruneTargetBytes: Int { budgetBytes * 8 / 10 }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    private var pressureSource: DispatchSourceMemoryPressure?
+
+    init(budgetBytes: Int, admissionByteCap: Int, respondsToMemoryPressure: Bool = false) {
+        self.budgetBytes = max(0, budgetBytes)
+        self.admissionByteCap = max(0, admissionByteCap)
+        if respondsToMemoryPressure {
+            let source = DispatchSource.makeMemoryPressureSource(
+                eventMask: [.warning, .critical],
+                queue: DispatchQueue.global(qos: .utility)
+            )
+            // weak source: the handler must not retain the source it hangs on.
+            source.setEventHandler { [weak self, weak source] in
+                guard let self, let source else { return }
+                let event = source.data
+                if event.contains(.critical) {
+                    self.removeAllUnpinned()
+                } else if event.contains(.warning) {
+                    self.removeSpeculative()
+                }
+            }
+            source.activate()
+            pressureSource = source
+        }
+    }
+
+    deinit {
+        pressureSource?.cancel()
+    }
+
+    // MARK: - Source lifecycle
+
+    func registerSource() -> SourceToken {
+        state.withLock { state in
+            let id = state.nextSourceID
+            state.nextSourceID += 1
+            return SourceToken(id: id)
+        }
+    }
+
+    /// Returns the source's lease: drops its entries and its pin.
+    func unregisterSource(_ token: SourceToken) {
+        removeAll(for: token)
+    }
+
+    func removeAll(for token: SourceToken) {
+        state.withLock { state in
+            state.pinnedImageIDBySource.removeValue(forKey: token.id)
+            removeEntries(in: &state) { key, _ in key.source == token.id }
+        }
+    }
+
+    // MARK: - Store / lookup
+
+    /// Admits the frame unless it exceeds the admission cap. `speculative`
+    /// marks prefetched entries that have not yet been consumed on screen.
+    /// Returns whether the entry was admitted.
+    @discardableResult
+    func store(_ bytes: Data, source: SourceToken, imageID: Int, speculative: Bool) -> Bool {
+        guard bytes.count <= admissionByteCap else { return false }
+        return state.withLock { state in
+            let key = Key(source: token(source), imageID: imageID)
+            state.tick += 1
+            if let existing = state.entries[key] {
+                state.totalBytes -= existing.bytes.count
+            }
+            state.entries[key] = Entry(bytes: bytes, lastAccess: state.tick, speculative: speculative)
+            state.totalBytes += bytes.count
+            pruneIfNeeded(&state)
+            return true
+        }
+    }
+
+    /// Touches the entry, clears its speculative flag, and pins it as the
+    /// source's current on-screen image.
+    func lookup(source: SourceToken, imageID: Int) -> Data? {
+        state.withLock { state in
+            let key = Key(source: token(source), imageID: imageID)
+            guard var entry = state.entries[key] else { return nil }
+            state.tick += 1
+            entry.lastAccess = state.tick
+            entry.speculative = false
+            state.entries[key] = entry
+            state.pinnedImageIDBySource[token(source)] = imageID
+            return entry.bytes
+        }
+    }
+
+    func contains(source: SourceToken, imageID: Int) -> Bool {
+        state.withLock { state in
+            state.entries[Key(source: token(source), imageID: imageID)] != nil
+        }
+    }
+
+    /// Pin without lookup — callers set the current frame before upload so a
+    /// concurrent prune from another source's admission can't evict it.
+    func pin(source: SourceToken, imageID: Int) {
+        state.withLock { state in
+            state.pinnedImageIDBySource[token(source)] = imageID
+        }
+    }
+
+    // MARK: - Pressure trims
+
+    /// Warning-level pressure: drop everything prefetched-but-unconsumed.
+    func removeSpeculative() {
+        state.withLock { state in
+            let pinned = pinnedKeys(state)
+            removeEntries(in: &state) { key, entry in
+                entry.speculative && !pinned.contains(key)
+            }
+        }
+    }
+
+    /// Critical-level pressure: drop everything except the on-screen frames.
+    func removeAllUnpinned() {
+        state.withLock { state in
+            let pinned = pinnedKeys(state)
+            removeEntries(in: &state) { key, _ in !pinned.contains(key) }
+        }
+    }
+
+    // MARK: - Introspection (diagnostics/tests)
+
+    var totalBytes: Int {
+        state.withLock { $0.totalBytes }
+    }
+
+    var entryCount: Int {
+        state.withLock { $0.entries.count }
+    }
+
+    func imageIDs(for token: SourceToken) -> Set<Int> {
+        state.withLock { state in
+            Set(state.entries.keys.filter { $0.source == token.id }.map(\.imageID))
+        }
+    }
+
+    // MARK: - Internals (caller holds the lock)
+
+    private func token(_ token: SourceToken) -> UInt64 { token.id }
+
+    private func pinnedKeys(_ state: State) -> Set<Key> {
+        Set(state.pinnedImageIDBySource.map { Key(source: $0.key, imageID: $0.value) })
+    }
+
+    private func removeEntries(in state: inout State, where predicate: (Key, Entry) -> Bool) {
+        let victims = state.entries.filter { predicate($0.key, $0.value) }.map(\.key)
+        for key in victims {
+            if let removed = state.entries.removeValue(forKey: key) {
+                state.totalBytes -= removed.bytes.count
+            }
+        }
+    }
+
+    private func pruneIfNeeded(_ state: inout State) {
+        guard state.totalBytes > budgetBytes else { return }
+        let pinned = pinnedKeys(state)
+
+        func evictLRU(speculativeOnly: Bool) {
+            while state.totalBytes > pruneTargetBytes {
+                let victim = state.entries
+                    .filter { key, entry in
+                        !pinned.contains(key) && (!speculativeOnly || entry.speculative)
+                    }
+                    .min { lhs, rhs in
+                        lhs.value.lastAccess != rhs.value.lastAccess
+                            ? lhs.value.lastAccess < rhs.value.lastAccess
+                            : (lhs.key.source, lhs.key.imageID) < (rhs.key.source, rhs.key.imageID)
+                    }?.key
+                guard let victim else { return }
+                if let removed = state.entries.removeValue(forKey: victim) {
+                    state.totalBytes -= removed.bytes.count
+                }
+            }
+        }
+
+        evictLRU(speculativeOnly: true)
+        evictLRU(speculativeOnly: false)
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/Assets/WPETexLazyAnimatedTextureSource.swift
+++ b/LiveWallpaper/Runtime/Assets/WPETexLazyAnimatedTextureSource.swift
@@ -56,8 +56,15 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
         repeating: WorkingTextureSlot(),
         count: WPEMetalRenderExecutor.maxFramesInFlight
     )
-    private var decodedImageCache: [Int: Data] = [:]
-    private var decodedImageOrder: [Int] = []
+    /// Process-wide decoded-frame byte budget (shared across all lazy sources).
+    private let frameByteCache: WPEAnimatedFrameByteCache
+    private let cacheToken: WPEAnimatedFrameByteCache.SourceToken
+    /// Reusable sub-rect crop target per frame slot — steady state allocates
+    /// nothing per frame (the slot's texture.replace copies out synchronously).
+    private var cropScratchSlots = Array(
+        repeating: Data(),
+        count: WPEMetalRenderExecutor.maxFramesInFlight
+    )
     /// In-flight prefetch jobs (dedup + bounded backlog; drop when leaving look-ahead).
     private var prefetchJobs: [Int: (item: DispatchWorkItem, box: OSAllocatedUnfairLock<PrefetchOutcome>)] = [:]
     /// Failed image IDs — never re-scheduled (corrupt frame thrash guard).
@@ -75,7 +82,7 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
     // Probes harvest first so tests without a completion pump see finished decodes.
     var debugDecodedImageCacheIDs: Set<Int> {
         harvestCompletedPrefetches()
-        return Set(decodedImageCache.keys)
+        return frameByteCache.imageIDs(for: cacheToken)
     }
     var debugPrefetchInFlightImageIDs: Set<Int> {
         harvestCompletedPrefetches()
@@ -89,8 +96,6 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
 
     /// Distinct upcoming source images to keep warm (wrap-aware, by image not frame).
     private static let decodedImagePrefetchLookahead = 2
-    /// Decoded-cache upper bound = current + prefetch window + one slack.
-    private static let decompressedImageCacheCapacity = 4
         /// Anti-OOM hard cap on `Data(count:)` for an untrusted `decompressedByteCount`; mirrors
         /// the eager path's cap (WPETexDecoder.swift:922, 256 MB).
         private static let maxDecompressedByteCount = 268_435_456
@@ -100,7 +105,8 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
         device: MTLDevice,
         label: String,
         capabilities: WPEMetalTextureCapabilities? = nil,
-        maximumTextureDimension2D: Int? = nil
+        maximumTextureDimension2D: Int? = nil,
+        frameByteCache: WPEAnimatedFrameByteCache = .shared
     ) throws {
         guard !payload.frames.isEmpty else { throw Failure.missingFrames }
         guard let format = payload.info.format else {
@@ -124,6 +130,8 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
         self.label = label
         self.maximumTextureDimension2D = maximumTextureDimension2D
             ?? WPEMetalTextureLimits.maximum2DTextureDimension(for: device)
+        self.frameByteCache = frameByteCache
+        self.cacheToken = frameByteCache.registerSource()
 
         var cursor: TimeInterval = 0
         var starts: [TimeInterval] = []
@@ -134,6 +142,11 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
         }
         self.frameStartTimes = starts
         self.totalDuration = cursor > 0 ? cursor : Double(payload.frames.count) / self.frameRate
+    }
+
+    deinit {
+        // Return the process-cache lease; entries must not outlive the source.
+        frameByteCache.unregisterSource(cacheToken)
     }
 
     func texture(at time: TimeInterval) -> MTLTexture? {
@@ -151,7 +164,7 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
         do {
             let frame = frames[index]
             let image = try decodedImage(for: frame.imageID)
-            let cropped = try crop(image: image, frame: frame)
+            let cropped = try crop(image: image, frame: frame, frameSlot: frameSlot)
             let texture = try textureForUpload(
                 width: cropped.width,
                 height: cropped.height,
@@ -214,8 +227,11 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
             repeating: WorkingTextureSlot(),
             count: WPEMetalRenderExecutor.maxFramesInFlight
         )
-        decodedImageCache.removeAll(keepingCapacity: false)
-        decodedImageOrder.removeAll(keepingCapacity: false)
+        cropScratchSlots = Array(
+            repeating: Data(),
+            count: WPEMetalRenderExecutor.maxFramesInFlight
+        )
+        frameByteCache.removeAll(for: cacheToken)
         // Cancel in-flight jobs; orphaned boxes are never harvested.
         for job in prefetchJobs.values { job.item.cancel() }
         prefetchJobs.removeAll(keepingCapacity: false)
@@ -229,8 +245,7 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
     private func decodedImage(for imageID: Int) throws -> Data {
         // Prefetch may already have completed off-thread.
         harvestCompletedPrefetches()
-        if let cached = decodedImageCache[imageID] {
-            touchDecodedImage(imageID)
+        if let cached = frameByteCache.lookup(source: cacheToken, imageID: imageID) {
             return cached
         }
         guard compressedImages.indices.contains(imageID) else {
@@ -252,7 +267,11 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
 #if DEBUG
         debugSynchronousDecodedImageIDs.append(imageID)
 #endif
-        storeDecodedImage(decoded, for: imageID)
+        // Pin before store so the concurrent prune from another source's
+        // admission cannot evict the frame we are about to upload. Oversize
+        // frames stay out of the cache (upload-and-release).
+        frameByteCache.pin(source: cacheToken, imageID: imageID)
+        frameByteCache.store(decoded, source: cacheToken, imageID: imageID, speculative: false)
         return decoded
     }
 
@@ -273,11 +292,15 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
         }
 
         for imageID in wanted {
-            guard decodedImageCache[imageID] == nil,
+            guard !frameByteCache.contains(source: cacheToken, imageID: imageID),
                   prefetchJobs[imageID] == nil,
                   !prefetchFailedImageIDs.contains(imageID),
                   compressedImages.indices.contains(imageID),
-                  let mipmap = compressedImages[imageID].payloads.first else { continue }
+                  let mipmap = compressedImages[imageID].payloads.first,
+                  // Oversize frames never prefetch: they cannot enter the
+                  // cache, so a speculative decode would be thrown away.
+                  mipmap.decompressedByteCount <= frameByteCache.admissionByteCap
+            else { continue }
 
 #if DEBUG
             let delay = debugPrefetchDecodeDelay
@@ -311,8 +334,9 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
                 continue
             }
             // Drop stale results so they can't LRU-evict current/next.
-            guard prefetchWantedImageIDs.contains(imageID), decodedImageCache[imageID] == nil else { continue }
-            storeDecodedImage(decoded, for: imageID)
+            guard prefetchWantedImageIDs.contains(imageID),
+                  !frameByteCache.contains(source: cacheToken, imageID: imageID) else { continue }
+            frameByteCache.store(decoded, source: cacheToken, imageID: imageID, speculative: true)
         }
     }
 
@@ -333,7 +357,8 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
                 break
             }
             let imageID = frames[targetIndex].imageID
-            guard seen.insert(imageID).inserted, decodedImageCache[imageID] == nil else { continue }
+            guard seen.insert(imageID).inserted,
+                  !frameByteCache.contains(source: cacheToken, imageID: imageID) else { continue }
             imageIDs.append(imageID)
             if imageIDs.count == Self.decodedImagePrefetchLookahead { break }
         }
@@ -344,25 +369,6 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
         prefetchJobs.removeValue(forKey: imageID)?.item.cancel()
     }
 
-    private func storeDecodedImage(_ decoded: Data, for imageID: Int) {
-        decodedImageCache[imageID] = decoded
-        touchDecodedImage(imageID)
-        evictIfNeeded()
-    }
-
-    private func touchDecodedImage(_ imageID: Int) {
-        decodedImageOrder.removeAll { $0 == imageID }
-        decodedImageOrder.append(imageID)
-    }
-
-    private func evictIfNeeded() {
-        while decodedImageOrder.count > Self.decompressedImageCacheCapacity,
-              let victim = decodedImageOrder.first {
-            decodedImageOrder.removeFirst()
-            decodedImageCache.removeValue(forKey: victim)
-        }
-    }
-
     private nonisolated static func decodedBytes(from mipmap: WPETexCompressedMipmap) throws -> Data {
         if mipmap.isCompressed {
             return try inflate(mipmap)
@@ -370,7 +376,7 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
         guard mipmap.compressedBytes.count >= mipmap.decompressedByteCount else {
             throw Failure.truncatedImageBytes
         }
-        return mipmap.compressedBytes.prefix(mipmap.decompressedByteCount)
+        return mipmap.compressedBytes.prefix(mipmap.decompressedByteCount).materializedData()
     }
 
     private nonisolated static func inflate(_ mipmap: WPETexCompressedMipmap) throws -> Data {
@@ -389,7 +395,7 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
                       let src = srcRaw.bindMemory(to: UInt8.self).baseAddress else { return -1 }
                 return compression_decode_buffer(
                     dst, outputCount,
-                    src, mipmap.compressedBytes.count,
+                    src, srcRaw.count,
                     nil,
                     COMPRESSION_LZ4_RAW
                 )
@@ -407,21 +413,28 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
     }
 
     /// Crop sub-rect (row copy or 4×4 BC blocks). Non-block-aligned BC rects throw.
-    private func crop(image: Data, frame: WPETexStreamingFrame) throws -> Cropped {
+    /// A frame covering the whole image uploads the decoded buffer directly —
+    /// no second full-frame copy (P1.4); sub-rects reuse a per-slot scratch.
+    private func crop(image: Data, frame: WPETexStreamingFrame, frameSlot: Int) throws -> Cropped {
         guard compressedImages.indices.contains(frame.imageID),
               let mipmap = compressedImages[frame.imageID].payloads.first else {
             throw Failure.missingCompressedImage(frame.imageID)
         }
         let rect = pixelRect(frame.subRect, width: mipmap.width, height: mipmap.height)
         try validateTextureDimensions(width: rect.width, height: rect.height)
+        let coversFullImage = rect.x == 0 && rect.y == 0
+            && rect.width == mipmap.width && rect.height == mipmap.height
 
         if let bytesPerPixel = mapping.bytesPerPixel {
             let sourceBytesPerRow = mipmap.width * bytesPerPixel
-            let outputBytesPerRow = rect.width * bytesPerPixel
             guard image.count >= sourceBytesPerRow * mipmap.height else {
                 throw Failure.truncatedImageBytes
             }
-            var output = Data(count: outputBytesPerRow * rect.height)
+            if coversFullImage {
+                return Cropped(bytes: image, width: rect.width, height: rect.height, bytesPerRow: sourceBytesPerRow)
+            }
+            let outputBytesPerRow = rect.width * bytesPerPixel
+            var output = takeCropScratch(slot: frameSlot, byteCount: outputBytesPerRow * rect.height)
             image.withUnsafeBytes { srcRaw in
                 output.withUnsafeMutableBytes { dstRaw in
                     guard let src = srcRaw.bindMemory(to: UInt8.self).baseAddress,
@@ -433,6 +446,7 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
                     }
                 }
             }
+            cropScratchSlots[frameSlot] = output
             return Cropped(bytes: output, width: rect.width, height: rect.height, bytesPerRow: outputBytesPerRow)
         }
 
@@ -460,7 +474,10 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
         guard image.count >= sourceBytesPerBlockRow * sourceBlocksY else {
             throw Failure.truncatedImageBytes
         }
-        var output = Data(count: outputBytesPerBlockRow * cropBlocksY)
+        if coversFullImage {
+            return Cropped(bytes: image, width: rect.width, height: rect.height, bytesPerRow: sourceBytesPerBlockRow)
+        }
+        var output = takeCropScratch(slot: frameSlot, byteCount: outputBytesPerBlockRow * cropBlocksY)
         image.withUnsafeBytes { srcRaw in
             output.withUnsafeMutableBytes { dstRaw in
                 guard let src = srcRaw.bindMemory(to: UInt8.self).baseAddress,
@@ -472,7 +489,20 @@ final class WPETexLazyAnimatedTextureSource: WPEDynamicTextureSource {
                 }
             }
         }
+        cropScratchSlots[frameSlot] = output
         return Cropped(bytes: output, width: rect.width, height: rect.height, bytesPerRow: outputBytesPerBlockRow)
+    }
+
+    /// Detaches the slot's scratch so the mutation below cannot CoW-copy
+    /// (the array would otherwise hold a second reference). Same-size frames
+    /// reuse the allocation; a size change (rare) reallocates once.
+    private func takeCropScratch(slot: Int, byteCount: Int) -> Data {
+        var scratch = cropScratchSlots[slot]
+        cropScratchSlots[slot] = Data()
+        if scratch.count != byteCount {
+            scratch = Data(count: byteCount)
+        }
+        return scratch
     }
 
     private struct PixelRect {

--- a/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
+++ b/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
@@ -82,6 +82,11 @@ final class WPEVideoTextureSource {
     /// Test seam: retired frames whose wrappers are still held for the GPU.
     var pendingRetirementCountForTesting: Int { pendingRetirements.count }
 
+    /// Test seam: total fences ever registered. `pendingRetirements` is empty
+    /// both when a frame was fenced-and-drained and when it was never fenced at
+    /// all, so the count is what distinguishes them at teardown.
+    private(set) var retirementFencesCreatedForTesting = 0
+
     /// Test seam: skip the macOS 15+ player-level output so the item-level
     /// (`AVPlayerItemVideoOutput`) branch — the shipping path on macOS 14 — is
     /// exercisable on an OS where both APIs exist.
@@ -296,6 +301,18 @@ final class WPEVideoTextureSource {
         // completed handlers only mark flags — they hold no wrapper to carry a
         // late release past this point. Bounded wait (one small pass per
         // fence, already committed).
+        // The frame still published has never been retired — retirement happens
+        // at replacement, and there is no next publish. On the biplanar path the
+        // drain below already covers it (its conversion pass is the fence
+        // registered by that publish), but a BGRA frame is sampled by the
+        // renderer directly, so fence it now: without this, releasing the
+        // wrapper hands the buffer back to a pool the decoder is still feeding
+        // for the few milliseconds until `player.pause()` below, and a render
+        // command buffer mid-flight would sample the overwritten surface.
+        if let current = latest, let marker = conversionQueue.makeCommandBuffer() {
+            retire(current, fence: marker)
+            marker.commit()
+        }
         drainRetiredFrames()
         // Drop the published frame BEFORE the player goes away. Its
         // `CVMetalTexture` backing references a pixel buffer owned by the video
@@ -485,6 +502,7 @@ final class WPEVideoTextureSource {
     /// `invalidate()` can wait out the conversion pass reading the CURRENT
     /// frame's planes. Must run before `fence` is committed.
     private func retire(_ previous: PublishedFrame?, fence: MTLCommandBuffer) {
+        retirementFencesCreatedForTesting += 1
         let flag = WPEFrameFenceFlag()
         fence.addCompletedHandler { _ in flag.markCompleted() }
         pendingRetirements.append(PendingFrameRetirement(

--- a/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
+++ b/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
@@ -59,32 +59,45 @@ final class WPEVideoTextureSource {
 
     private struct PublishedFrame {
         let texture: MTLTexture
-        /// CV wrappers stay retained until the next publish replaces this frame:
-        /// the pool must not recycle a plane's pixel buffer while the GPU may
-        /// still read it (conversion pass or direct sampling). One wrapper on
-        /// the BGRA path, two (luma + chroma) on the biplanar path.
-        ///
-        /// Known gap (accepted, predates NV12): "until the next publish" is not
-        /// "until command-buffer completion" — with the GPU a full publish
-        /// behind, the pool can reuse the buffer mid-read (transient tear, no
-        /// crash: the MTLTexture keeps the IOSurface mapped). The BGRA wrap
-        /// path shipped with the same window, and the NV12 conversion pass
-        /// completes strictly earlier than the render pass that window covered.
-        /// Extending retention to a completed-handler must first resolve the
-        /// invalidate() ordering documented above `latest = nil` in
-        /// `invalidate()` (wrapper release after pool teardown crashes).
+        /// CV wrappers stay retained here until the next publish replaces this
+        /// frame (one wrapper on the BGRA path, luma + chroma on biplanar).
+        /// At replacement they do NOT drop — they move into
+        /// `pendingRetirements`, fenced by a command buffer committed on
+        /// `conversionQueue` at that publish (NV12: the conversion pass itself;
+        /// BGRA: an empty marker buffer). In the app `conversionQueue` is the
+        /// render executor's frame queue, so the fence completes only after
+        /// every render command buffer that could still sample this frame —
+        /// the pool cannot recycle a plane mid-read anymore. Release happens
+        /// on the publishing thread (`sweepRetiredFrames`) or in `invalidate()`
+        /// after `waitUntilCompleted` on the fences; the completed handler
+        /// itself never releases anything (see `WPEFrameFenceFlag`).
         let retainedSourceTextures: [CVMetalTexture]
     }
+
+    /// Retired frame wrappers waiting for their GPU fence. Mutated only on the
+    /// thread that owns this source (render executor in the app); the completed
+    /// handler touches only the flag, never this array.
+    private var pendingRetirements: [PendingFrameRetirement] = []
+
+    /// Test seam: retired frames whose wrappers are still held for the GPU.
+    var pendingRetirementCountForTesting: Int { pendingRetirements.count }
+
+    /// Test seam: skip the macOS 15+ player-level output so the item-level
+    /// (`AVPlayerItemVideoOutput`) branch — the shipping path on macOS 14 — is
+    /// exercisable on an OS where both APIs exist.
+    private let forceLegacyItemLevelOutput: Bool
 
     init(
         device: MTLDevice,
         videoURL: URL,
         commandQueue: MTLCommandQueue? = nil,
-        onInvalidate: (@Sendable (URL) -> Void)? = nil
+        onInvalidate: (@Sendable (URL) -> Void)? = nil,
+        forceLegacyItemLevelOutputForTesting: Bool = false
     ) throws {
         self.cleanupURL = videoURL
         self.onInvalidate = onInvalidate
         self.device = device
+        self.forceLegacyItemLevelOutput = forceLegacyItemLevelOutputForTesting
         guard let queue = commandQueue ?? device.makeCommandQueue() else {
             throw WPEMetalTextureLoaderError.textureAllocationFailed
         }
@@ -137,7 +150,7 @@ final class WPEVideoTextureSource {
         self.videoOutput = output
 
         // macOS 15+: attach player-level output BEFORE looper enqueues items.
-        if #available(macOS 15.0, *) {
+        if #available(macOS 15.0, *), !forceLegacyItemLevelOutput {
             self.playerLevelOutput = WPEPlayerLevelVideoOutput(
                 player: queuePlayer,
                 pixelFormats: Self.negotiatedPixelFormats
@@ -146,8 +159,10 @@ final class WPEVideoTextureSource {
 
         self.playerLooper = AVPlayerLooper(player: queuePlayer, templateItem: playerItem)
 
-        // macOS 14: item-level output; stay paused until performance profile.
-        if #unavailable(macOS 15.0) {
+        // macOS 14 (or forced legacy): item-level output; stay paused until
+        // performance profile. `texture(at:)` falls through to this path
+        // whenever `playerLevelOutput` is nil.
+        if playerLevelOutput == nil {
             attachOutputIfNeeded(to: queuePlayer.currentItem ?? playerItem)
         }
     }
@@ -201,6 +216,12 @@ final class WPEVideoTextureSource {
             if !scriptControlled { player.play() }
         case .suspended:
             player.pause()
+            // `sweepRetiredFrames` only runs from `publish`, and a paused source
+            // never publishes again — without this the last replaced frame's
+            // planes (~12 MiB NV12 4K, ~32 MiB BGRA) stay resident for the whole
+            // suspension. Fences here are a conversion pass or an empty marker,
+            // both already committed, so the wait is bounded and short.
+            drainRetiredFrames()
         }
     }
 
@@ -267,6 +288,12 @@ final class WPEVideoTextureSource {
     func invalidate() {
         guard !isInvalidated else { return }
         isInvalidated = true
+        // Drain in-flight GPU work BEFORE releasing any CV wrapper: a pending
+        // conversion pass may still be reading retired planes, and the
+        // completed handlers only mark flags — they hold no wrapper to carry a
+        // late release past this point. Bounded wait (one small pass per
+        // fence, already committed).
+        drainRetiredFrames()
         // Drop the published frame BEFORE the player goes away. Its
         // `CVMetalTexture` backing references a pixel buffer owned by the video
         // output's pool, so releasing it after `remove(videoOutput)` /
@@ -313,6 +340,7 @@ final class WPEVideoTextureSource {
     }
 
     private func publish(pixelBuffer: CVPixelBuffer) {
+        sweepRetiredFrames()
         switch CVPixelBufferGetPixelFormatType(pixelBuffer) {
         case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
             publishBiPlanar(pixelBuffer: pixelBuffer, fullRange: false)
@@ -383,6 +411,10 @@ final class WPEVideoTextureSource {
         encoder.setFragmentBytes(&conversion, length: MemoryLayout<WPEVideoYCbCrConversion>.stride, index: 0)
         encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
         encoder.endEncoding()
+        // The conversion pass doubles as the retirement fence for the frame
+        // being replaced (same queue as the render executor → completes after
+        // any render pass that sampled it). Handler must attach pre-commit.
+        retire(latest, fence: commandBuffer)
         commandBuffer.commit()
 
         latest = PublishedFrame(texture: working.sampleView, retainedSourceTextures: [lumaCV, chromaCV])
@@ -431,10 +463,49 @@ final class WPEVideoTextureSource {
               let texture = CVMetalTextureGetTexture(cvTexture) else {
             return
         }
+        // No conversion pass on this path — commit an empty marker buffer as
+        // the retirement fence for the frame being replaced. If the marker
+        // cannot be created the wrappers drop immediately: that is exactly the
+        // pre-hardening contract, not a new hole.
+        if let previous = latest, let marker = conversionQueue.makeCommandBuffer() {
+            retire(previous, fence: marker)
+            marker.commit()
+        }
         latest = PublishedFrame(texture: texture, retainedSourceTextures: [cvTexture])
         lastPublishPathForTesting = .bgra
         // See publishBiPlanar for why this flush is safe and required.
         CVMetalTextureCacheFlush(textureCache, 0)
+    }
+
+    /// Queue a replaced frame's CV wrappers behind a GPU fence. Also called
+    /// with `nil` (biplanar first publish) purely to track the fence, so
+    /// `invalidate()` can wait out the conversion pass reading the CURRENT
+    /// frame's planes. Must run before `fence` is committed.
+    private func retire(_ previous: PublishedFrame?, fence: MTLCommandBuffer) {
+        let flag = WPEFrameFenceFlag()
+        fence.addCompletedHandler { _ in flag.markCompleted() }
+        pendingRetirements.append(PendingFrameRetirement(
+            fence: fence,
+            flag: flag,
+            wrappers: previous?.retainedSourceTextures ?? []
+        ))
+    }
+
+    /// Release wrappers whose fence completed. Runs on the publishing thread,
+    /// so wrapper release is never concurrent with player/pool teardown.
+    private func sweepRetiredFrames() {
+        guard !pendingRetirements.isEmpty else { return }
+        pendingRetirements.removeAll { $0.flag.isCompleted }
+    }
+
+    /// Wait out every pending fence and release all retired wrappers. Same
+    /// owning thread as `sweepRetiredFrames`; used where no further publish
+    /// will arrive to sweep (suspend, invalidate).
+    private func drainRetiredFrames() {
+        for retirement in pendingRetirements {
+            retirement.fence.waitUntilCompleted()
+        }
+        pendingRetirements.removeAll()
     }
 
     /// PQ/HLG-tagged buffers must not go through the 8-bit matrix path (that
@@ -454,6 +525,7 @@ final class WPEVideoTextureSource {
     private func rebuildOutputsForBGRAFallback(reason: String) {
         guard !forcedBGRAOutput else { return }
         forcedBGRAOutput = true
+        bgraFallbackRebuildCountForTesting += 1
         Logger.info(
             "[WPE.video] \(reason) — pinning video output to 32BGRA",
             category: .wpeRender
@@ -465,7 +537,7 @@ final class WPEVideoTextureSource {
         let output = AVPlayerItemVideoOutput(pixelBufferAttributes: Self.bgraFallbackPixelBufferAttributes)
         output.suppressesPlayerRendering = true
         videoOutput = output
-        if #available(macOS 15.0, *) {
+        if #available(macOS 15.0, *), !forceLegacyItemLevelOutput {
             (playerLevelOutput as? WPEPlayerLevelVideoOutput)?.detach()
             playerLevelOutput = WPEPlayerLevelVideoOutput(
                 player: player,
@@ -476,6 +548,9 @@ final class WPEVideoTextureSource {
             attachOutputIfNeeded(to: player.currentItem)
         }
     }
+
+    /// Test seam: number of HDR/shader-fallback output rebuilds (contract: at most 1).
+    private(set) var bgraFallbackRebuildCountForTesting = 0
 
     private func ensureConversionPipeline() -> MTLRenderPipelineState? {
         if let conversionPipeline { return conversionPipeline }
@@ -610,6 +685,38 @@ final class WPEVideoTextureSource {
 }
 
 extension WPEVideoTextureSource: WPEDynamicTextureSource {}
+
+/// The ONLY thing a frame-fence completed handler captures. It must never
+/// capture the source, the texture cache, or the wrappers themselves: an
+/// earlier attempt that released wrappers from the handler crashed when the
+/// handler fired after `invalidate()` had torn the buffer pool down
+/// (`CVBufferBacking::releaseUser` on a dead backing). A handler that only
+/// flips this flag is safe to fire at any time, on any thread.
+private final class WPEFrameFenceFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completed = false
+
+    func markCompleted() {
+        lock.lock()
+        completed = true
+        lock.unlock()
+    }
+
+    var isCompleted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return completed
+    }
+}
+
+/// Wrappers of a replaced frame plus the command buffer whose completion
+/// proves the GPU is done reading them. Owned exclusively by
+/// `WPEVideoTextureSource.pendingRetirements`.
+private struct PendingFrameRetirement {
+    let fence: MTLCommandBuffer
+    let flag: WPEFrameFenceFlag
+    let wrappers: [CVMetalTexture]
+}
 
 /// macOS 15+ player-level frame tap (spans looper rotations). Pixel formats
 /// come from the caller: NV12-first for the normal path, 32BGRA-only after the

--- a/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
+++ b/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
@@ -138,6 +138,9 @@ final class WPEVideoTextureSource {
         playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = false
 
         let queuePlayer = AVQueuePlayer()
+        // Deliberately NOT `actionAtItemEnd = .none`: AVPlayerLooper loops by
+        // advancing the queue, and pinning the player at item end stalls it at
+        // the last frame of the first pass. Do not re-add it.
         // Prefetch next looped item before wrap to avoid sparse-decode slow-mo.
         queuePlayer.automaticallyWaitsToMinimizeStalling = true
         queuePlayer.preventsDisplaySleepDuringVideoPlayback = false

--- a/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
+++ b/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
@@ -6,13 +6,16 @@ import Foundation
 import LiveWallpaperCore
 import Metal
 import QuartzCore
+import simd
 
 /// MP4-in-`.tex` video source → current frame as Metal texture (player-level output on macOS 15+).
 /// Player stays paused after init; performance profile starts it. Not `@MainActor` (renderer actor).
 final class WPEVideoTextureSource {
+    private let device: MTLDevice
     private let textureCache: CVMetalTextureCache
     private let player: AVQueuePlayer
-    private let videoOutput: AVPlayerItemVideoOutput
+    /// `var`: the HDR fallback replaces it with a BGRA-pinned output.
+    private var videoOutput: AVPlayerItemVideoOutput
     /// Retained for source lifetime — looper drops item rotation if released.
     private let playerLooper: AVPlayerLooper
     /// Resource-loader delegate is weak — hold the loader so in-memory bytes survive.
@@ -30,18 +33,62 @@ final class WPEVideoTextureSource {
     private var latest: PublishedFrame?
     private var isInvalidated = false
 
+    /// Conversion passes commit here. In the app this is the render executor's
+    /// frame queue: same-queue hazard tracking then orders the NV12→BGRA pass
+    /// ahead of the frame that samples the working texture (a private queue
+    /// would be unordered against the render frame).
+    private let conversionQueue: MTLCommandQueue
+    private var conversionPipeline: MTLRenderPipelineState?
+    private var conversionSetupFailed = false
+    /// Reused private BGRA render target for NV12 conversion, plus the sRGB
+    /// view the renderer samples. Recreated only when the decoder size changes.
+    private var workingTarget: MTLTexture?
+    private var workingSampleView: MTLTexture?
+    /// HDR fallback engaged — outputs are pinned to 32BGRA for the source's lifetime.
+    private var forcedBGRAOutput = false
+    private var loggedUnsupportedFormat = false
+
+    enum PublishPath {
+        case biPlanar
+        case bgra
+    }
+
+    /// Last publish branch taken — observation seam for the NV12 tests.
+    private(set) var lastPublishPathForTesting: PublishPath?
+    var didForceBGRAOutputForTesting: Bool { forcedBGRAOutput }
+
     private struct PublishedFrame {
         let texture: MTLTexture
-        let cvTexture: CVMetalTexture
+        /// CV wrappers stay retained until the next publish replaces this frame:
+        /// the pool must not recycle a plane's pixel buffer while the GPU may
+        /// still read it (conversion pass or direct sampling). One wrapper on
+        /// the BGRA path, two (luma + chroma) on the biplanar path.
+        ///
+        /// Known gap (accepted, predates NV12): "until the next publish" is not
+        /// "until command-buffer completion" — with the GPU a full publish
+        /// behind, the pool can reuse the buffer mid-read (transient tear, no
+        /// crash: the MTLTexture keeps the IOSurface mapped). The BGRA wrap
+        /// path shipped with the same window, and the NV12 conversion pass
+        /// completes strictly earlier than the render pass that window covered.
+        /// Extending retention to a completed-handler must first resolve the
+        /// invalidate() ordering documented above `latest = nil` in
+        /// `invalidate()` (wrapper release after pool teardown crashes).
+        let retainedSourceTextures: [CVMetalTexture]
     }
 
     init(
         device: MTLDevice,
         videoURL: URL,
+        commandQueue: MTLCommandQueue? = nil,
         onInvalidate: (@Sendable (URL) -> Void)? = nil
     ) throws {
         self.cleanupURL = videoURL
         self.onInvalidate = onInvalidate
+        self.device = device
+        guard let queue = commandQueue ?? device.makeCommandQueue() else {
+            throw WPEMetalTextureLoaderError.textureAllocationFailed
+        }
+        self.conversionQueue = queue
 
         var cache: CVMetalTextureCache?
         let status = CVMetalTextureCacheCreate(kCFAllocatorDefault, nil, device, nil, &cache)
@@ -91,7 +138,10 @@ final class WPEVideoTextureSource {
 
         // macOS 15+: attach player-level output BEFORE looper enqueues items.
         if #available(macOS 15.0, *) {
-            self.playerLevelOutput = WPEPlayerLevelVideoOutput(player: queuePlayer)
+            self.playerLevelOutput = WPEPlayerLevelVideoOutput(
+                player: queuePlayer,
+                pixelFormats: Self.negotiatedPixelFormats
+            )
         }
 
         self.playerLooper = AVPlayerLooper(player: queuePlayer, templateItem: playerItem)
@@ -225,6 +275,11 @@ final class WPEVideoTextureSource {
         // reached from `WPEDisplayRenderActor` teardown on a scene swap.
         latest = nil
         CVMetalTextureCacheFlush(textureCache, 0)
+        // Plain GPU allocations (not CV-backed) — safe to drop in any order;
+        // the renderer's own reference keeps a sampled view alive if needed.
+        workingTarget = nil
+        workingSampleView = nil
+        conversionPipeline = nil
         if #available(macOS 15.0, *), let playerOutput = playerLevelOutput as? WPEPlayerLevelVideoOutput {
             playerOutput.detach()
         }
@@ -258,6 +313,92 @@ final class WPEVideoTextureSource {
     }
 
     private func publish(pixelBuffer: CVPixelBuffer) {
+        switch CVPixelBufferGetPixelFormatType(pixelBuffer) {
+        case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+            publishBiPlanar(pixelBuffer: pixelBuffer, fullRange: false)
+        case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+            publishBiPlanar(pixelBuffer: pixelBuffer, fullRange: true)
+        case kCVPixelFormatType_32BGRA:
+            publishBGRA(pixelBuffer: pixelBuffer)
+        default:
+            // A format outside the requested set — drop the frame, keep the last one.
+            if !loggedUnsupportedFormat {
+                loggedUnsupportedFormat = true
+                Logger.warning(
+                    "[WPE.video] unsupported pixel format \(CVPixelBufferGetPixelFormatType(pixelBuffer)) — frame dropped",
+                    category: .wpeRender
+                )
+            }
+        }
+    }
+
+    /// NV12 decode surface → reused private BGRA working texture via a
+    /// fragment-shader YCbCr→RGB pass (matrix from the buffer's colorimetry
+    /// attachments). HDR (PQ/HLG) is explicitly out of scope: those buffers
+    /// re-pin the outputs to 32BGRA and take the legacy path instead.
+    private func publishBiPlanar(pixelBuffer: CVPixelBuffer, fullRange: Bool) {
+        if !forcedBGRAOutput, Self.isHDRTransfer(pixelBuffer) {
+            rebuildOutputsForBGRAFallback(reason: "HDR transfer function detected")
+            return
+        }
+        guard let pipeline = ensureConversionPipeline() else { return }
+        let lumaWidth = CVPixelBufferGetWidthOfPlane(pixelBuffer, 0)
+        let lumaHeight = CVPixelBufferGetHeightOfPlane(pixelBuffer, 0)
+        let chromaWidth = CVPixelBufferGetWidthOfPlane(pixelBuffer, 1)
+        let chromaHeight = CVPixelBufferGetHeightOfPlane(pixelBuffer, 1)
+
+        var lumaCV: CVMetalTexture?
+        guard CVMetalTextureCacheCreateTextureFromImage(
+            kCFAllocatorDefault, textureCache, pixelBuffer, nil,
+            .r8Unorm, lumaWidth, lumaHeight, 0, &lumaCV
+        ) == kCVReturnSuccess, let lumaCV, let lumaTexture = CVMetalTextureGetTexture(lumaCV) else {
+            return
+        }
+        var chromaCV: CVMetalTexture?
+        guard CVMetalTextureCacheCreateTextureFromImage(
+            kCFAllocatorDefault, textureCache, pixelBuffer, nil,
+            .rg8Unorm, chromaWidth, chromaHeight, 1, &chromaCV
+        ) == kCVReturnSuccess, let chromaCV, let chromaTexture = CVMetalTextureGetTexture(chromaCV) else {
+            return
+        }
+        guard let working = ensureWorkingTexture(width: lumaWidth, height: lumaHeight) else { return }
+
+        let matrixAttachment = CVBufferCopyAttachment(pixelBuffer, kCVImageBufferYCbCrMatrixKey, nil) as? String
+        var conversion = WPEVideoYCbCrConversion.make(
+            kind: WPEVideoYCbCrConversion.kind(matrixAttachment: matrixAttachment, sourceHeight: lumaHeight),
+            fullRange: fullRange
+        )
+
+        let passDescriptor = MTLRenderPassDescriptor()
+        passDescriptor.colorAttachments[0].texture = working.target
+        passDescriptor.colorAttachments[0].loadAction = .dontCare
+        passDescriptor.colorAttachments[0].storeAction = .store
+        guard let commandBuffer = conversionQueue.makeCommandBuffer(),
+              let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: passDescriptor) else {
+            return
+        }
+        encoder.setRenderPipelineState(pipeline)
+        encoder.setFragmentTexture(lumaTexture, index: 0)
+        encoder.setFragmentTexture(chromaTexture, index: 1)
+        encoder.setFragmentBytes(&conversion, length: MemoryLayout<WPEVideoYCbCrConversion>.stride, index: 0)
+        encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        encoder.endEncoding()
+        commandBuffer.commit()
+
+        latest = PublishedFrame(texture: working.sampleView, retainedSourceTextures: [lumaCV, chromaCV])
+        lastPublishPathForTesting = .biPlanar
+        // The cache holds a mapping per pixel buffer it has wrapped; the pool
+        // rotates buffers, so without a periodic flush the mappings accumulate
+        // for the source's lifetime. Flushing only drops unreferenced mappings —
+        // the frame just stored in `latest` retains its wrappers, so the in-use
+        // mappings survive.
+        CVMetalTextureCacheFlush(textureCache, 0)
+    }
+
+    /// Legacy direct-wrap path: BGRA buffers arrive when NV12 cannot represent
+    /// the source (alpha-bearing video) or after the HDR fallback pinned the
+    /// outputs to 32BGRA.
+    private func publishBGRA(pixelBuffer: CVPixelBuffer) {
         let width = CVPixelBufferGetWidth(pixelBuffer)
         let height = CVPixelBufferGetHeight(pixelBuffer)
         var cvTexture: CVMetalTexture?
@@ -290,20 +431,137 @@ final class WPEVideoTextureSource {
               let texture = CVMetalTextureGetTexture(cvTexture) else {
             return
         }
-        latest = PublishedFrame(texture: texture, cvTexture: cvTexture)
-        // The cache holds a mapping per pixel buffer it has wrapped; the pool
-        // rotates buffers, so without a periodic flush the mappings accumulate
-        // for the source's lifetime. Flushing only drops unreferenced mappings —
-        // the frame just stored in `latest` retains its `CVMetalTexture`, so
-        // the in-use mapping survives.
+        latest = PublishedFrame(texture: texture, retainedSourceTextures: [cvTexture])
+        lastPublishPathForTesting = .bgra
+        // See publishBiPlanar for why this flush is safe and required.
         CVMetalTextureCacheFlush(textureCache, 0)
+    }
+
+    /// PQ/HLG-tagged buffers must not go through the 8-bit matrix path (that
+    /// would drop the transfer function). P010/EDR is explicitly out of scope
+    /// (plan P1.6) — pin the outputs back to 32BGRA and let AVFoundation own
+    /// the HDR→SDR conversion, exactly the pre-NV12 behavior.
+    static func isHDRTransfer(_ pixelBuffer: CVPixelBuffer) -> Bool {
+        guard let transfer = CVBufferCopyAttachment(
+            pixelBuffer, kCVImageBufferTransferFunctionKey, nil
+        ) as? String else {
+            return false
+        }
+        return transfer == (kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ as String)
+            || transfer == (kCVImageBufferTransferFunction_ITU_R_2100_HLG as String)
+    }
+
+    private func rebuildOutputsForBGRAFallback(reason: String) {
+        guard !forcedBGRAOutput else { return }
+        forcedBGRAOutput = true
+        Logger.info(
+            "[WPE.video] \(reason) — pinning video output to 32BGRA",
+            category: .wpeRender
+        )
+        if let item = attachedOutputItem {
+            item.remove(videoOutput)
+            attachedOutputItem = nil
+        }
+        let output = AVPlayerItemVideoOutput(pixelBufferAttributes: Self.bgraFallbackPixelBufferAttributes)
+        output.suppressesPlayerRendering = true
+        videoOutput = output
+        if #available(macOS 15.0, *) {
+            (playerLevelOutput as? WPEPlayerLevelVideoOutput)?.detach()
+            playerLevelOutput = WPEPlayerLevelVideoOutput(
+                player: player,
+                pixelFormats: [kCVPixelFormatType_32BGRA]
+            )
+            lastPlayerLevelPresentationTime = nil
+        } else {
+            attachOutputIfNeeded(to: player.currentItem)
+        }
+    }
+
+    private func ensureConversionPipeline() -> MTLRenderPipelineState? {
+        if let conversionPipeline { return conversionPipeline }
+        guard !conversionSetupFailed else { return nil }
+        guard let library = device.makeDefaultLibrary(),
+              let vertexFunction = library.makeFunction(name: "wpe_fullscreen_vertex"),
+              let fragmentFunction = library.makeFunction(name: "wpe_video_nv12_convert_fragment") else {
+            conversionSetupFailed = true
+            // Same escape hatch as HDR: don't latch into dropping every NV12
+            // frame (frozen video) — rebuild the outputs as 32BGRA and keep playing.
+            rebuildOutputsForBGRAFallback(reason: "NV12 conversion shaders unavailable")
+            return nil
+        }
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.vertexFunction = vertexFunction
+        descriptor.fragmentFunction = fragmentFunction
+        descriptor.colorAttachments[0].pixelFormat = .bgra8Unorm
+        do {
+            let pipeline = try device.makeRenderPipelineState(descriptor: descriptor)
+            conversionPipeline = pipeline
+            return pipeline
+        } catch {
+            conversionSetupFailed = true
+            rebuildOutputsForBGRAFallback(reason: "NV12 conversion pipeline failed: \(error)")
+            return nil
+        }
+    }
+
+    private func ensureWorkingTexture(width: Int, height: Int) -> (target: MTLTexture, sampleView: MTLTexture)? {
+        if let workingTarget, let workingSampleView,
+           workingTarget.width == width, workingTarget.height == height {
+            return (workingTarget, workingSampleView)
+        }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm,
+            width: width,
+            height: height,
+            mipmapped: false
+        )
+        // `.pixelFormatView` is required for the sRGB view below. Omitting it
+        // happens to work on this Mac even under the Metal validation layer,
+        // but that is undocumented tolerance: without the flag the view can
+        // fail elsewhere and the `?? target` fallback would silently sample
+        // gamma bytes as linear — brighter video, no log.
+        descriptor.usage = [.renderTarget, .shaderRead, .pixelFormatView]
+        descriptor.storageMode = .private
+        guard let target = device.makeTexture(descriptor: descriptor) else { return nil }
+        target.label = "WPE video NV12 working texture"
+        // The pass stores gamma R'G'B' bytes in a non-sRGB target; the renderer
+        // samples through this sRGB view — byte-identical to the old
+        // `.bgra8Unorm_srgb` CV wrap, with no double gamma conversion.
+        let sampleView = target.makeTextureView(pixelFormat: .bgra8Unorm_srgb) ?? target
+        workingTarget = target
+        workingSampleView = sampleView
+        return (target, sampleView)
+    }
+
+    /// Direct pixel-buffer ingest — test seam for hermetic NV12/HDR/BGRA
+    /// branch coverage without AVPlayer timing.
+    func ingestForTesting(pixelBuffer: CVPixelBuffer) {
+        publish(pixelBuffer: pixelBuffer)
     }
 
     /// 2s forward buffer (RAM-resident asset; longer buffers only cost decoder state).
     private static let bufferHintSeconds: TimeInterval = 2
 
-    /// BGRA Metal video-output attrs as `[String: any Sendable]` for concurrency.
+    /// Decoder-native NV12 first (video then full range) with a 32BGRA tail:
+    /// AVFoundation picks the closest match to the source, so 8-bit SDR lands
+    /// on the biplanar path and sources NV12 cannot represent (alpha video)
+    /// negotiate BGRA. Width/height stay absent — buffers mirror the decoder's
+    /// dimensions (VideoResolutionContract).
+    private static let negotiatedPixelFormats: [OSType] = [
+        kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+        kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+        kCVPixelFormatType_32BGRA
+    ]
+
+    /// Metal video-output attrs as `[String: any Sendable]` for concurrency.
     private static let outputPixelBufferAttributes: [String: any Sendable] = [
+        kCVPixelBufferPixelFormatTypeKey as String: negotiatedPixelFormats,
+        kCVPixelBufferMetalCompatibilityKey as String: true,
+        kCVPixelBufferIOSurfacePropertiesKey as String: [String: any Sendable]()
+    ]
+
+    /// HDR fallback attrs: 32BGRA only, no width/height (decoder dimensions).
+    private static let bgraFallbackPixelBufferAttributes: [String: any Sendable] = [
         kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
         kCVPixelBufferMetalCompatibilityKey as String: true,
         kCVPixelBufferIOSurfacePropertiesKey as String: [String: any Sendable]()
@@ -353,17 +611,18 @@ final class WPEVideoTextureSource {
 
 extension WPEVideoTextureSource: WPEDynamicTextureSource {}
 
-/// macOS 15+ player-level frame tap (spans looper rotations; 32BGRA for existing texture path).
+/// macOS 15+ player-level frame tap (spans looper rotations). Pixel formats
+/// come from the caller: NV12-first for the normal path, 32BGRA-only after the
+/// HDR fallback.
 @available(macOS 15.0, *)
 private final class WPEPlayerLevelVideoOutput {
     private let output: AVPlayerVideoOutput
     private weak var player: AVQueuePlayer?
 
-    init(player: AVQueuePlayer) {
+    init(player: AVQueuePlayer, pixelFormats: [OSType]) {
         let specification = AVVideoOutputSpecification(tagCollections: [.monoscopicForVideoOutput()])
-        // Pin 32BGRA so existing .bgra8Unorm[_srgb] texture path is unchanged.
         let outputSettings: [String: any Sendable] = [
-            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+            kCVPixelBufferPixelFormatTypeKey as String: pixelFormats,
             kCVPixelBufferMetalCompatibilityKey as String: true,
             kCVPixelBufferIOSurfacePropertiesKey as String: [String: any Sendable]()
         ]
@@ -391,6 +650,60 @@ private final class WPEPlayerLevelVideoOutput {
 
     func detach() {
         player?.videoOutput = nil
+    }
+}
+
+/// CPU-side YCbCr→RGB conversion parameters, laid out to match the shader's
+/// `WPEVideoYCbCrUniforms` (float3x3 + float3, 64 bytes) so it can be passed
+/// via `setFragmentBytes` directly. Living on the CPU lets tests pin the
+/// coefficients against the published BT.601/709/2020 constants.
+struct WPEVideoYCbCrConversion: Equatable {
+    enum MatrixKind: Equatable {
+        case bt601
+        case bt709
+        case bt2020
+    }
+
+    var matrix: simd_float3x3
+    var offset: SIMD3<Float>
+
+    /// Honors the buffer's `kCVImageBufferYCbCrMatrixKey`; untagged buffers use
+    /// the conventional SD→601 / HD→709 line-count heuristic.
+    static func kind(matrixAttachment: String?, sourceHeight: Int) -> MatrixKind {
+        if let matrixAttachment {
+            if matrixAttachment == (kCVImageBufferYCbCrMatrix_ITU_R_709_2 as String) { return .bt709 }
+            if matrixAttachment == (kCVImageBufferYCbCrMatrix_ITU_R_601_4 as String) { return .bt601 }
+            if matrixAttachment == (kCVImageBufferYCbCrMatrix_ITU_R_2020 as String) { return .bt2020 }
+        }
+        return sourceHeight < 720 ? .bt601 : .bt709
+    }
+
+    /// Standard full-matrix derivation from the luma coefficients:
+    /// R = y + 2(1−Kr)·cr, G = y − 2Kb(1−Kb)/Kg·cb − 2Kr(1−Kr)/Kg·cr,
+    /// B = y + 2(1−Kb)·cb, with 219/224 range expansion folded in for
+    /// video-range sources.
+    static func make(kind: MatrixKind, fullRange: Bool) -> WPEVideoYCbCrConversion {
+        let (kr, kb): (Float, Float)
+        switch kind {
+        case .bt601: (kr, kb) = (0.299, 0.114)
+        case .bt709: (kr, kb) = (0.2126, 0.0722)
+        case .bt2020: (kr, kb) = (0.2627, 0.0593)
+        }
+        let kg = 1 - kr - kb
+        let yScale: Float = fullRange ? 1 : 255.0 / 219.0
+        let cScale: Float = fullRange ? 1 : 255.0 / 224.0
+        let matrix = simd_float3x3(columns: (
+            SIMD3(yScale, yScale, yScale),
+            SIMD3(0, -2 * kb * (1 - kb) / kg * cScale, 2 * (1 - kb) * cScale),
+            SIMD3(2 * (1 - kr) * cScale, -2 * kr * (1 - kr) / kg * cScale, 0)
+        ))
+        let offset = SIMD3<Float>(fullRange ? 0 : 16.0 / 255.0, 128.0 / 255.0, 128.0 / 255.0)
+        return WPEVideoYCbCrConversion(matrix: matrix, offset: offset)
+    }
+
+    /// Reference implementation of the shader's math for test comparison.
+    func apply(_ ycbcr: SIMD3<Float>) -> SIMD3<Float> {
+        simd_clamp(matrix * (ycbcr - offset), SIMD3<Float>(repeating: 0), SIMD3<Float>(repeating: 1))
     }
 }
 #endif

--- a/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
+++ b/LiveWallpaper/Runtime/Assets/WPEVideoTextureSource.swift
@@ -78,7 +78,6 @@ final class WPEVideoTextureSource {
         playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = false
 
         let queuePlayer = AVQueuePlayer()
-        queuePlayer.actionAtItemEnd = .none
         // Prefetch next looped item before wrap to avoid sparse-decode slow-mo.
         queuePlayer.automaticallyWaitsToMinimizeStalling = true
         queuePlayer.preventsDisplaySleepDuringVideoPlayback = false
@@ -292,6 +291,12 @@ final class WPEVideoTextureSource {
             return
         }
         latest = PublishedFrame(texture: texture, cvTexture: cvTexture)
+        // The cache holds a mapping per pixel buffer it has wrapped; the pool
+        // rotates buffers, so without a periodic flush the mappings accumulate
+        // for the source's lifetime. Flushing only drops unreferenced mappings —
+        // the frame just stored in `latest` retains its `CVMetalTexture`, so
+        // the in-use mapping survives.
+        CVMetalTextureCacheFlush(textureCache, 0)
     }
 
     /// 2s forward buffer (RAM-resident asset; longer buffers only cost decoder state).
@@ -307,7 +312,8 @@ final class WPEVideoTextureSource {
     /// Resource-loader queue — byte-range fulfilment stays off main.
     private static let resourceLoaderQueue = DispatchQueue(
         label: "app.livewallpaper.wpe.video.in-memory-loader",
-        qos: .userInitiated
+        qos: .userInitiated,
+        autoreleaseFrequency: .workItem
     )
 
     /// Current item time (s); used by play-once wrap detection in all builds.

--- a/LiveWallpaper/Runtime/Audio/AudioSpectrumBroker.swift
+++ b/LiveWallpaper/Runtime/Audio/AudioSpectrumBroker.swift
@@ -1,20 +1,34 @@
+import Dispatch
 import os
 
-/// Spectrum frames from realtime capture to consumers; publish drops on contention.
+/// Pull-driven analysis source consulted by `snapshot()`; nil means the cached
+/// frame is still current (no new samples, or inside the analyzer's cadence cap).
+protocol AudioSpectrumAnalyzing: AnyObject, Sendable {
+    func analyzeIfDue(nowNanos: UInt64) -> AudioSpectrumFrame?
+}
+
+/// Latest-spectrum cache for consumers; `snapshot()` pulls fresh analysis on demand.
 final class AudioSpectrumBroker: Sendable {
     private struct State {
         var left: [Float]
         var right: [Float]
         var timestampNanos: UInt64
+        var analyzer: (any AudioSpectrumAnalyzing)?
     }
 
     private let lock = OSAllocatedUnfairLock(
         initialState: State(
             left: [Float](repeating: 0, count: AudioSpectrumFrame.binCount),
             right: [Float](repeating: 0, count: AudioSpectrumFrame.binCount),
-            timestampNanos: 0
+            timestampNanos: 0,
+            analyzer: nil
         )
     )
+
+    /// Capture service attaches its processor while running; nil detaches.
+    func attachAnalyzer(_ analyzer: (any AudioSpectrumAnalyzing)?) {
+        lock.withLock { $0.analyzer = analyzer }
+    }
 
     func publish(_ frame: AudioSpectrumFrame) {
         lock.withLockIfAvailable { state in
@@ -26,8 +40,16 @@ final class AudioSpectrumBroker: Sendable {
 
     func snapshot() -> AudioSpectrumFrame {
         lock.withLock { state in
+            // Analysis runs on the pulling consumer's thread; concurrent
+            // snapshots dedupe on this lock plus the analyzer's generation +
+            // cadence check (later callers get the freshly cached frame).
+            if let fresh = state.analyzer?.analyzeIfDue(nowNanos: DispatchTime.now().uptimeNanoseconds) {
+                Self.copyChannel(fresh.left, into: &state.left)
+                Self.copyChannel(fresh.right, into: &state.right)
+                state.timestampNanos = fresh.timestampNanos
+            }
             // Sanitizing copy-out so returned frame owns independent buffers (no COW).
-            AudioSpectrumFrame(
+            return AudioSpectrumFrame(
                 left: state.left,
                 right: state.right,
                 timestampNanos: state.timestampNanos

--- a/LiveWallpaper/Runtime/Audio/AudioSpectrumBroker.swift
+++ b/LiveWallpaper/Runtime/Audio/AudioSpectrumBroker.swift
@@ -30,14 +30,6 @@ final class AudioSpectrumBroker: Sendable {
         lock.withLock { $0.analyzer = analyzer }
     }
 
-    func publish(_ frame: AudioSpectrumFrame) {
-        lock.withLockIfAvailable { state in
-            Self.copyChannel(frame.left, into: &state.left)
-            Self.copyChannel(frame.right, into: &state.right)
-            state.timestampNanos = frame.timestampNanos
-        }
-    }
-
     func snapshot() -> AudioSpectrumFrame {
         lock.withLock { state in
             // Analysis runs on the pulling consumer's thread; concurrent

--- a/LiveWallpaper/Runtime/Audio/AudioSpectrumProcessor.swift
+++ b/LiveWallpaper/Runtime/Audio/AudioSpectrumProcessor.swift
@@ -234,7 +234,15 @@ final class AudioSpectrumProcessor: AudioSpectrumAnalyzing, @unchecked Sendable 
     }
 
     private func updateSmoothingIfNeeded(hopSize: Int) {
-        let hop = hopSize > 0 ? hopSize : configuration.fftSize
+        // A consumer that stopped pulling (suspended, hibernated, App-Napped)
+        // leaves `lastAnalyzedTotal` arbitrarily far behind the producer, and a
+        // hop of hundreds of thousands of samples drives both coefficients to
+        // ~0 — no smoothing at all on the first frame back, i.e. a spectrum pop
+        // on resume. The window itself is fresh (the lap guard rejects torn
+        // ones), so clamp the hop to the ring: gaps larger than that carry no
+        // usable relation to the retained audio anyway.
+        let clamped = Swift.min(hopSize, ringCapacity)
+        let hop = clamped > 0 ? clamped : configuration.fftSize
         guard hop != lastHopSize else { return }
         lastHopSize = hop
         attackCoefficient = Self.smoothingCoefficient(

--- a/LiveWallpaper/Runtime/Audio/AudioSpectrumProcessor.swift
+++ b/LiveWallpaper/Runtime/Audio/AudioSpectrumProcessor.swift
@@ -85,6 +85,12 @@ final class AudioSpectrumProcessor: AudioSpectrumAnalyzing, @unchecked Sendable 
     /// Pull cadence cap: at most one FFT per 1/120 s regardless of caller count.
     static let minAnalysisIntervalNanos: UInt64 = 8_333_333
 
+    #if DEBUG
+    /// Test seam: runs between the window copy and the lap recheck so a test can
+    /// interleave producer writes deterministically.
+    var afterWindowCopyForTesting: (() -> Void)?
+    #endif
+
     init(configuration: Configuration = Configuration()) {
         var resolved = configuration
         if resolved.fftSize < 2 || !Self.isPowerOfTwo(resolved.fftSize) {
@@ -158,11 +164,15 @@ final class AudioSpectrumProcessor: AudioSpectrumAnalyzing, @unchecked Sendable 
         }
     }
 
-    /// Immediate ingest + analysis (test / fallback path; capture pulls via `analyzeIfDue`).
+    /// Immediate ingest + analysis in one call (single-threaded test/oracle seam;
+    /// capture pulls via `analyzeIfDue`).
     func process(left: [Float], right: [Float], timestampNanos: UInt64) -> AudioSpectrumFrame {
         ingest(left: left, right: right, timestampNanos: timestampNanos)
         let total = ringCursor.withLock { $0.totalSamples }
+        // Single caller thread means no concurrent producer, so the lap discard
+        // cannot trip; the fallback only satisfies the optional.
         return analyze(total: total, timestampNanos: timestampNanos)
+            ?? AudioSpectrumFrame(validatedLeft: leftOutput, validatedRight: rightOutput, timestampNanos: timestampNanos)
     }
 
     /// Audio-thread entry: copy the callback's samples into the ring and publish the
@@ -195,11 +205,22 @@ final class AudioSpectrumProcessor: AudioSpectrumAnalyzing, @unchecked Sendable 
 
     /// One analysis of the latest window. The spectrum math (Hann window, FFT,
     /// normalization, band reduction, smoothing) is unchanged from the push-driven
-    /// version — only which windows get analyzed changed.
-    private func analyze(total: Int, timestampNanos: UInt64) -> AudioSpectrumFrame {
-        updateSmoothingIfNeeded(hopSize: total - lastAnalyzedTotal)
+    /// version — only which windows get analyzed changed. Returns nil when the
+    /// copied window was lapped by the producer (torn — see below).
+    private func analyze(total: Int, timestampNanos: UInt64) -> AudioSpectrumFrame? {
         copyWindow(from: leftRing, upTo: total, into: &leftInput)
         copyWindow(from: rightRing, upTo: total, into: &rightInput)
+        #if DEBUG
+        afterWindowCopyForTesting?()
+        #endif
+        // Recheck the write cursor after the copy: if the producer advanced past
+        // windowStart + capacity, the window's oldest samples were overwritten
+        // mid-copy (consumer stalled longer than the ring covers, ~170 ms at
+        // 48 kHz) and the copy mixes generations. Discard rather than render
+        // torn data; smoothing state is untouched so the next pull retries.
+        let writeTotal = ringCursor.withLock { $0.totalSamples }
+        guard writeTotal - (total - configuration.fftSize) <= ringCapacity else { return nil }
+        updateSmoothingIfNeeded(hopSize: total - lastAnalyzedTotal)
         lastAnalyzedTotal = total
 
         processChannel(input: leftInput, previous: &previousLeft, output: &leftOutput)
@@ -211,10 +232,6 @@ final class AudioSpectrumProcessor: AudioSpectrumAnalyzing, @unchecked Sendable 
             timestampNanos: timestampNanos
         )
     }
-
-    /// Used by the scene-owned audio fallback when system capture is unavailable.
-
-    // Capture boundary normalizes to noninterleaved Float (Tap vs SCK differ).
 
     private func updateSmoothingIfNeeded(hopSize: Int) {
         let hop = hopSize > 0 ? hopSize : configuration.fftSize

--- a/LiveWallpaper/Runtime/Audio/AudioSpectrumProcessor.swift
+++ b/LiveWallpaper/Runtime/Audio/AudioSpectrumProcessor.swift
@@ -1,9 +1,14 @@
 import Accelerate
 import Foundation
+import os
 
 /// Alloc-free stereo FFT → 64 log-spaced bins with treble EQ + attack/release (WPE-style).
-/// Sliding input window so short device callbacks still feed a full FFT size.
-final class AudioSpectrumProcessor {
+/// Input arrives through `ingest` into a ring (audio thread, no FFT); analysis is
+/// pull-driven via `analyzeIfDue`, so FFT rate follows consumer demand, capped at 120 Hz.
+/// @unchecked Sendable: producer fields are audio-IO-thread-only, analysis fields run
+/// under the broker snapshot lock (or single-threaded direct `process` use), and the
+/// two sides hand off through the `ringCursor` lock.
+final class AudioSpectrumProcessor: AudioSpectrumAnalyzing, @unchecked Sendable {
     struct Configuration: Equatable, Sendable {
         var fftSize: Int = 2048
         var binCount: Int = 64
@@ -53,6 +58,33 @@ final class AudioSpectrumProcessor {
     private var previousRight: [Float]
     private let bands: [Band]
 
+    // MARK: - Ring ingestion (SPSC: audio IO thread produces, snapshot pull consumes)
+
+    private struct RingCursor {
+        var totalSamples: Int
+        var timestampNanos: UInt64
+    }
+
+    /// Producer→consumer handoff of (samples written, host time). The unfair lock
+    /// stands in for a release/acquire atomic pair — deployment target 14.6 predates
+    /// the Synchronization module. Each critical section is a single store or load.
+    private let ringCursor = OSAllocatedUnfairLock(initialState: RingCursor(totalSamples: 0, timestampNanos: 0))
+    /// Running sample count, touched only by the single producer (audio IO thread).
+    private var producerTotal = 0
+    private let ringCapacity: Int
+    private let ringMask: Int
+    /// Raw buffers so concurrent producer writes / consumer reads don't trip Swift's
+    /// dynamic exclusivity checks (overlapping Array withUnsafe… accesses would).
+    private let leftRing: UnsafeMutableBufferPointer<Float>
+    private let rightRing: UnsafeMutableBufferPointer<Float>
+
+    /// Consumer-side analysis state; mutual exclusion is the caller's (broker lock).
+    private var lastAnalyzedTotal = 0
+    private var lastAnalysisNanos: UInt64 = 0
+
+    /// Pull cadence cap: at most one FFT per 1/120 s regardless of caller count.
+    static let minAnalysisIntervalNanos: UInt64 = 8_333_333
+
     init(configuration: Configuration = Configuration()) {
         var resolved = configuration
         if resolved.fftSize < 2 || !Self.isPowerOfTwo(resolved.fftSize) {
@@ -86,6 +118,21 @@ final class AudioSpectrumProcessor {
         self.previousLeft = [Float](repeating: 0, count: resolved.binCount)
         self.previousRight = [Float](repeating: 0, count: resolved.binCount)
         self.bands = Self.logBands(configuration: resolved)
+
+        // 4× the window (power of two): the analyzed region trails the producer by
+        // ≥ 3×fftSize samples, so in-flight callback writes never touch it.
+        let capacity = resolved.fftSize * 4
+        self.ringCapacity = capacity
+        self.ringMask = capacity - 1
+        self.leftRing = .allocate(capacity: capacity)
+        self.rightRing = .allocate(capacity: capacity)
+        self.leftRing.initialize(repeating: 0)
+        self.rightRing.initialize(repeating: 0)
+    }
+
+    deinit {
+        leftRing.deallocate()
+        rightRing.deallocate()
     }
 
     /// Build log-spaced bands with treble EQ; each spans ≥1 bin; edges clamped.
@@ -111,11 +158,49 @@ final class AudioSpectrumProcessor {
         }
     }
 
+    /// Immediate ingest + analysis (test / fallback path; capture pulls via `analyzeIfDue`).
     func process(left: [Float], right: [Float], timestampNanos: UInt64) -> AudioSpectrumFrame {
-        updateSmoothingIfNeeded(hopSize: max(left.count, right.count))
+        ingest(left: left, right: right, timestampNanos: timestampNanos)
+        let total = ringCursor.withLock { $0.totalSamples }
+        return analyze(total: total, timestampNanos: timestampNanos)
+    }
 
-        appendSamples(left, into: &leftInput)
-        appendSamples(right, into: &rightInput)
+    /// Audio-thread entry: copy the callback's samples into the ring and publish the
+    /// cursor. No allocation, no FFT — analysis happens on consumer pull.
+    /// Shorter channel zero-pads (HAL always delivers matched counts).
+    func ingest(left: [Float], right: [Float], timestampNanos: UInt64) {
+        let frameCount = max(left.count, right.count)
+        guard frameCount > 0 else { return }
+        // Oversized batch (never from HAL): only the freshest ringCapacity samples matter.
+        let dropped = max(frameCount - ringCapacity, 0)
+        writeRing(leftRing, samples: left, from: dropped, count: frameCount - dropped, at: producerTotal + dropped)
+        writeRing(rightRing, samples: right, from: dropped, count: frameCount - dropped, at: producerTotal + dropped)
+        producerTotal += frameCount
+        let published = RingCursor(totalSamples: producerTotal, timestampNanos: timestampNanos)
+        ringCursor.withLock { $0 = published }
+    }
+
+    /// Consumer pull: run one analysis if new samples arrived since the last one and
+    /// the cadence cap allows; nil means "cached frame is still current". Caller
+    /// provides mutual exclusion (broker snapshot lock).
+    func analyzeIfDue(nowNanos: UInt64) -> AudioSpectrumFrame? {
+        let cursor = ringCursor.withLock { $0 }
+        guard cursor.totalSamples > lastAnalyzedTotal else { return nil }
+        guard lastAnalysisNanos == 0 || nowNanos &- lastAnalysisNanos >= Self.minAnalysisIntervalNanos else {
+            return nil
+        }
+        lastAnalysisNanos = nowNanos
+        return analyze(total: cursor.totalSamples, timestampNanos: cursor.timestampNanos)
+    }
+
+    /// One analysis of the latest window. The spectrum math (Hann window, FFT,
+    /// normalization, band reduction, smoothing) is unchanged from the push-driven
+    /// version — only which windows get analyzed changed.
+    private func analyze(total: Int, timestampNanos: UInt64) -> AudioSpectrumFrame {
+        updateSmoothingIfNeeded(hopSize: total - lastAnalyzedTotal)
+        copyWindow(from: leftRing, upTo: total, into: &leftInput)
+        copyWindow(from: rightRing, upTo: total, into: &rightInput)
+        lastAnalyzedTotal = total
 
         processChannel(input: leftInput, previous: &previousLeft, output: &leftOutput)
         processChannel(input: rightInput, previous: &previousRight, output: &rightOutput)
@@ -147,25 +232,37 @@ final class AudioSpectrumProcessor {
         )
     }
 
-    /// Slide window left and append samples; keep continuous fftSize history.
-    private func appendSamples(_ samples: [Float], into target: inout [Float]) {
-        let capacity = target.count
-        let incoming = min(samples.count, capacity)
-        guard incoming > 0 else { return }
-
-        let retained = capacity - incoming
-        if retained > 0 {
-            target.withUnsafeMutableBufferPointer { buffer in
-                guard let base = buffer.baseAddress else { return }
-                memmove(base, base + incoming, retained * MemoryLayout<Float>.stride)
-            }
+    private func writeRing(
+        _ ring: UnsafeMutableBufferPointer<Float>,
+        samples: [Float],
+        from sourceStart: Int,
+        count: Int,
+        at ringStart: Int
+    ) {
+        for offset in 0..<count {
+            let sourceIndex = sourceStart + offset
+            ring[(ringStart + offset) & ringMask] = sourceIndex < samples.count ? samples[sourceIndex] : 0
         }
+    }
 
-        // If incoming > window, keep only the tail (most recent audio).
-        let sourceStart = samples.count - incoming
-        for offset in 0..<incoming {
-            let sample = samples[sourceStart + offset]
-            target[retained + offset] = sample.isFinite ? sample : 0
+    /// Ring → contiguous FFT window (last `target.count` samples ending at `total`),
+    /// sanitizing non-finite samples like the old sliding append did.
+    private func copyWindow(
+        from ring: UnsafeMutableBufferPointer<Float>,
+        upTo total: Int,
+        into target: inout [Float]
+    ) {
+        let windowStart = total - target.count
+        target.withUnsafeMutableBufferPointer { buffer in
+            for offset in 0..<buffer.count {
+                let absolute = windowStart + offset
+                if absolute < 0 {
+                    buffer[offset] = 0
+                } else {
+                    let sample = ring[absolute & ringMask]
+                    buffer[offset] = sample.isFinite ? sample : 0
+                }
+            }
         }
     }
 

--- a/LiveWallpaper/Runtime/Audio/AudioSpectrumProcessor.swift
+++ b/LiveWallpaper/Runtime/Audio/AudioSpectrumProcessor.swift
@@ -7,7 +7,16 @@ import os
 /// pull-driven via `analyzeIfDue`, so FFT rate follows consumer demand, capped at 120 Hz.
 /// @unchecked Sendable: producer fields are audio-IO-thread-only, analysis fields run
 /// under the broker snapshot lock (or single-threaded direct `process` use), and the
-/// two sides hand off through the `ringCursor` lock.
+/// `ringCursor` lock publishes the write position between them.
+///
+/// The lock covers the CURSOR, not the sample storage: the consumer copies its
+/// window out of `leftRing`/`rightRing` unsynchronized while the producer may be
+/// writing. Aligned 32-bit stores do not tear, so the observable failure is a
+/// window mixing two generations, which the post-copy lap check detects and
+/// discards. That is detection, not prevention — it stays a formal data race
+/// and Thread Sanitizer will say so. Removing it needs ownership transfer
+/// (SPSC hand-off or sealed double buffers), not a bigger ring; see the
+/// memory/CPU backlog.
 final class AudioSpectrumProcessor: AudioSpectrumAnalyzing, @unchecked Sendable {
     struct Configuration: Equatable, Sendable {
         var fftSize: Int = 2048

--- a/LiveWallpaper/Runtime/Audio/SystemAudioCaptureService.swift
+++ b/LiveWallpaper/Runtime/Audio/SystemAudioCaptureService.swift
@@ -2,7 +2,6 @@
 import CoreAudio
 import Foundation
 import LiveWallpaperCore
-import os
 
 /// App-wide Core Audio process-tap → spectrum processor → shared broker (WPE-style loopback).
 /// Main-thread lifecycle; IOProc is allocation-free steady-state on a dedicated queue.
@@ -34,20 +33,11 @@ final class SystemAudioCaptureService: @unchecked Sendable {
     /// Captured by IOProc (not `self`) so HAL cannot pin the service during teardown.
     private final class IOContext: @unchecked Sendable {
         let processor: AudioSpectrumProcessor
-        let broker: AudioSpectrumBroker
         var scratchLeft: [Float] = []
         var scratchRight: [Float] = []
-        
-        private let diagnosticLock = OSAllocatedUnfairLock(initialState: Float(0))
-        /// Diagnostic: confirms tap delivers normalized [-1, 1] samples.
-        var lastInputPeak: Float {
-            get { diagnosticLock.withLock { $0 } }
-            set { diagnosticLock.withLock { $0 = newValue } }
-        }
 
-        init(processor: AudioSpectrumProcessor, broker: AudioSpectrumBroker) {
+        init(processor: AudioSpectrumProcessor) {
             self.processor = processor
-            self.broker = broker
         }
     }
 
@@ -150,8 +140,10 @@ final class SystemAudioCaptureService: @unchecked Sendable {
         let processor = AudioSpectrumProcessor(
             configuration: AudioSpectrumProcessor.Configuration(sampleRate: Float(asbd.mSampleRate))
         )
-        let ioContext = IOContext(processor: processor, broker: broker)
+        let ioContext = IOContext(processor: processor)
         context = ioContext
+        // Consumers' snapshot() pulls analysis from this processor while capture runs.
+        broker.attachAnalyzer(processor)
 
         let channelCount = Int(asbd.mChannelsPerFrame)
         let isInterleaved = (asbd.mFormatFlags & kAudioFormatFlagIsNonInterleaved) == 0
@@ -219,6 +211,7 @@ final class SystemAudioCaptureService: @unchecked Sendable {
             AudioHardwareDestroyProcessTap(tapID)
             tapID = AudioObjectID(kAudioObjectUnknown)
         }
+        broker.attachAnalyzer(nil)
         context = nil
         isRunning = false
     }
@@ -255,7 +248,7 @@ final class SystemAudioCaptureService: @unchecked Sendable {
                     )
                 }
             }
-            publish(context, frameCount: frameCount, timestampNanos: timestampNanos)
+            ingest(context, timestampNanos: timestampNanos)
         } else {
             // Non-interleaved: buffer0=L, buffer1=R.
             let leftBuffer = bufferList[0]
@@ -279,24 +272,17 @@ final class SystemAudioCaptureService: @unchecked Sendable {
                     )
                 }
             }
-            publish(context, frameCount: frameCount, timestampNanos: timestampNanos)
+            ingest(context, timestampNanos: timestampNanos)
         }
     }
 
-    private static func publish(_ context: IOContext, frameCount: Int, timestampNanos: UInt64) {
-        var peak: Float = 0
-        let count = min(frameCount, context.scratchLeft.count)
-        for index in 0..<count {
-            peak = max(peak, abs(context.scratchLeft[index]))
-        }
-        context.lastInputPeak = peak
-
-        let frame = context.processor.process(
+    /// Ring write + cursor bump only — no FFT, no allocation on the IO thread.
+    private static func ingest(_ context: IOContext, timestampNanos: UInt64) {
+        context.processor.ingest(
             left: context.scratchLeft,
             right: context.scratchRight,
             timestampNanos: timestampNanos
         )
-        context.broker.publish(frame)
     }
 
     /// Resize scratch only when hardware buffer size changes (steady-state alloc-free).

--- a/LiveWallpaper/Runtime/Metal/RenderThread/WPEDisplayLinkFrameDriver.swift
+++ b/LiveWallpaper/Runtime/Metal/RenderThread/WPEDisplayLinkFrameDriver.swift
@@ -72,6 +72,11 @@ final class WPERenderThreadFramePacer: WPESurfaceControl, @unchecked Sendable {
             if let paused = update.isPaused { actor.setLinkPaused(paused) }
             if let fps = update.preferredFramesPerSecond { actor.setLinkPreferredFPS(fps) }
         }
+        // The pointer-event monitor gate belongs to the main-thread surface (like
+        // click capture); forward only that field so the view knobs stay dropped.
+        if let pointerEvents = update.pointerEventsEnabled {
+            surface.applyPacing(WPERenderPacingUpdate(pointerEventsEnabled: pointerEvents))
+        }
     }
 
     nonisolated func setNeedsRedraw() {

--- a/LiveWallpaper/Runtime/Metal/RenderThread/WPEDisplayRenderActor.swift
+++ b/LiveWallpaper/Runtime/Metal/RenderThread/WPEDisplayRenderActor.swift
@@ -353,9 +353,23 @@ actor WPEDisplayRenderActor {
         defer { renderer.onDemandVideoLoading.remove(key) }
         guard renderer.loadGeneration == generation else { return }
         do {
-            try await renderer.loadDynamicTextureOnActor(path: key, layerName: key, on: self)
+            // The generation must hold at PUBLICATION time, not just entry: the
+            // asset load suspends, and a hibernate/reload in that window bumps
+            // the generation — a stale rebuild must not overwrite the sources a
+            // wake reload just installed (or revive a hibernated renderer).
+            try await renderer.loadDynamicTextureOnActor(
+                path: key,
+                layerName: key,
+                publicationAllowed: { renderer.loadGeneration == generation },
+                on: self
+            )
         } catch {
             Logger.warning("Scene \(renderer.descriptor.workshopID) [OnDemandVideo] rebuild failed for \(key): \(error)", category: .wpeRender)
+            // With released on-demand videos carrying no frame demand, a silent
+            // failure here would leave the loop paused forever: nothing else
+            // retries. Kick one frame so reconcileVideoResidency runs again
+            // (the defer above already cleared the loading marker).
+            renderer.surfaceControl.setNeedsRedraw()
             return
         }
         guard renderer.loadGeneration == generation,
@@ -392,6 +406,8 @@ actor WPEDisplayRenderActor {
         } else {
             runtime.pause()
         }
+        // Audio arriving flips the session's audible mirror (App Nap gate).
+        renderer.publishRuntimeActivity()
     }
 
     /// Promote a submitted present to "ready" only after Metal reports successful
@@ -433,6 +449,15 @@ actor WPEDisplayRenderActor {
         scenePropertyRendererGeneration &+= 1
         try await renderer?.reload(on: self)
         thread?.boostRenderQoSWarmup()
+    }
+
+    /// Deep hibernate: releases the loaded scene's runtime resources while the
+    /// session stays alive. Waking is a plain `reload()`. Bumps the property
+    /// generation because prepared patches preflighted against the loaded state.
+    func hibernate() async -> Bool {
+        guard let renderer else { return false }
+        scenePropertyRendererGeneration &+= 1
+        return await renderer.hibernate(on: self)
     }
 
     /// Tear down the renderer on this actor, then drop it. Sync: `cleanup()`
@@ -518,11 +543,19 @@ actor WPEDisplayRenderActor {
     /// The caller has already persisted this patch's descriptor. Actor FIFO and
     /// renderer-generation identity make this a committed delivery, not another
     /// fallible latest-intent proposal.
-    func commitScenePropertyPatch(_ prepared: PreparedScenePropertyPatch) -> Bool {
+    func commitScenePropertyPatch(
+        _ prepared: PreparedScenePropertyPatch,
+        updatedDescriptor: SceneDescriptor
+    ) -> Bool {
         guard prepared.rendererGeneration == scenePropertyRendererGeneration else {
             return false
         }
-        return renderer?.applyScenePropertyPatch(prepared.patch) ?? false
+        guard let renderer, renderer.applyScenePropertyPatch(prepared.patch) else {
+            return false
+        }
+        // Keep the reload source of truth in step with the live structures.
+        renderer.descriptor = updatedDescriptor
+        return true
     }
 
     func captureLivePoster() async -> NSImage? {

--- a/LiveWallpaper/Runtime/Metal/RenderThread/WPERenderSurface.swift
+++ b/LiveWallpaper/Runtime/Metal/RenderThread/WPERenderSurface.swift
@@ -1,6 +1,7 @@
 #if !LITE_BUILD
 import AppKit
 import MetalKit
+import os
 import QuartzCore
 
 /// Owns the AppKit-bound Metal surface and pointer publishing on the main actor.
@@ -14,6 +15,9 @@ final class WPERenderSurface: NSObject, MTKViewDelegate {
     let metalLayer: CAMetalLayer
 
     private let publisher: WPEPointerPublisher
+    /// Written synchronously (caller order) by the nonisolated pacing seam;
+    /// main-thread deliveries apply this latest value, not their captured one.
+    private let desiredPointerEventsEnabled = OSAllocatedUnfairLock<Bool?>(initialState: nil)
     /// Strongly held delivery shim; the session owns the surface and the shim targets the render actor.
     private var client: WPERenderSurfaceClient?
 
@@ -140,6 +144,14 @@ final class WPERenderSurface: NSObject, MTKViewDelegate {
         if let paused = update.isPaused { mtkView.isPaused = paused }
         if let enable = update.enableSetNeedsDisplay { mtkView.enableSetNeedsDisplay = enable }
         if let fps = update.preferredFramesPerSecond { mtkView.preferredFramesPerSecond = fps }
+        if update.pointerEventsEnabled != nil,
+           let latest = desiredPointerEventsEnabled.withLock({ $0 }) {
+            // Latest-wins: `deliver`'s unstructured Tasks are not FIFO, so a
+            // rapid suspend→resume pair could apply gates inverted. The seam
+            // writes the lock in caller order; every delivery applies the
+            // newest value, so out-of-order Tasks converge instead of sticking.
+            publisher.setMouseMonitoringEnabled(latest)
+        }
     }
 
     private func setNeedsRedrawOnMain() { mtkView.setNeedsDisplay(mtkView.bounds) }
@@ -201,6 +213,9 @@ struct WPERenderPacingUpdate: Sendable {
     var isPaused: Bool?
     var enableSetNeedsDisplay: Bool?
     var preferredFramesPerSecond: Int?
+    /// Gates the pointer publisher's NSEvent monitors (suspend + demand). Rides
+    /// the pacing update so it stays ordered with the pause state it mirrors.
+    var pointerEventsEnabled: Bool?
 }
 
 /// What the surface calls back into (the renderer). Kept a protocol so the
@@ -227,6 +242,9 @@ protocol WPESurfaceControl: Sendable {
 
 extension WPERenderSurface: WPESurfaceControl {
     nonisolated func applyPacing(_ update: WPERenderPacingUpdate) {
+        if let pointerEvents = update.pointerEventsEnabled {
+            desiredPointerEventsEnabled.withLock { $0 = pointerEvents }
+        }
         deliver { $0.applyPacingOnMain(update) }
     }
 

--- a/LiveWallpaper/Runtime/Metal/WPEMetalRenderExecutor+Targets.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalRenderExecutor+Targets.swift
@@ -33,6 +33,10 @@ extension WPEMetalRenderExecutor {
         outputTexturePool.removeAll()
         recentOutputTextureIDs.removeAll()
         bootstrapPreviousTextureCache.removeAll()
+        // Same size-keyed lifetime as the bootstrap cache: rebuilt on-miss in
+        // sceneReadHazardSnapshot(matching:commandBuffer:), so dropping it here
+        // only frees the old scene's size/format entries.
+        sceneReadHazardSnapshotCache.removeAll()
         // Pass-id keyed; a reload can reuse an id for a different shader, so drop
         // it here (reload routes through releaseTransientResources). The
         // content-keyed translatedShaderCache is safe to persist and is not cleared.

--- a/LiveWallpaper/Runtime/Metal/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalRenderExecutor.swift
@@ -364,6 +364,13 @@ final class WPEMetalRenderExecutor {
         device
     }
 
+    /// Video NV12→BGRA conversion passes must commit on the frame queue:
+    /// same-queue hazard tracking orders them ahead of the frame that samples
+    /// the converted working texture (a separate queue would be unordered).
+    var textureSourceCommandQueue: MTLCommandQueue {
+        commandQueue
+    }
+
     /// One-shot guard so the waterwaves dispatch logs its first live execution per renderer
     /// (confirms the builtin effect_waterwaves path actually runs). Internal —
     /// flipped by the waterwaves `bind` closure in `WPEMetalEffectDispatchTable`.

--- a/LiveWallpaper/Runtime/Metal/WPEMetalRenderExecutor.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalRenderExecutor.swift
@@ -412,6 +412,16 @@ final class WPEMetalRenderExecutor {
     /// single puppet/layer introduces an artifact. Scoped to one object to
     /// stay memory-safe (capturing every pass scene-wide would OOM the GPU).
     private var dumpLayerPassesID: String?
+    /// Both dump defaults read once at executor init instead of twice per frame.
+    /// Safe for the oracle gate: OracleCorpusCaptureTests.swift sets
+    /// `WPEDumpScenePasses` per scene BEFORE constructing WPEMetalSceneRenderer
+    /// (which builds this executor in its init), so an init-time read observes it.
+    private let dumpScenePassesDefaultID: String? =
+        UserDefaults.standard.string(forKey: "WPEDumpScenePasses")
+    private let dumpLayerPassesDefaultID: String? = {
+        let id = UserDefaults.standard.string(forKey: "WPEDumpLayerPasses")
+        return (id?.isEmpty == false) ? id : nil
+    }()
     #endif
 
     func render(
@@ -474,12 +484,9 @@ final class WPEMetalRenderExecutor {
         // trace). Oracle collection forces particles standalone (below) — a render-
         // encoder boundary change only, byte-identical composite, consistent across
         // both before/after oracle runs.
-        let dumpScenePasses = (sceneID.map { !$0.isEmpty && UserDefaults.standard.string(forKey: "WPEDumpScenePasses") == $0 } ?? false)
+        let dumpScenePasses = (sceneID.map { !$0.isEmpty && dumpScenePassesDefaultID == $0 } ?? false)
             || WPEOracleMode.perPassHashesEnabled
-        dumpLayerPassesID = {
-            let id = UserDefaults.standard.string(forKey: "WPEDumpLayerPasses")
-            return (id?.isEmpty == false) ? id : nil
-        }()
+        dumpLayerPassesID = dumpLayerPassesDefaultID
         #endif
         let preparedPipeline = pipeline.addingMetalRuntimeUniforms(
             runtimeUniforms,

--- a/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Configuration.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Configuration.swift
@@ -44,8 +44,8 @@ extension WPEMetalSceneRenderer {
 
     static let textureCacheBudgetMiBDefaultsKey = "WPEMetalTextureCacheBudgetMiB"
     /// VRAM budget for reloadable static source textures. Unset ⇒ the machine's
-    /// memory-tier default (8/16 GB Macs bounded, ≥24 GB unbounded — see
-    /// `WPEMemoryTier`); explicit 0 or negative ⇒ unbounded (manual opt-out);
+    /// memory-tier default (every tier bounded — see `WPEMemoryTier`);
+    /// explicit 0 or negative ⇒ unbounded (manual opt-out);
     /// positive ⇒ that many MiB. Over-budget inactive (hidden-layer) textures
     /// are LRU-evicted and reloaded on demand. Snapshot per scene load, so
     /// `defaults write com.loomscreen.pro WPEMetalTextureCacheBudgetMiB -int 256`

--- a/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Debug.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Debug.swift
@@ -319,7 +319,12 @@ extension WPEMetalSceneRenderer {
         let manager = MTLCaptureManager.shared()
         guard manager.supportsDestination(.gpuTraceDocument) else {
             Logger.info(
-                "[WPEMetalCaptureScene] device does not support gpuTraceDocument capture; ensure MetalCaptureEnabled is YES in Info.plist and Xcode is attached.",
+                // MetalCaptureEnabled is deliberately absent from the shipped
+                // Info.plists: it loads GPUToolsCapture into every launch, whose
+                // per-draw interposition grew the AGX DataBufferAllocator arena
+                // without bound (~40-60MB/min, ledger §14). Capture instead via
+                // Xcode attach or an MTL_CAPTURE_ENABLED=1 launch.
+                "[WPEMetalCaptureScene] device does not support gpuTraceDocument capture; attach Xcode or launch with MTL_CAPTURE_ENABLED=1.",
                 category: .wpeRender
             )
             return nil

--- a/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Lifecycle.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Lifecycle.swift
@@ -25,6 +25,15 @@ extension WPEMetalSceneRenderer {
     // MARK: - Reload & scene property patching
 
     func reload(on actor: isolated WPEDisplayRenderActor) async throws {
+        await retireRuntimeState(on: actor)
+        try await load(on: actor)
+    }
+
+    /// The teardown half of `reload`: drops every loaded runtime resource —
+    /// static/dynamic textures, particles, text, scripts (JSContexts), sound,
+    /// executor transients — while keeping the descriptor, resolvers, and asset
+    /// provider so a later `load` can rebuild the scene from disk.
+    func retireRuntimeState(on actor: isolated WPEDisplayRenderActor) async {
         sceneScriptLoadState.retireCurrent()
         didLoad = false
         let staticTextureReloadDrain = await staticTextureReloadTaskOwner.quiesce()
@@ -73,8 +82,26 @@ extension WPEMetalSceneRenderer {
         lastRuntimeUniforms = nil
         lastFramePipeline = nil
         cachedSnapshot = nil
+        // Load rebuilds both (Load.swift). Left stale, a hibernated renderer's
+        // frameDemand stays non-empty and the wake's `.quality` command unpauses
+        // the display link for the whole reload — seconds of no-op vsync ticks
+        // on a heavy scene.
+        hasAnimatedShaderPasses = false
+        sceneSupportsAudioProcessing = false
         executor.releaseTransientResources()
-        try await load(on: actor)
+    }
+
+    /// Deep hibernate: the suspend path's resource-release depth, not a third
+    /// performance profile. Runs the reload teardown without the reload — the
+    /// session wakes a hibernated renderer by calling `reload()`, which rebuilds
+    /// everything from the retained descriptor/provider. Returns false when
+    /// nothing is loaded (mid-load or already hibernated), so the caller does not
+    /// mark the session hibernated on a no-op.
+    func hibernate(on actor: isolated WPEDisplayRenderActor) async -> Bool {
+        guard didLoad else { return false }
+        await retireRuntimeState(on: actor)
+        publishRuntimeActivity()
+        return true
     }
 
     func canApplyScenePropertyPatch(_ patch: WPEScenePropertyPatch) -> Bool {
@@ -406,7 +433,7 @@ extension WPEMetalSceneRenderer {
             // Re-present so the cleared state shows at once even if the scene is paused.
             surfaceControl.setNeedsRedraw()
         }
-        refreshLiveness()
+        synchronizeFrameDemand()
         pushPointerEventMonitoring()
     }
 
@@ -423,19 +450,44 @@ extension WPEMetalSceneRenderer {
 
     func setClickCaptureEnabled(_ enabled: Bool) {
         surfaceControl.setClickCaptureEnabled(enabled)
-        refreshLiveness()
+        // Record before the demand re-evaluation so `pointerDrivenContent` sees
+        // this toggle instead of the possibly-stale mailbox copy.
+        lastPushedClickCaptureEnabled = enabled
+        synchronizeFrameDemand()
         pushPointerEventMonitoring(clickCaptureEnabled: enabled)
     }
 
-    /// Re-evaluates the paused/continuous state after a mouse-interaction toggle
-    /// flips at runtime, so turning Follow Cursor / Interaction on un-pauses a
-    /// previously-static scene (and turning them off lets it re-pause).
-    private func refreshLiveness() {
-        guard currentProfile == .quality else { return }
-        surfaceControl.applyPacing(WPERenderPacingUpdate(
-            isPaused: !needsContinuousFrames,
-            enableSetNeedsDisplay: !needsContinuousFrames
-        ))
+    /// Re-evaluates frame demand after anything that can flip it at runtime — a
+    /// mouse-interaction toggle, an on-demand video release/rebuild, or a particle
+    /// emitter finishing — and pushes the paused/continuous state to the surface
+    /// (dedup'd on transitions) plus the activity mirror to the session.
+    func synchronizeFrameDemand() {
+        let continuous = needsContinuousFrames
+        if currentProfile == .quality, lastAppliedContinuousFrames != continuous {
+            lastAppliedContinuousFrames = continuous
+            surfaceControl.applyPacing(WPERenderPacingUpdate(
+                isPaused: !continuous,
+                enableSetNeedsDisplay: !continuous
+            ))
+        }
+        publishRuntimeActivity()
+    }
+
+    /// Pushes the "would this renderer do real work under `.quality`" mirror to
+    /// the session (App Nap gate). Renderer-side dedupe; the callback hops to
+    /// MainActor on the session side.
+    func publishRuntimeActivity() {
+        guard let onRuntimeActivityChange else { return }
+        let activity = WPESceneRuntimeActivity(
+            // retireRuntimeState clears the demand inputs, but `didLoad &&`
+            // stays as the belt: activity must never read "working" between a
+            // retire and the load that rebuilds those flags.
+            producesFrames: didLoad && needsContinuousFrames,
+            audible: soundRuntime != nil
+        )
+        guard activity != lastPublishedRuntimeActivity else { return }
+        lastPublishedRuntimeActivity = activity
+        onRuntimeActivityChange(activity)
     }
 
     /// Applies the user-selected frame rate ceiling. `.unlimited` falls
@@ -505,15 +557,30 @@ extension WPEMetalSceneRenderer {
     /// SceneScript-driven transform. Static-scene + dynamic-content combos must
     /// NOT short-circuit MTKView into the paused/on-demand path or they freeze
     /// after the first frame.
-    var needsContinuousFrames: Bool {
-        hasAnimatedShaderPasses
-            || sceneSupportsAudioProcessing
-            || !dynamicTextureSources.isEmpty
-            // On-demand videos may all be released (hidden) yet still need a live
-            // loop so a reveal triggers their rebuild via reconcileVideoResidency.
-            || !onDemandVideoKeyByID.isEmpty
-            || !particleSystems.isEmpty
-            || !dynamicOriginScriptInstances.isEmpty
+    var needsContinuousFrames: Bool { !frameDemand.isEmpty }
+
+    /// Per-category frame demand. Each bit answers "does this subsystem need the
+    /// loop running RIGHT NOW", not "does the scene contain this subsystem":
+    ///
+    /// - `.particles` excludes permanently finished emitters (one-shot bursts /
+    ///   duration-bounded systems whose last particle died) — nothing can respawn
+    ///   them short of a reload, so no wake path is needed.
+    /// - Fully released on-demand videos carry no demand: a reveal is script-
+    ///   (scripts hold `.scripts` demand) or property-patch-driven (the static
+    ///   patch path renders a frame, whose `reconcileVideoResidency` rebuild
+    ///   re-raises `.dynamicTextures` via the `dynamicTextureSources` didSet).
+    ///
+    /// Every other category is deliberately kept whole-scene conservative:
+    /// missing a shrink costs CPU, a wrong shrink freezes a live animation.
+    var frameDemand: WPEFrameDemand {
+        var demand: WPEFrameDemand = []
+        if hasAnimatedShaderPasses { demand.insert(.animatedShaders) }
+        if sceneSupportsAudioProcessing { demand.insert(.audioReactive) }
+        if !dynamicTextureSources.isEmpty { demand.insert(.dynamicTextures) }
+        if particleSystems.contains(where: { !$0.isPermanentlyIdle }) {
+            demand.insert(.particles)
+        }
+        if !dynamicOriginScriptInstances.isEmpty
             || !dynamicScaleScriptInstances.isEmpty
             || !dynamicAnglesScriptInstances.isEmpty
             || !dynamicColorScriptInstances.isEmpty
@@ -524,8 +591,11 @@ extension WPEMetalSceneRenderer {
             // text script must keep the loop running or it freezes at frame 0.
             || !textScriptInstances.isEmpty
             || !textVisibleScriptInstances.isEmpty
-            || !textAlphaScriptInstances.isEmpty
-            || pointerDrivenContent
+            || !textAlphaScriptInstances.isEmpty {
+            demand.insert(.scripts)
+        }
+        if pointerDrivenContent { demand.insert(.pointer) }
+        return demand
     }
 
     /// The cursor moves between frames, so anything that consumes it needs a
@@ -537,11 +607,16 @@ extension WPEMetalSceneRenderer {
     private var pointerDrivenContent: Bool {
         // `!= 0`, not `> 0`: a negative amount/influence is an INVERTED parallax
         // (WPE multiplies the sign straight in), so it still needs the pointer.
+        // The last-pushed click-capture value takes priority over the mailbox for
+        // the same reason as in `pushPointerEventMonitoring`: the mailbox copy is
+        // written on the main thread and may not have landed when the toggle's
+        // demand re-evaluation runs on the render actor.
         (mouseInteractionEnabled
             && cameraParallaxSettings.enabled
             && cameraParallaxSettings.amount != 0
             && cameraParallaxSettings.mouseInfluence != 0)
-            || mailbox.read().clickCaptureEnabled
+            || lastPushedClickCaptureEnabled
+            ?? mailbox.read().clickCaptureEnabled
     }
 
     /// Whether anything in the loaded scene could consume the mailbox pointer.
@@ -609,15 +684,20 @@ extension WPEMetalSceneRenderer {
         dynamicTextureSources.values.forEach { $0.applyPerformanceProfile(profile) }
         switch profile {
         case .quality:
+            let continuous = needsContinuousFrames
+            lastAppliedContinuousFrames = continuous
             surfaceControl.applyPacing(WPERenderPacingUpdate(
-                isPaused: !needsContinuousFrames,
-                enableSetNeedsDisplay: !needsContinuousFrames,
+                isPaused: !continuous,
+                enableSetNeedsDisplay: !continuous,
                 preferredFramesPerSecond: effectiveFPS
             ))
             // Restart scene audio that a prior `.suspended` paused. No-op when
             // audio never started (deferred startup) or is already running.
             soundRuntime?.resume()
         case .suspended:
+            // Nil, not false: the next `.quality` transition must re-apply the
+            // pause state unconditionally.
+            lastAppliedContinuousFrames = nil
             surfaceControl.applyPacing(WPERenderPacingUpdate(isPaused: true, enableSetNeedsDisplay: true))
             surfaceControl.releaseDrawables()
             // Pause the audio engine + FFT tap so a suspended wallpaper costs no
@@ -633,6 +713,7 @@ extension WPEMetalSceneRenderer {
         // Post-switch so the gate sees the profile it just entered. Also the
         // post-load demand evaluation: `load` ends by re-applying the profile.
         pushPointerEventMonitoring()
+        publishRuntimeActivity()
     }
 
     // MARK: - Teardown
@@ -733,6 +814,11 @@ extension WPEMetalSceneRenderer {
                 throw error
             }
             didLogFrameFailure = false
+            // A frame can retire the last demand source (a one-shot emitter's
+            // final particle dying, a patch-hidden video releasing): settle the
+            // loop as soon as that happens instead of ticking a finished scene.
+            // Dedup'd inside, so steady continuous scenes pay two bool sweeps.
+            synchronizeFrameDemand()
         } catch is WPEMetalFrameInFlightBudgetExhausted {
             // GPU still busy on a prior frame — skip this vsync rather than
             // block this display's render actor (keeps other displays at full
@@ -747,5 +833,28 @@ extension WPEMetalSceneRenderer {
             }
         }
     }
+}
+
+/// One bit per subsystem that needs the render loop running this instant.
+/// Empty ⇒ the scene is static right now and may sit on the paused/on-demand
+/// path. See `WPEMetalSceneRenderer.frameDemand` for the per-bit semantics.
+struct WPEFrameDemand: OptionSet, Sendable {
+    let rawValue: UInt8
+    static let animatedShaders = Self(rawValue: 1 << 0)
+    static let audioReactive = Self(rawValue: 1 << 1)
+    static let dynamicTextures = Self(rawValue: 1 << 2)
+    static let particles = Self(rawValue: 1 << 3)
+    static let scripts = Self(rawValue: 1 << 4)
+    static let pointer = Self(rawValue: 1 << 5)
+}
+
+/// Renderer→session mirror of what would do real work under `.quality`, pushed
+/// on change so the App Nap assertion can be released for a playing-but-static
+/// scene without reaching across the render actor synchronously.
+struct WPESceneRuntimeActivity: Equatable, Sendable {
+    /// Mirrors `needsContinuousFrames` (false while hibernated/unloaded).
+    let producesFrames: Bool
+    /// A scene sound runtime exists (conservative: counts even while muted).
+    let audible: Bool
 }
 #endif

--- a/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Lifecycle.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Lifecycle.swift
@@ -407,6 +407,7 @@ extension WPEMetalSceneRenderer {
             surfaceControl.setNeedsRedraw()
         }
         refreshLiveness()
+        pushPointerEventMonitoring()
     }
 
     /// Updates how the scene is fitted to the screen. For a static (non-continuous)
@@ -423,6 +424,7 @@ extension WPEMetalSceneRenderer {
     func setClickCaptureEnabled(_ enabled: Bool) {
         surfaceControl.setClickCaptureEnabled(enabled)
         refreshLiveness()
+        pushPointerEventMonitoring(clickCaptureEnabled: enabled)
     }
 
     /// Re-evaluates the paused/continuous state after a mouse-interaction toggle
@@ -542,6 +544,52 @@ extension WPEMetalSceneRenderer {
             || mailbox.read().clickCaptureEnabled
     }
 
+    /// Whether anything in the loaded scene could consume the mailbox pointer.
+    /// Deliberately conservative: effects/workshop shaders can sample
+    /// `g_PointerPosition*`, any script instance can read the pointer or register
+    /// cursor handlers at runtime, and particle systems can follow it through
+    /// pointer-locked control points/attractors even when `tracksPointer` is
+    /// false — all of those keep the monitors on. Only the provably pointer-free
+    /// scene gates them off.
+    private var scenePointerConsumersPossible: Bool {
+        (cameraParallaxSettings.enabled
+            && cameraParallaxSettings.amount != 0
+            && cameraParallaxSettings.mouseInfluence != 0)
+            || hasAnimatedShaderPasses
+            || !particleSystems.isEmpty
+            || !dynamicOriginScriptInstances.isEmpty
+            || !dynamicScaleScriptInstances.isEmpty
+            || !dynamicAnglesScriptInstances.isEmpty
+            || !dynamicColorScriptInstances.isEmpty
+            || !layerScriptInstances.isEmpty
+            || !layerAlphaScriptInstances.isEmpty
+            || !textScriptInstances.isEmpty
+            || !textVisibleScriptInstances.isEmpty
+            || !textAlphaScriptInstances.isEmpty
+            || !effectConstantScriptInstances.isEmpty
+            || !effectVisibilityScriptInstances.isEmpty
+    }
+
+    /// Pushes the NSEvent-monitor gate to the surface: every mouse move wakes the
+    /// main thread while monitors are installed, so they run only when the
+    /// renderer is unsuspended AND the pointer can be consumed. The config half
+    /// mirrors `sampleFrameContext`'s discard rule — with Follow Cursor and click
+    /// capture both off the sample is forced `.inactive`, so the mailbox feed is
+    /// provably unread. `clickCaptureEnabled` is passed explicitly on the toggle
+    /// path because the mailbox copy is written on the main thread and may not
+    /// have landed when this runs on the render actor.
+    private func pushPointerEventMonitoring(clickCaptureEnabled: Bool? = nil) {
+        if let clickCaptureEnabled { lastPushedClickCaptureEnabled = clickCaptureEnabled }
+        let clickCapture = clickCaptureEnabled
+            ?? lastPushedClickCaptureEnabled
+            ?? mailbox.read().clickCaptureEnabled
+        let demanded = clickCapture
+            || (mouseInteractionEnabled && scenePointerConsumersPossible)
+        surfaceControl.applyPacing(WPERenderPacingUpdate(
+            pointerEventsEnabled: currentProfile != .suspended && demanded
+        ))
+    }
+
     /// A pass animates per-frame when its shader samples `g_Time` /
     /// `g_AudioSpectrum*` — i.e. WPE local effects (`effects/…`) and workshop
     /// custom shaders (`workshop/…`). The static base shaders (`solidcolor`,
@@ -582,6 +630,9 @@ extension WPEMetalSceneRenderer {
             textMeshRenderer?.releaseCachedResources()
             executor.releaseTransientResources()
         }
+        // Post-switch so the gate sees the profile it just entered. Also the
+        // post-load demand evaluation: `load` ends by re-applying the profile.
+        pushPointerEventMonitoring()
     }
 
     // MARK: - Teardown

--- a/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Scripts.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Scripts.swift
@@ -492,9 +492,11 @@ extension WPEMetalSceneRenderer {
             }
         }
     }
-    private var hoverCursorDebugEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "WPEHoverCursorDebug")
-    }
+    /// Read once (static because extensions can't add stored instance
+    /// properties): log-only toggle per WPERenderFlagRegistryTests, and no test
+    /// flips it at runtime, so skipping per-frame defaults reads is safe.
+    private static let hoverCursorDebugDefault = UserDefaults.standard.bool(forKey: "WPEHoverCursorDebug")
+    private var hoverCursorDebugEnabled: Bool { Self.hoverCursorDebugDefault }
 
     /// Pointer (top-left scene pixels) vs a layer's axis-aligned screen rect.
     private func pointerHits(_ pointerPixels: SIMD2<Double>, geometry: WPERenderLayerGeometry) -> Bool {

--- a/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Textures.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Textures.swift
@@ -784,33 +784,10 @@ extension WPEMetalSceneRenderer {
         }
     }
 
+    /// Shares `WPEMetalTextureByteEstimator` with the memory-audit census so
+    /// diagnostics and the LRU budget count the same bytes.
     static func textureResidentBytes(for texture: MTLTexture) -> Int {
-        // BC is stored compressed in VRAM; per-pixel math would 4-6x over-count the budget.
-        let baseBytes: Int
-        switch texture.pixelFormat {
-        case .bc1_rgba, .bc1_rgba_srgb:
-            baseBytes = compressedTextureBytes(width: texture.width, height: texture.height, bytesPerBlock: 8)
-        case .bc2_rgba, .bc2_rgba_srgb, .bc3_rgba, .bc3_rgba_srgb,
-             .bc7_rgbaUnorm, .bc7_rgbaUnorm_srgb:
-            baseBytes = compressedTextureBytes(width: texture.width, height: texture.height, bytesPerBlock: 16)
-        default:
-            baseBytes = texture.width * texture.height * textureCacheBytesPerPixel(for: texture.pixelFormat)
-        }
-        // No loader path generates mips today; 4/3 keeps the estimate honest if one ever does.
-        return texture.mipmapLevelCount > 1 ? baseBytes * 4 / 3 : baseBytes
-    }
-
-    private static func compressedTextureBytes(width: Int, height: Int, bytesPerBlock: Int) -> Int {
-        max((width + 3) / 4, 1) * max((height + 3) / 4, 1) * bytesPerBlock
-    }
-
-    private static func textureCacheBytesPerPixel(for pixelFormat: MTLPixelFormat) -> Int {
-        switch pixelFormat {
-        case .rgba16Float: return 8
-        case .rg8Unorm: return 2
-        case .r8Unorm: return 1
-        default: return 4
-        }
+        WPEMetalTextureByteEstimator.estimatedBytes(of: texture)
     }
 
     // MARK: - Per-frame textures

--- a/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Textures.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Textures.swift
@@ -605,6 +605,7 @@ extension WPEMetalSceneRenderer {
             let source = try WPEVideoTextureSource(
                 device: executor.textureSourceDevice,
                 videoURL: url,
+                commandQueue: executor.textureSourceCommandQueue,
                 // Release the lease (keep the file); the cache owns lifetime now.
                 onInvalidate: { staleURL in
                     Task.detached(priority: .utility) {

--- a/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer.swift
@@ -23,7 +23,10 @@ final class WPEMetalSceneRenderer: NSObject {
     var debugSurface: WPERenderSurface?
     #endif
 
-    let descriptor: SceneDescriptor
+    /// Updated on every committed property patch (actor-side) so an in-place
+    /// reload — hibernate wake, detail-view retry — rebuilds the PATCHED scene;
+    /// reloading the original would silently revert incremental edits.
+    var descriptor: SceneDescriptor
     let cacheRootURL: URL
     let dependencyMounts: [WPEAssetMount]
     /// Install root that contains `assets/`. This object owns the security scope for its lifetime.
@@ -161,7 +164,13 @@ final class WPEMetalSceneRenderer: NSObject {
     var cachedActiveStaticSignature: Int?
     var staticTextureRecordsEpoch = 0
     var dynamicTextureSources: [String: WPEDynamicTextureSource] = [:] {
-        didSet { cachedDynamicTextureNames = nil }
+        didSet {
+            cachedDynamicTextureNames = nil
+            // On-demand video release/rebuild flips frame demand at runtime (the
+            // released-videos-only scene may pause; a rebuilt one must resume).
+            // Load-time churn is skipped: the load tail re-applies the profile.
+            if didLoad { synchronizeFrameDemand() }
+        }
     }
     /// Memo of `dynamicTextureSources.keys`. Mutations are cold and clear it via `didSet`; the frame path only reads.
     private var cachedDynamicTextureNames: Set<String>?
@@ -209,6 +218,15 @@ final class WPEMetalSceneRenderer: NSObject {
     /// Cached so callers arriving before deferred audio startup still record mute/volume; re-applied just before `play()`.
     var pendingAudioMuted: Bool = false
     var pendingAudioVolume: Double = 1.0
+    /// Last pacing decision derived from `needsContinuousFrames`, so the per-frame
+    /// demand re-check touches pacing only on a transition. Nil while suspended
+    /// (the next `.quality` application must re-apply unconditionally).
+    var lastAppliedContinuousFrames: Bool?
+    /// Session-facing push fired when frame/audio demand changes (App Nap mirror).
+    /// Set once by the builder before the actor adopts the renderer.
+    var onRuntimeActivityChange: (@Sendable (WPESceneRuntimeActivity) -> Void)?
+    /// Dedupe for `onRuntimeActivityChange`.
+    var lastPublishedRuntimeActivity: WPESceneRuntimeActivity?
     /// Preset level multiplies the master volume; it does not replace it.
     var presetAudioSettings: WPEEngineAudioSettings?
 

--- a/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer.swift
@@ -41,6 +41,11 @@ final class WPEMetalSceneRenderer: NSObject {
     /// Sendable surface handle: keeps the renderer region separate so it stays `sending`-adoptable.
     let surfaceControl: any WPESurfaceControl
     let mailbox: WPEPointerMailbox
+    /// Last click-capture value this renderer pushed. The mailbox copy is
+    /// written on the main thread, so a profile change racing that delivery
+    /// would recompute the pointer-monitor gate from a stale read; this keeps
+    /// the gate's input in renderer order.
+    var lastPushedClickCaptureEnabled: Bool?
     /// Sendable `CAMetalLayer` wrapper so the renderer region does not reach the main-thread surface.
     let metalLayer: WPEPresentLayer
     var surfaceDrawableSize: CGSize

--- a/LiveWallpaper/Runtime/Metal/WPEMetalShaderDispatcher.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalShaderDispatcher.swift
@@ -585,7 +585,9 @@ struct WPEMetalShaderDispatcher {
         let isWaveLikePass = Self.isWaveLikePass(pass)
         // The transpiler is fragment-only: it always uses wpe_fullscreen_vertex and
         // synthesizes v_TexCoord / v_Direction in the fragment (it does NOT run the scene .vert).
-        if isWaveLikePass {
+        // isEnabled checked here so the interpolated log line (and the slot scan
+        // feeding it) isn't built every frame just for appendLog to discard it.
+        if isWaveLikePass, WPESceneDebugArtifacts.shared.isEnabled {
             let maskLive = Self.hasExplicitTextureSlot(1, in: pass)
             WPESceneDebugArtifacts.shared.appendLog(
                 "🌊 [WPE.fx.vtx] \(pass.pass.shader) target=\(pass.pass.target) "

--- a/LiveWallpaper/Runtime/Metal/WPEMetalTextureByteEstimator.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalTextureByteEstimator.swift
@@ -1,0 +1,75 @@
+#if !LITE_BUILD
+import Foundation
+import Metal
+
+/// Single estimator for GPU texture footprints, shared by the texture-cache LRU
+/// (`WPEMetalSceneRenderer.textureResidentBytes`) and the memory-audit census
+/// (`WPEMetalTextureMetadataRegistry`). The two previously used different math
+/// — the census billed BC-compressed textures at uncompressed rates (4-6x
+/// over), so its numbers could not explain what the LRU was budgeting.
+enum WPEMetalTextureByteEstimator {
+    static func estimatedBytes(of texture: MTLTexture) -> Int {
+        estimatedBytes(
+            pixelFormat: texture.pixelFormat,
+            width: texture.width,
+            height: texture.height,
+            mipmapLevelCount: texture.mipmapLevelCount,
+            arrayLength: texture.arrayLength,
+            isCube: texture.textureType == .typeCube || texture.textureType == .typeCubeArray
+        )
+    }
+
+    /// Descriptor-shaped overload so estimates (and tests) need no MTLDevice.
+    /// For cube arrays `arrayLength` counts cubes, so the x6 face factor stacks.
+    static func estimatedBytes(
+        pixelFormat: MTLPixelFormat,
+        width: Int,
+        height: Int,
+        mipmapLevelCount: Int = 1,
+        arrayLength: Int = 1,
+        isCube: Bool = false
+    ) -> Int {
+        var sliceBytes = 0
+        for level in 0..<max(mipmapLevelCount, 1) {
+            sliceBytes += levelBytes(
+                pixelFormat: pixelFormat,
+                width: max(width >> level, 1),
+                height: max(height >> level, 1)
+            )
+        }
+        return sliceBytes * max(arrayLength, 1) * (isCube ? 6 : 1)
+    }
+
+    private static func levelBytes(pixelFormat: MTLPixelFormat, width: Int, height: Int) -> Int {
+        switch pixelFormat {
+        // BC stays compressed in VRAM; per-pixel math would 4-6x over-count.
+        case .bc1_rgba, .bc1_rgba_srgb:
+            return blockCount(width) * blockCount(height) * 8
+        case .bc2_rgba, .bc2_rgba_srgb, .bc3_rgba, .bc3_rgba_srgb,
+             .bc7_rgbaUnorm, .bc7_rgbaUnorm_srgb:
+            return blockCount(width) * blockCount(height) * 16
+        default:
+            return width * height * bytesPerPixel(for: pixelFormat)
+        }
+    }
+
+    /// Mip levels below 4px still occupy one full 4x4 block per axis.
+    private static func blockCount(_ dimension: Int) -> Int {
+        max((dimension + 3) / 4, 1)
+    }
+
+    private static func bytesPerPixel(for pixelFormat: MTLPixelFormat) -> Int {
+        switch pixelFormat {
+        case .rgba32Float: return 16
+        case .rgba16Float, .rg32Float: return 8
+        case .rgba8Unorm, .rgba8Unorm_srgb, .bgra8Unorm, .bgra8Unorm_srgb, .r32Float, .rg16Float:
+            return 4
+        case .rg8Unorm, .r16Float, .r16Unorm: return 2
+        case .r8Unorm: return 1
+        // Unknown formats fall back to 4 B/px: over-estimates most remaining
+        // formats, so the LRU errs toward evicting rather than over-retaining.
+        default: return 4
+        }
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/Metal/WPEMetalTextureMetadataRegistry.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEMetalTextureMetadataRegistry.swift
@@ -212,22 +212,11 @@ final class WPEMetalTextureMetadataRegistry: @unchecked Sendable {
         return label.split(separator: " ").prefix(2).joined(separator: " ")
     }
 
-    /// Bytes for the mip-0 slice times array length. Compressed formats report
-    /// their block size, so this stays an approximation for BC/ASTC — good
-    /// enough to rank categories, which is what the census is for.
+    /// Shares `WPEMetalTextureByteEstimator` with the texture-cache LRU so the
+    /// census reports the same bytes the eviction budget counts (BC block math
+    /// included — the old per-pixel path billed BC textures 4-6x over).
     private static func approximateBytes(of texture: MTLTexture) -> Int {
-        let bytesPerPixel: Int
-        switch texture.pixelFormat {
-        case .rgba32Float: bytesPerPixel = 16
-        case .rgba16Float, .rg32Float: bytesPerPixel = 8
-        case .rgba8Unorm, .rgba8Unorm_srgb, .bgra8Unorm, .bgra8Unorm_srgb, .r32Float, .rg16Float:
-            bytesPerPixel = 4
-        case .rg8Unorm, .r16Float, .r16Unorm: bytesPerPixel = 2
-        case .r8Unorm: bytesPerPixel = 1
-        default: bytesPerPixel = 4
-        }
-        let slices = max(texture.arrayLength, 1) * (texture.textureType == .typeCube ? 6 : 1)
-        return texture.width * texture.height * bytesPerPixel * slices
+        WPEMetalTextureByteEstimator.estimatedBytes(of: texture)
     }
 }
 #endif

--- a/LiveWallpaper/Runtime/Metal/WPEPointerPublisher.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEPointerPublisher.swift
@@ -22,6 +22,10 @@ final class WPEPointerPublisher {
     private var localMonitor: Any?
     private var geometryObservers: [NSObjectProtocol] = []
     private var lastMousePublishAt: TimeInterval = -.greatestFiniteMagnitude
+    private var isStarted = false
+    /// Defaults ON so `attach` behaves exactly as before the renderer's first
+    /// post-load demand evaluation arrives.
+    private var mouseMonitoringEnabled = true
 
     private static let mouseMask: NSEvent.EventTypeMask = [
         .mouseMoved, .leftMouseDragged, .rightMouseDragged, .otherMouseDragged
@@ -49,7 +53,43 @@ final class WPEPointerPublisher {
 
     /// Idempotent: a second `start()` while already running is a no-op.
     func start() {
-        guard !isRunning else { return }
+        guard !isStarted else { return }
+        isStarted = true
+        installGeometryObservers()
+        publishGeometry() // seed current geometry so the first read isn't `.none`
+        if mouseMonitoringEnabled { installMouseMonitors() }
+    }
+
+    /// The renderer's suspend/demand gate over the NSEvent monitors alone.
+    /// Geometry observers stay installed so a later re-enable publishes against
+    /// current geometry; the flag persists while stopped so a re-`start()` honors
+    /// the last request. The `isStarted` guard is load-bearing: an enable queued
+    /// before `detach()` can be delivered after it, and must not resurrect the
+    /// monitors on a torn-down surface. Main-actor because NSEvent monitors must be added and
+    /// removed on the main thread.
+    func setMouseMonitoringEnabled(_ enabled: Bool) {
+        mouseMonitoringEnabled = enabled
+        guard isStarted else { return }
+        if enabled {
+            installMouseMonitors()
+        } else {
+            removeMouseMonitors()
+        }
+    }
+
+    /// Idempotent: unloads both monitors and the geometry observers; safe to call
+    /// when never started or already stopped.
+    func stop() {
+        isStarted = false
+        removeMouseMonitors()
+        for observer in geometryObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        geometryObservers.removeAll()
+    }
+
+    private func installMouseMonitors() {
+        guard globalMonitor == nil, localMonitor == nil else { return }
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: Self.mouseMask) { [weak self] _ in
             self?.handleMouseEvent()
         }
@@ -57,20 +97,17 @@ final class WPEPointerPublisher {
             self?.handleMouseEvent()
             return event
         }
-        installGeometryObservers()
-        publishGeometry() // seed current geometry so the first read isn't `.none`
-        // Seed the cursor too: the old live sampler read `NSEvent.mouseLocation`
-        // every frame, so before any mouse *event* arrives the mailbox must still
-        // report the real cursor (not the off-screen sentinel) or the first frames
-        // would freeze parallax at center.
+        // Seed the cursor: the old live sampler read `NSEvent.mouseLocation`
+        // every frame, so before any mouse *event* arrives — including right
+        // after a gated-off stretch, when the slot still holds the pre-gate
+        // position — the mailbox must report the real cursor (not the off-screen
+        // sentinel) or the first frames would freeze parallax at center.
         let time = now()
         lastMousePublishAt = time
         mailbox.publishMouseLocation(NSEvent.mouseLocation, timestampNanos: Self.nanos(from: time))
     }
 
-    /// Idempotent: unloads both monitors and the geometry observers; safe to call
-    /// when never started or already stopped.
-    func stop() {
+    private func removeMouseMonitors() {
         if let globalMonitor {
             NSEvent.removeMonitor(globalMonitor)
             self.globalMonitor = nil
@@ -79,10 +116,6 @@ final class WPEPointerPublisher {
             NSEvent.removeMonitor(localMonitor)
             self.localMonitor = nil
         }
-        for observer in geometryObservers {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        geometryObservers.removeAll()
     }
 
     // MARK: - Mouse

--- a/LiveWallpaper/Runtime/Metal/WPEPointerPublisher.swift
+++ b/LiveWallpaper/Runtime/Metal/WPEPointerPublisher.swift
@@ -49,6 +49,10 @@ final class WPEPointerPublisher {
         self.throttleInterval = throttleFPS > 0 ? 1.0 / throttleFPS : 0
     }
 
+    /// True while the NSEvent mouse monitors are installed — not the start/stop
+    /// lifecycle: a started publisher whose monitors were gated off by
+    /// `setMouseMonitoringEnabled(false)` reports false. No production reader;
+    /// tests observe the demand gate through it.
     var isRunning: Bool { globalMonitor != nil || localMonitor != nil }
 
     /// Idempotent: a second `start()` while already running is a no-op.

--- a/LiveWallpaper/Runtime/Scene/WPELayerScriptRuntime.swift
+++ b/LiveWallpaper/Runtime/Scene/WPELayerScriptRuntime.swift
@@ -476,6 +476,7 @@ final class WPELayerScriptInstance {
         /// Set by the context exception handler so `init()` failures can degrade
         /// safely (run on the engine queue, so no synchronization needed).
         private var didThrow = false
+        private var faultPolicy = WPEScriptFaultPolicy()
         /// One-shot latch for `logFirstThrow` (per instance, not per tick).
         private var hasLoggedThrow = false
         /// Handles minted by `thisScene.getLayer(name)`, keyed by layer name.
@@ -791,8 +792,11 @@ final class WPELayerScriptInstance {
             guard let context, let updateFunction else {
                 return WPELayerScriptOutput(own: .init(visible: true, alpha: 1, videoCommands: []), others: [:])
             }
+            let now = WPEScriptFaultPolicy.monotonicNow()
+            guard faultPolicy.shouldAttempt(entryPoint: "update", at: now) else { return readOutput() }
             pendingVideo.removeAll(keepingCapacity: true)
             evaluationResourceBudget.beginEvaluation()
+            didThrow = false
             switch outputMode {
             case .layerState:
                 // Official contract for property-attached scripts: update(value)
@@ -841,6 +845,11 @@ final class WPELayerScriptInstance {
                     }
                 }
             }
+            if didThrow {
+                faultPolicy.recordFailure(entryPoint: "update", at: now)
+            } else {
+                faultPolicy.recordSuccess(entryPoint: "update")
+            }
             return readOutput()
         }
 
@@ -852,8 +861,8 @@ final class WPELayerScriptInstance {
             guard !hasLoggedThrow else { return }
             hasLoggedThrow = true
             Logger.warning(
-                "SceneScript threw: \(exception?.toString() ?? "unknown") — it keeps running, but this "
-                    + "tick produced nothing and a throwing tick costs ~100x a clean one",
+                "SceneScript threw: \(exception?.toString() ?? "unknown") — this tick produced nothing; "
+                    + "retries back off exponentially (a throwing tick costs ~100x a clean one)",
                 category: .wpeRender
             )
         }
@@ -873,12 +882,24 @@ final class WPELayerScriptInstance {
                   !fn.isUndefined, fn.hasProperty("call") else {
                 return readOutput()
             }
+            // Keyed by handler name, so a throwing cursorClick backs off alone
+            // and never gates update() or the other cursor handlers.
+            let now = WPEScriptFaultPolicy.monotonicNow()
+            guard faultPolicy.shouldAttempt(entryPoint: event.handlerName, at: now) else {
+                return readOutput()
+            }
+            didThrow = false
             _ = fn.call(withArguments: [cursorEventObject(
                 event,
                 pointerFrame: pointerFrame,
                 hit: hit,
                 in: context
             )])
+            if didThrow {
+                faultPolicy.recordFailure(entryPoint: event.handlerName, at: now)
+            } else {
+                faultPolicy.recordSuccess(entryPoint: event.handlerName)
+            }
             return readOutput()
         }
 

--- a/LiveWallpaper/Runtime/Scene/WPEParticleSystem.swift
+++ b/LiveWallpaper/Runtime/Scene/WPEParticleSystem.swift
@@ -995,6 +995,16 @@ final class WPEParticleSystem {
 
     var liveInstanceCount: Int { aliveCount }
 
+    /// Updated at the end of every `advance`: true once every spawn gate is
+    /// permanently closed (see the mirror computation there). False until the
+    /// first tick so an untouched system always counts as live.
+    private var emissionExhausted = false
+
+    /// True when this system can never put another particle on stage: nothing is
+    /// alive and no spawn path can reopen. Drives the renderer's frame-demand
+    /// gate — a finished one-shot/duration-bounded emitter stops forcing 30 FPS.
+    var isPermanentlyIdle: Bool { aliveCount == 0 && emissionExhausted }
+
     var tracksPointer: Bool { emitterTracksPointer }
 
     /// Follow Cursor off must clear pointer-locked spawns immediately.
@@ -1165,6 +1175,21 @@ final class WPEParticleSystem {
                 spawnAccumulator = min(spawnAccumulator, 1)
             }
         }
+        // Mirrors the spawn gates above exactly: `elapsed` is monotonic within a
+        // load, so once every gate is closed no later tick can reopen one. A
+        // pointer-blocked burst keeps `hasEmittedBurst` false and an eventfollow
+        // child without a duration stays emittable — both remain not-exhausted,
+        // which is the conservative direction for the frame-demand gate.
+        let rateExhausted = definition.rate <= 0 || !isWithinDuration
+        let burstExhausted: Bool
+        if definition.instantaneousCount <= 0 {
+            burstExhausted = true
+        } else if requiresFollowParent {
+            burstExhausted = !isWithinDuration
+        } else {
+            burstExhausted = hasEmittedBurst
+        }
+        emissionExhausted = hasStartedEmitting && rateExhausted && burstExhausted
     }
 
     #if !LITE_BUILD && DEBUG

--- a/LiveWallpaper/Runtime/Scene/WPEParticleSystem.swift
+++ b/LiveWallpaper/Runtime/Scene/WPEParticleSystem.swift
@@ -51,11 +51,73 @@ struct SplitMix64: RandomNumberGenerator {
     }
 }
 
+/// Live-slot bitset over the particle pool. Birth takes the LOWEST free slot and
+/// live iteration is ASCENDING — both must match the old 0..<capacity linear
+/// scans exactly, or RNG consumption, draw order, and spawn-event order drift.
+struct WPEParticleSlotIndex {
+    private var words: [UInt64]
+    let capacity: Int
+
+    init(capacity: Int) {
+        self.capacity = capacity
+        self.words = .init(repeating: 0, count: (capacity + 63) >> 6)
+    }
+
+    var wordCount: Int { words.count }
+
+    func word(at index: Int) -> UInt64 { words[index] }
+
+    func isLive(_ slot: Int) -> Bool {
+        words[slot >> 6] & ((1 as UInt64) << UInt64(slot & 63)) != 0
+    }
+
+    mutating func markLive(_ slot: Int) {
+        words[slot >> 6] |= (1 as UInt64) << UInt64(slot & 63)
+    }
+
+    mutating func markDead(_ slot: Int) {
+        words[slot >> 6] &= ~((1 as UInt64) << UInt64(slot & 63))
+    }
+
+    mutating func removeAll() {
+        for index in words.indices { words[index] = 0 }
+    }
+
+    /// Equivalent to the old linear free scan from slot 0. Tail bits past
+    /// `capacity` are never set, so a full pool maps them to nil, not a slot.
+    var lowestFreeSlot: Int? {
+        for wordIndex in words.indices {
+            let free = ~words[wordIndex]
+            if free != 0 {
+                let slot = wordIndex << 6 | free.trailingZeroBitCount
+                return slot < capacity ? slot : nil
+            }
+        }
+        return nil
+    }
+
+    /// Ascending live slots. The body must not mutate this index (exclusivity);
+    /// loops that kill mid-iteration use `wordCount`/`word(at:)` instead.
+    func forEachLiveSlot(_ body: (Int) -> Void) {
+        for wordIndex in words.indices {
+            var word = words[wordIndex]
+            while word != 0 {
+                body(wordIndex << 6 | word.trailingZeroBitCount)
+                word &= word &- 1
+            }
+        }
+    }
+}
+
 /// WPE author space is Y-up; origin, velocity, gravity, and rotation must not be flipped.
 struct WPEParticleSceneTransform {
     var renderOrigin: SIMD3<Float>
     var objectScale: SIMD3<Float>
-    var objectAngleZ: Float
+    let objectAngleZ: Float
+    /// Hoisted cos/sin(objectAngleZ) — same libm calls, so results stay bit-exact.
+    /// `objectAngleZ` is `let` so these cannot go stale.
+    let cosAngleZ: Float
+    let sinAngleZ: Float
     /// Caps oversized additive sprites so a scaled emitter cannot saturate the frame.
     var sceneHeight: Float
 
@@ -67,6 +129,8 @@ struct WPEParticleSceneTransform {
         )
         self.objectScale = objectScale
         self.objectAngleZ = objectAngleZ
+        self.cosAngleZ = cos(objectAngleZ)
+        self.sinAngleZ = sin(objectAngleZ)
         self.sceneHeight = max(1, sceneSize.y)
     }
 
@@ -79,8 +143,8 @@ struct WPEParticleSceneTransform {
 
     func applyModelMatrix(toLocalPoint p: SIMD3<Float>) -> SIMD3<Float> {
         let scaled = SIMD3<Float>(p.x * objectScale.x, p.y * objectScale.y, p.z * objectScale.z)
-        let cosA = cos(objectAngleZ)
-        let sinA = sin(objectAngleZ)
+        let cosA = cosAngleZ
+        let sinA = sinAngleZ
         return renderOrigin + SIMD3<Float>(
             scaled.x * cosA - scaled.y * sinA,
             scaled.x * sinA + scaled.y * cosA,
@@ -91,8 +155,8 @@ struct WPEParticleSceneTransform {
     /// No Y-flip. Oracle 3526278753: velocity Y must stay negative = falling.
     func applyModelDirection(_ v: SIMD3<Float>) -> SIMD3<Float> {
         let scaled = SIMD3<Float>(v.x * objectScale.x, v.y * objectScale.y, v.z * objectScale.z)
-        let cosA = cos(objectAngleZ)
-        let sinA = sin(objectAngleZ)
+        let cosA = cosAngleZ
+        let sinA = sinAngleZ
         return SIMD3<Float>(
             scaled.x * cosA - scaled.y * sinA,
             scaled.x * sinA + scaled.y * cosA,
@@ -178,14 +242,18 @@ final class WPEParticleSystem {
     var groupTint: SIMD3<Float> = SIMD3<Float>(1, 1, 1)
     var pointerCentered: SIMD2<Float>?
 
-    weak var followParent: WPEParticleSystem?
+    weak var followParent: WPEParticleSystem? {
+        didSet { followParent?.beginRecordingSpawnEvents() }
+    }
     var followControlPointID: Int = 1
     var requiresFollowParent: Bool = false
     var injectedControlPoints: [Int: SIMD3<Float>] = [:]
     /// Event-driven children only: roll `probability` per parent event, not per scene.
     var spawnProbability: Double = 1
     /// Birth positions this `advance`; an `eventfollow` child bursts once per entry.
+    /// Recorded only once a child attaches (`recordsSpawnEvents`) — nothing else reads it.
     private(set) var spawnEventsThisTick: [SIMD3<Float>] = []
+    private var recordsSpawnEvents = false
 
     private let attractors: [WPEParticleControlPointAttractor]
     private let emitterTracksPointer: Bool
@@ -195,6 +263,23 @@ final class WPEParticleSystem {
     private var aliveCount: Int = 0
     private(set) var lastAttractorAffectedCount = 0
     private var particles: [Particle]
+    /// Must stay exactly consistent with the `age` sentinel: every alive/dead
+    /// transition (spawn, lifetime expiry, clearLiveParticles) updates both.
+    private var liveSlots: WPEParticleSlotIndex
+    private struct ResolvedAttractor {
+        var position: SIMD3<Float>
+        var threshold: Float
+        var scale: Float
+    }
+    /// Rebuilt each `advance`: injected/pointer control points move between ticks,
+    /// but never inside the per-particle loop.
+    private var resolvedAttractors: [ResolvedAttractor] = []
+    private var ropeKnotScratch: [(position: SIMD2<Float>, color: SIMD4<Float>, halfSize: Float, age: Float)] = []
+    /// Youngest live particle (equal ages keep the lower slot), maintained by
+    /// `advance` so follow-child queries skip the full pool scan.
+    private var cachedPrimaryPosition: SIMD3<Float>?
+    private var cachedPrimaryAge: Float = .greatestFiniteMagnitude
+    private var cachedPrimarySlot: Int = .max
     private var spawnAccumulator: Double = 0
     private var hasEmittedBurst = false
     private var lastTickTime: Double?
@@ -205,6 +290,11 @@ final class WPEParticleSystem {
     /// Cached gravity in render space (Y-up).
     private let gravity: SIMD3<Float>
     private let oscillatePositionMask: SIMD3<Float>
+    /// Per-system invariants (definition/transform/gravity are all `let`),
+    /// hoisted out of the per-particle draw and spawn paths.
+    private let perspectiveExtent: Float
+    private let visualScaleSigns: SIMD2<Float>
+    private let spawnWorldSizeMultiplier: Float
 
     /// Pre-uploaded TEXS UV rects; avoids the 4 KB `setVertexBytes` limit.
     let frameRectsBuffer: MTLBuffer?
@@ -287,6 +377,7 @@ final class WPEParticleSystem {
             oscSizeFrequency: 0,
             oscSizePhase: 0
         ), count: cap)
+        self.liveSlots = WPEParticleSlotIndex(capacity: cap)
         var instanceBuffers: [MTLBuffer] = []
         instanceBuffers.reserveCapacity(WPEMetalRenderExecutor.maxFramesInFlight)
         for slot in 0..<WPEMetalRenderExecutor.maxFramesInFlight {
@@ -352,7 +443,12 @@ final class WPEParticleSystem {
             Float(definition.gravity.y),
             Float(definition.gravity.z)
         )
-        self.gravity = sceneTransform.applyModelDirection(localGravity)
+        let gravity = sceneTransform.applyModelDirection(localGravity)
+        self.gravity = gravity
+        self.perspectiveExtent = Self.perspectiveDepthExtent(
+            definition: definition, sceneTransform: sceneTransform, gravity: gravity)
+        self.visualScaleSigns = sceneTransform.visualScaleSigns()
+        self.spawnWorldSizeMultiplier = sceneTransform.worldSizeMultiplier()
         if let osc = definition.oscillatePosition {
             // Mask gates axes, does not scale them (snowperspective 1 0.5 0).
             let gate = SIMD3<Float>(
@@ -391,6 +487,8 @@ final class WPEParticleSystem {
                 Double.random(in: 0..<10, using: &rng)
             )
         }
+        if definition.isRope { ropeKnotScratch.reserveCapacity(cap) }
+        resolvedAttractors.reserveCapacity(definition.attractors.count)
     }
 
     func controlPointPosition(_ id: Int) -> SIMD3<Float>? {
@@ -627,12 +725,16 @@ final class WPEParticleSystem {
     }
 
     private func perspectiveDepthScale(depth z: Float) -> Float {
-        let maxDepth = perspectiveDepthExtent()
-        let t = min(max(z / maxDepth, 0), 1)
+        let t = min(max(z / perspectiveExtent, 0), 1)
         return 1 + Self.perspectiveNearBoost * t
     }
 
-    private func perspectiveDepthExtent() -> Float {
+    /// Called once from init; every input is a per-system invariant.
+    private static func perspectiveDepthExtent(
+        definition: WPEParticleDefinition,
+        sceneTransform: WPEParticleSceneTransform,
+        gravity: SIMD3<Float>
+    ) -> Float {
         let localSpawnDepth: Double
         switch definition.emitterShape {
         case .box:
@@ -676,10 +778,8 @@ final class WPEParticleSystem {
         let frameCount: Float = Float(max(1, spriteSheet?.frameCount ?? 1))
         let animatesSequence = definition.animationMode == .sequence && frameCount > 1
         let cyclesPerLifetime = max(0.0001, Float(definition.sequenceMultiplier))
-        let visualScaleSigns = sceneTransform.visualScaleSigns()
         var written = 0
-        for index in 0..<capacity {
-            guard particles[index].age != .greatestFiniteMagnitude else { continue }
+        liveSlots.forEachLiveSlot { index in
             let particle = particles[index]
             let attrs = drawAttributes(of: particle)
             let lifetimeFraction = attrs.lifetimeFraction
@@ -713,34 +813,32 @@ final class WPEParticleSystem {
             ropeVertexCount = 0
             return
         }
-        var knots: [(position: SIMD2<Float>, color: SIMD4<Float>, halfSize: Float, age: Float)] = []
-        knots.reserveCapacity(capacity)
-        for index in 0..<capacity {
+        ropeKnotScratch.removeAll(keepingCapacity: true)
+        liveSlots.forEachLiveSlot { index in
             let particle = particles[index]
-            guard particle.age != .greatestFiniteMagnitude else { continue }
             let attrs = drawAttributes(of: particle)
-            knots.append((
+            ropeKnotScratch.append((
                 SIMD2<Float>(attrs.position.x, attrs.position.y),
                 SIMD4<Float>(attrs.rgb.x, attrs.rgb.y, attrs.rgb.z, attrs.alpha),
                 max(0, attrs.size * 0.5),
                 particle.age
             ))
         }
-        aliveCount = knots.count
-        guard knots.count >= 2 else {
+        aliveCount = ropeKnotScratch.count
+        guard ropeKnotScratch.count >= 2 else {
             ropeVertexCount = 0
             return
         }
-        knots.sort { $0.age < $1.age }
+        ropeKnotScratch.sort { $0.age < $1.age }
 
         let verts = buffer.contents().bindMemory(to: WPEParticleRopeVertex.self, capacity: capacity * 2)
-        let count = knots.count
+        let count = ropeKnotScratch.count
         // Carry the last valid normal across coincident knots so the ribbon does not spike.
         var lastNormal = SIMD2<Float>(0, 1)
         var written = 0
         for i in 0..<count {
-            let prev = knots[max(0, i - 1)].position
-            let next = knots[min(count - 1, i + 1)].position
+            let prev = ropeKnotScratch[max(0, i - 1)].position
+            let next = ropeKnotScratch[min(count - 1, i + 1)].position
             let tangent = next - prev
             let length = (tangent.x * tangent.x + tangent.y * tangent.y).squareRoot()
             var normal = lastNormal
@@ -749,7 +847,7 @@ final class WPEParticleSystem {
                 normal = SIMD2<Float>(-unit.y, unit.x)
                 lastNormal = normal
             }
-            let knot = knots[i]
+            let knot = ropeKnotScratch[i]
             let offset = normal * knot.halfSize
             let along = Float(i) / Float(count - 1)
             verts[written] = WPEParticleRopeVertex(
@@ -777,11 +875,10 @@ final class WPEParticleSystem {
         let perRibbon = pointCount * 2 + 2
         var written = 0
         var live = 0
-        for index in 0..<capacity {
+        liveSlots.forEachLiveSlot { index in
             let particle = particles[index]
-            guard particle.age != .greatestFiniteMagnitude else { continue }
             live += 1
-            guard written + perRibbon <= ropeVertexCapacity else { continue }
+            guard written + perRibbon <= ropeVertexCapacity else { return }
             let attrs = drawAttributes(of: particle)
             let color = SIMD4<Float>(attrs.rgb.x, attrs.rgb.y, attrs.rgb.z, attrs.alpha)
             let halfSize = max(0, attrs.size * 0.5)
@@ -902,21 +999,42 @@ final class WPEParticleSystem {
 
     /// Follow Cursor off must clear pointer-locked spawns immediately.
     func clearLiveParticles() {
+        // Deliberately sweeps every slot: clearing must reach all of them.
         for index in 0..<capacity {
             particles[index].age = .greatestFiniteMagnitude
         }
+        liveSlots.removeAll()
+        resetPrimaryCache()
         aliveCount = 0
         spawnAccumulator = 0
     }
 
-    var primaryLiveParticlePosition: SIMD3<Float>? {
-        var bestPosition: SIMD3<Float>?
-        var bestAge = Float.greatestFiniteMagnitude
-        for particle in particles where particle.age != .greatestFiniteMagnitude && particle.age < bestAge {
-            bestAge = particle.age
-            bestPosition = particle.position
+    /// Youngest live particle; equal ages keep the lower slot (cache preserves
+    /// the old ascending strict-< scan). Valid between ticks, which is the only
+    /// time `injectFollowControlPoint` reads it.
+    var primaryLiveParticlePosition: SIMD3<Float>? { cachedPrimaryPosition }
+
+    private func resetPrimaryCache() {
+        cachedPrimaryPosition = nil
+        cachedPrimaryAge = .greatestFiniteMagnitude
+        cachedPrimarySlot = .max
+    }
+
+    /// Lexicographic (age, slot) min — identical to the old ascending strict-< scan,
+    /// including a fresh spawn landing in a lower slot than an equal-age survivor.
+    private func notePrimaryCandidate(age: Float, slot: Int, position: SIMD3<Float>) {
+        if age < cachedPrimaryAge || (age == cachedPrimaryAge && slot < cachedPrimarySlot) {
+            cachedPrimaryAge = age
+            cachedPrimarySlot = slot
+            cachedPrimaryPosition = position
         }
-        return bestPosition
+    }
+
+    private func beginRecordingSpawnEvents() {
+        guard !recordsSpawnEvents else { return }
+        recordsSpawnEvents = true
+        // Upper bound on births observable in one tick.
+        spawnEventsThisTick.reserveCapacity(capacity)
     }
 
     private var systemElapsed: Double = 0
@@ -943,53 +1061,70 @@ final class WPEParticleSystem {
         let turbulenceMask = turbulenceOp.map {
             SIMD3<Double>($0.mask.x, $0.mask.y, $0.mask.z)
         } ?? .zero
+        // Control points move between ticks (injection, pointer), never inside
+        // the particle loop, so one resolution per tick observes the same values.
+        resolvedAttractors.removeAll(keepingCapacity: true)
+        for attractor in attractors {
+            guard let cp = controlPointPosition(attractor.controlPointID) else { continue }
+            resolvedAttractors.append(ResolvedAttractor(
+                position: cp,
+                threshold: Float(attractor.threshold),
+                scale: Float(attractor.scale)
+            ))
+        }
 
+        resetPrimaryCache()
         var attractorAffectedThisTick = 0
-        for index in 0..<capacity {
-            guard particles[index].age != .greatestFiniteMagnitude else { continue }
-            particles[index].age += dt
-            if particles[index].age >= particles[index].lifetime {
-                particles[index].age = .greatestFiniteMagnitude
-                continue
-            }
-            particles[index].velocity += gravity * dt
-            if dragScalar < 1 { particles[index].velocity *= dragScalar }
-            if !attractors.isEmpty {
-                let pos = particles[index].position
-                var affectedThisParticle = false
-                for attractor in attractors {
-                    guard let cp = controlPointPosition(attractor.controlPointID) else { continue }
-                    let dx = cp.x - pos.x
-                    let dy = cp.y - pos.y
-                    let dist = (dx * dx + dy * dy).squareRoot()
-                    let threshold = Float(attractor.threshold)
-                    guard dist > 1e-3, dist < threshold else { continue }
-                    let falloff = 1 - dist / threshold
-                    let accel = Float(attractor.scale) * falloff / dist
-                    particles[index].velocity.x += dx * accel * dt
-                    particles[index].velocity.y += dy * accel * dt
-                    affectedThisParticle = true
+        for wordIndex in 0..<liveSlots.wordCount {
+            var liveWord = liveSlots.word(at: wordIndex)
+            while liveWord != 0 {
+                let index = wordIndex << 6 | liveWord.trailingZeroBitCount
+                liveWord &= liveWord &- 1
+                particles[index].age += dt
+                if particles[index].age >= particles[index].lifetime {
+                    particles[index].age = .greatestFiniteMagnitude
+                    liveSlots.markDead(index)
+                    continue
                 }
-                if affectedThisParticle { attractorAffectedThisTick += 1 }
+                particles[index].velocity += gravity * dt
+                if dragScalar < 1 { particles[index].velocity *= dragScalar }
+                if !resolvedAttractors.isEmpty {
+                    let pos = particles[index].position
+                    var affectedThisParticle = false
+                    for attractor in resolvedAttractors {
+                        let dx = attractor.position.x - pos.x
+                        let dy = attractor.position.y - pos.y
+                        let dist = (dx * dx + dy * dy).squareRoot()
+                        guard dist > 1e-3, dist < attractor.threshold else { continue }
+                        let falloff = 1 - dist / attractor.threshold
+                        let accel = attractor.scale * falloff / dist
+                        particles[index].velocity.x += dx * accel * dt
+                        particles[index].velocity.y += dy * accel * dt
+                        affectedThisParticle = true
+                    }
+                    if affectedThisParticle { attractorAffectedThisTick += 1 }
+                }
+                if turbulenceOp != nil, particles[index].turbulenceSpeed > 0 {
+                    let pos = particles[index].position
+                    let sample = SIMD3<Double>(
+                        Double(pos.x) + Double(particles[index].turbulencePhase) + turbulenceTimescale * elapsed,
+                        Double(pos.y),
+                        Double(pos.z)
+                    ) * turbulenceScale
+                    let dir = WPEParticleCurlNoise.direction(at: sample)
+                    let speed = Double(particles[index].turbulenceSpeed)
+                    particles[index].velocity.x += Float(dir.x * speed * turbulenceMask.x) * dt
+                    particles[index].velocity.y += Float(dir.y * speed * turbulenceMask.y) * dt
+                    particles[index].velocity.z += Float(dir.z * speed * turbulenceMask.z) * dt
+                }
+                particles[index].position += particles[index].velocity * dt
+                particles[index].angularVelocityZ += angularForce * dt
+                if angularDragScalar < 1 { particles[index].angularVelocityZ *= angularDragScalar }
+                particles[index].rotationZ += particles[index].angularVelocityZ * dt
+                if trailPointCount > 0 { pushTrailPoint(index) }
+                notePrimaryCandidate(
+                    age: particles[index].age, slot: index, position: particles[index].position)
             }
-            if turbulenceOp != nil, particles[index].turbulenceSpeed > 0 {
-                let pos = particles[index].position
-                let sample = SIMD3<Double>(
-                    Double(pos.x) + Double(particles[index].turbulencePhase) + turbulenceTimescale * elapsed,
-                    Double(pos.y),
-                    Double(pos.z)
-                ) * turbulenceScale
-                let dir = WPEParticleCurlNoise.direction(at: sample)
-                let speed = Double(particles[index].turbulenceSpeed)
-                particles[index].velocity.x += Float(dir.x * speed * turbulenceMask.x) * dt
-                particles[index].velocity.y += Float(dir.y * speed * turbulenceMask.y) * dt
-                particles[index].velocity.z += Float(dir.z * speed * turbulenceMask.z) * dt
-            }
-            particles[index].position += particles[index].velocity * dt
-            particles[index].angularVelocityZ += angularForce * dt
-            if angularDragScalar < 1 { particles[index].angularVelocityZ *= angularDragScalar }
-            particles[index].rotationZ += particles[index].angularVelocityZ * dt
-            if trailPointCount > 0 { pushTrailPoint(index) }
         }
         lastAttractorAffectedCount = attractorAffectedThisTick
 
@@ -1146,12 +1281,7 @@ final class WPEParticleSystem {
     }
 
     private func nextFreeSlot() -> Int? {
-        for index in 0..<capacity {
-            if particles[index].age == .greatestFiniteMagnitude {
-                return index
-            }
-        }
-        return nil
+        liveSlots.lowestFreeSlot
     }
 
     @discardableResult
@@ -1206,7 +1336,7 @@ final class WPEParticleSystem {
             position = sceneTransform.applyModelMatrix(toLocalPoint: localPoint)
         }
         let velocity = sceneTransform.applyModelDirection(localVelocity)
-        let sizeScale = (isRefract || isNestedChildSystem) ? 1.0 : sceneTransform.worldSizeMultiplier()
+        let sizeScale = (isRefract || isNestedChildSystem) ? 1.0 : spawnWorldSizeMultiplier
         // `sizerandom`: min + (max-min)·rand^exp (exp>1 biases toward min).
         let sizeSample: Double
         if abs(definition.sizeExponent - 1) < 0.0001 {
@@ -1297,8 +1427,10 @@ final class WPEParticleSystem {
             oscSizeFrequency: oscSizeFrequency,
             oscSizePhase: oscSizePhase
         )
+        liveSlots.markLive(slot)
+        notePrimaryCandidate(age: 0, slot: slot, position: position)
         if trailPointCount > 0 { resetTrailHistory(slot, to: position) }
-        spawnEventsThisTick.append(position)
+        if recordsSpawnEvents { spawnEventsThisTick.append(position) }
         return true
     }
 

--- a/LiveWallpaper/Runtime/Scene/WPESceneScriptRuntime.swift
+++ b/LiveWallpaper/Runtime/Scene/WPESceneScriptRuntime.swift
@@ -228,6 +228,10 @@ final class WPESceneScriptContextBeacon: NSObject {
 final class WPESceneScriptAudioBridge {
     /// WPE AUDIO_RESOLUTION_* constants (broker width = largest).
     private static let resolutions = [16, 32, 64]
+    /// FIFO cap on registrations: a script that calls registerAudioBuffers()
+    /// from update() would otherwise append 3 permanently-protected JSValues
+    /// per frame, pinning them for the context's lifetime.
+    private static let maxRegisteredBuffers = 16
 
     private struct Buffer {
         let bands: Int
@@ -269,9 +273,16 @@ final class WPESceneScriptAudioBridge {
                     category: .audioCapture
                 )
             }
-            self?.buffers.append(
-                Buffer(bands: bands, average: average, left: left, right: right)
-            )
+            if let self {
+                self.buffers.append(
+                    Buffer(bands: bands, average: average, left: left, right: right)
+                )
+                // A dropped buffer's JS arrays simply stop receiving updates;
+                // a per-update registrant converges on its newest registration.
+                if self.buffers.count > Self.maxRegisteredBuffers {
+                    self.buffers.removeFirst(self.buffers.count - Self.maxRegisteredBuffers)
+                }
+            }
             return buffer
         }
         // Undocumented 64-bin stereo average; sampled per call (rare, no per-tick cache).
@@ -800,6 +811,7 @@ final class WPESceneScriptInstance {
         /// that throws every tick surfaces once instead of spamming per frame.
         private var didLogException = false
         private var didThrow = false
+        private var faultPolicy = WPEScriptFaultPolicy()
         /// Scene render size, or nil to leave the sandbox's 1920x1080.
         private let canvasSize: SIMD2<Double>?
 
@@ -942,7 +954,7 @@ final class WPESceneScriptInstance {
                 guard !self.didLogException else { return }
                 self.didLogException = true
                 Logger.warning(
-                    "Text SceneScript raised an uncaught JS exception — keeping last value; update() retries each tick (logged once): \(ex?.toString() ?? "unknown")",
+                    "Text SceneScript raised an uncaught JS exception — keeping last value; retries back off exponentially (logged once): \(ex?.toString() ?? "unknown")",
                     category: .wpeRender
                 )
             }
@@ -985,9 +997,17 @@ final class WPESceneScriptInstance {
             audioBridge?.refresh()
             guard advanceTimers(to: updateEngineRuntime(runtimeSeconds)) else { return nil }
             guard let context, let updateFunction else { return nil }
+            let now = WPEScriptFaultPolicy.monotonicNow()
+            guard faultPolicy.shouldAttempt(entryPoint: "update", at: now) else { return nil }
             let arg = JSValue(object: lastValue, in: context) ?? JSValue(nullIn: context)!
-            guard let result = updateFunction.call(withArguments: [arg as Any]),
-                  !result.isUndefined && !result.isNull else {
+            didThrow = false
+            let result = updateFunction.call(withArguments: [arg as Any])
+            if didThrow {
+                faultPolicy.recordFailure(entryPoint: "update", at: now)
+                return nil
+            }
+            faultPolicy.recordSuccess(entryPoint: "update")
+            guard let result, !result.isUndefined && !result.isNull else {
                 return nil
             }
             if result.isString, let s = result.toString() {
@@ -2182,11 +2202,12 @@ final class WPEDynamicTransformScriptInstance: @unchecked Sendable {
         private var neutralLayerHandle: JSValue?
         private var lastRuntimeSeconds: Double?
         private var didThrow = false
-        private var consecutiveRuntimeExceptions = 0
-        /// Cap repeated update() exceptions so JSC reporting cannot thrash every tick.
+        /// Repeated update() exceptions back off through the shared policy so
+        /// JSC reporting cannot thrash every tick.
+        private var faultPolicy = WPEScriptFaultPolicy()
+        /// Set on hard quarantine so callers can stop scheduling without a queue hop.
         private let runtimeFault = OSAllocatedUnfairLock(initialState: false)
         var hasRuntimeFault: Bool { runtimeFault.withLock { $0 } }
-        private static let runtimeExceptionLimit = 3
 
         init(
             seed: SIMD3<Double>,
@@ -2379,10 +2400,12 @@ final class WPEDynamicTransformScriptInstance: @unchecked Sendable {
 
             didThrow = false
             guard let argument = jsValue(for: currentValue, in: context) else { return nil }
+            let now = WPEScriptFaultPolicy.monotonicNow()
+            guard faultPolicy.shouldAttempt(entryPoint: "update", at: now) else { return nil }
             let result = updateFunction.call(withArguments: [argument])
             if didThrow {
-                consecutiveRuntimeExceptions += 1
-                if consecutiveRuntimeExceptions >= Self.runtimeExceptionLimit {
+                let verdict = faultPolicy.recordFailure(entryPoint: "update", at: now)
+                if verdict == .quarantined {
                     // Release the JS callable on its owning queue and stop
                     // scheduling this broken transform until scene reload.
                     self.updateFunction = nil
@@ -2390,7 +2413,7 @@ final class WPEDynamicTransformScriptInstance: @unchecked Sendable {
                 }
                 return nil
             }
-            consecutiveRuntimeExceptions = 0
+            faultPolicy.recordSuccess(entryPoint: "update")
             guard let result,
                   !result.isUndefined, !result.isNull else {
                 return nil

--- a/LiveWallpaper/Runtime/Scene/WPESceneScriptRuntime.swift
+++ b/LiveWallpaper/Runtime/Scene/WPESceneScriptRuntime.swift
@@ -279,8 +279,17 @@ final class WPESceneScriptAudioBridge {
                 )
                 // A dropped buffer's JS arrays simply stop receiving updates;
                 // a per-update registrant converges on its newest registration.
+                // A scene that legitimately registers more than the cap once at
+                // init loses its FIRST registrations instead, and the symptom
+                // (a subset of elements frozen at their initial values) is
+                // otherwise invisible — so say it happened.
                 if self.buffers.count > Self.maxRegisteredBuffers {
-                    self.buffers.removeFirst(self.buffers.count - Self.maxRegisteredBuffers)
+                    let dropped = self.buffers.count - Self.maxRegisteredBuffers
+                    self.buffers.removeFirst(dropped)
+                    Logger.warning(
+                        "[SceneScript] registerAudioBuffers exceeded \(Self.maxRegisteredBuffers) registrations — dropped \(dropped) oldest; those buffers stop updating",
+                        category: .wpeRender
+                    )
                 }
             }
             return buffer

--- a/LiveWallpaper/Runtime/Scene/WPEScriptFaultPolicy.swift
+++ b/LiveWallpaper/Runtime/Scene/WPEScriptFaultPolicy.swift
@@ -1,0 +1,92 @@
+#if !LITE_BUILD
+import Foundation
+
+/// Outcome of `WPEScriptFaultPolicy.recordFailure`.
+enum WPEScriptFaultVerdict: Equatable {
+    /// Skip the entry point for the given number of attempts.
+    case backoff(skippedFrames: Int)
+    /// Backoff exhausted; retry at most once per `probeInterval`.
+    case probing
+    /// Same signature failed `quarantineProbeLimit` probes and the entry point
+    /// never succeeded once — stop attempting it for this engine's lifetime.
+    case quarantined
+}
+
+/// Per-entry-point exponential backoff for script entry points that raise
+/// uncaught JS exceptions. A throwing tick costs ~100x a clean one (measured in
+/// WPELayerScriptRuntime.logFirstThrow), so re-running it every frame is the
+/// expensive part of a broken script. Keyed by entry point ("update", a cursor
+/// handler name) only — deliberately NOT the exception message: a script
+/// throwing `Error("t=" + Date.now())` would restart the escalation on every
+/// tick and never reach quarantine.
+/// Pure value type, mutated only on the owning engine's serial queue; `now` is
+/// caller-supplied for testability.
+struct WPEScriptFaultPolicy {
+    /// Attempts skipped after the 1st, 2nd and 3rd consecutive failure.
+    static let backoffFrames: [Int] = [1, 8, 64]
+    /// Minimum spacing of retries once backoff is exhausted.
+    static let probeInterval: TimeInterval = 1.0
+    /// Failed probes before hard quarantine (only for entry points that never
+    /// succeeded; 12 chosen from the reviewed 8-16 range).
+    static let quarantineProbeLimit = 12
+
+    private struct FaultState {
+        var failureCount = 0
+        var skipRemaining = 0
+        var nextProbeAt: Double?
+        var probeFailures = 0
+        var isQuarantined = false
+    }
+
+    private var faults: [String: FaultState] = [:]
+    private var succeededEntryPoints: Set<String> = []
+
+    /// Uptime seconds; the engines' shared `now` source for `at:` arguments.
+    static func monotonicNow() -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds) / 1_000_000_000
+    }
+
+    /// One call per would-be attempt: a `false` during backoff consumes one
+    /// skipped frame. Always `true` for an entry point with no recorded fault.
+    mutating func shouldAttempt(entryPoint: String, at now: Double) -> Bool {
+        guard var state = faults[entryPoint] else { return true }
+        if state.isQuarantined { return false }
+        if state.skipRemaining > 0 {
+            state.skipRemaining -= 1
+            faults[entryPoint] = state
+            return false
+        }
+        if let nextProbeAt = state.nextProbeAt { return now >= nextProbeAt }
+        return true
+    }
+
+    @discardableResult
+    mutating func recordFailure(entryPoint: String, at now: Double) -> WPEScriptFaultVerdict {
+        var state = faults[entryPoint] ?? FaultState()
+        state.failureCount += 1
+        if state.failureCount <= Self.backoffFrames.count {
+            state.skipRemaining = Self.backoffFrames[state.failureCount - 1]
+            state.nextProbeAt = nil
+            faults[entryPoint] = state
+            return .backoff(skippedFrames: state.skipRemaining)
+        }
+        state.probeFailures += 1
+        if state.probeFailures >= Self.quarantineProbeLimit,
+           !succeededEntryPoints.contains(entryPoint) {
+            state.isQuarantined = true
+            faults[entryPoint] = state
+            return .quarantined
+        }
+        state.nextProbeAt = now + Self.probeInterval
+        faults[entryPoint] = state
+        return .probing
+    }
+
+    /// Any success clears the entry point's fault state and permanently exempts
+    /// it from hard quarantine (it degrades to 1 Hz probing instead).
+    mutating func recordSuccess(entryPoint: String) {
+        succeededEntryPoints.insert(entryPoint)
+        faults.removeValue(forKey: entryPoint)
+    }
+}
+#endif

--- a/LiveWallpaper/Runtime/Session/AmbientWallpaperSessionBuilder.swift
+++ b/LiveWallpaper/Runtime/Session/AmbientWallpaperSessionBuilder.swift
@@ -1,6 +1,7 @@
 import AppKit
 import LiveWallpaperCore
 import Metal
+import os
 
 #if !LITE_BUILD
 import LiveWallpaperProWPE
@@ -353,6 +354,21 @@ final class AmbientWallpaperSessionBuilder {
 
         // Adopt renderer into actor then load; session keeps surface (+ shim) alive.
         let session = SceneWallpaperSession(window: window, renderActor: renderActor, surface: surface)
+        // Frame/audio activity mirror for the App Nap gate. Installed before the
+        // handoff (the renderer must not be touched after adoption); the renderer
+        // pushes from its actor, the session consumes on MainActor.
+        // Unstructured MainActor hops are not FIFO: deliver latest-wins through
+        // a mailbox so a stale idle can't land after (and overwrite) a newer
+        // active — the renderer dedups on its side, so a lost transition would
+        // never be corrected.
+        let activityMailbox = OSAllocatedUnfairLock<WPESceneRuntimeActivity?>(initialState: nil)
+        renderer.onRuntimeActivityChange = { [weak session] activity in
+            activityMailbox.withLock { $0 = activity }
+            Task { @MainActor in
+                guard let latest = activityMailbox.withLock({ $0 }) else { return }
+                session?.noteRendererRuntimeActivity(latest)
+            }
+        }
         // One-shot `WPERendererHandoff` (main-built, never touched again); session owns adopt+load task.
         session.startAdoptingRenderer(WPERendererHandoff(renderer: renderer))
         return session

--- a/LiveWallpaper/Runtime/Session/InspectorPreviewController.swift
+++ b/LiveWallpaper/Runtime/Session/InspectorPreviewController.swift
@@ -93,6 +93,9 @@ final class InspectorPreviewController {
                 generator.appliesPreferredTrackTransform = true
                 generator.requestedTimeToleranceBefore = .zero
                 generator.requestedTimeToleranceAfter = CMTime(seconds: 1, preferredTimescale: 600)
+                // Poster only fills the inspector preview pane / monitor backdrop,
+                // so don't decode a 4K/8K frame; aspect-fit is preserved.
+                generator.maximumSize = CGSize(width: 1280, height: 1280)
 
                 let loadedDuration = try? await asset.load(.duration)
                 let (cgImage, actualTime) = try await generator.image(at: targetTime)

--- a/LiveWallpaper/Runtime/Session/SceneWallpaperSession.swift
+++ b/LiveWallpaper/Runtime/Session/SceneWallpaperSession.swift
@@ -92,7 +92,14 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
     /// simply "not loaded" while hibernated.
     private(set) var isHibernated = false
     private let hibernationDelay: Duration
+    /// Manual pause is not an absence: the user may look at the frozen frame and
+    /// unpause any moment, so it gets its own much longer dwell (M4a) instead of
+    /// reusing the absence constant. Wake is a normal reload; seconds of latency
+    /// on unpause are accepted.
+    private let userPauseHibernationDelay: Duration
     private var hibernationTask: Task<Void, Never>?
+    private var pauseHibernationTask: Task<Void, Never>?
+    private var pressureHibernationTask: Task<Void, Never>?
     /// Retains the wake reload spawned on the suspended→quality transition so
     /// `cleanup()` can cancel it.
     private var wakeTask: Task<Void, Never>?
@@ -147,7 +154,8 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
         renderActor: WPEDisplayRenderActor,
         surface: WPERenderSurface,
         audioCaptureDemandController: any SystemAudioCaptureDemandControlling = SystemAudioCaptureManager.shared,
-        hibernationDelay: Duration = .seconds(20)
+        hibernationDelay: Duration = .seconds(20),
+        userPauseHibernationDelay: Duration = .seconds(300)
     ) {
         self.window = window
         self.renderActor = renderActor
@@ -155,6 +163,7 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
         self.rendererConfigAdapter = WPERendererConfigAdapter(renderActor: renderActor)
         self.audioCaptureDemandController = audioCaptureDemandController
         self.hibernationDelay = hibernationDelay
+        self.userPauseHibernationDelay = userPauseHibernationDelay
     }
 
     private var effectivePerformanceProfile: WallpaperPerformanceProfile {
@@ -343,9 +352,9 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
     private func applyEffectivePerformanceProfile() {
         let effective = effectivePerformanceProfile
         if effective == .quality {
-            // Any transition to playing cancels a pending hibernate countdown.
-            hibernationTask?.cancel()
-            hibernationTask = nil
+            // Any transition to playing cancels the pending hibernate countdowns.
+            cancelHibernationDwell(\.hibernationTask)
+            cancelHibernationDwell(\.pressureHibernationTask)
         }
         if lastAppliedPerformanceProfile != effective {
             lastAppliedPerformanceProfile = effective
@@ -359,6 +368,7 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
                 await self?.reload()
             }
         }
+        reconcileManualPauseHibernation()
         reconcileSystemAudioCaptureDemand()
     }
 
@@ -373,27 +383,96 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
               hasRenderer,
               !isHibernated,
               effectivePerformanceProfile == .suspended else {
-            hibernationTask?.cancel()
-            hibernationTask = nil
+            cancelHibernationDwell(\.hibernationTask)
             return
         }
-        guard hibernationTask == nil else { return }
-        hibernationTask = Task { [weak self, hibernationDelay] in
+        armHibernationDwell(
+            \.hibernationTask,
+            initialDwell: hibernationDelay,
+            retryDwell: hibernationDelay
+        )
+    }
+
+    /// Critical system memory pressure: skip the dwell and release renderer
+    /// resources now (policy has already suspended the session). Own slot so a
+    /// routine `setHibernationEligible(false)` push cannot cancel it.
+    ///
+    /// Takes the level as state rather than a one-shot trigger: the retry
+    /// cadence must not outlive the emergency. Armed-and-blocked (in-flight
+    /// load) plus a return to normal used to leave the 1s retry running, which
+    /// then hibernated a session suspended for an unrelated reason — bypassing
+    /// the manual-pause and absence dwells entirely.
+    func setCriticalMemoryPressureActive(_ active: Bool) {
+        guard active else {
+            cancelHibernationDwell(\.pressureHibernationTask)
+            return
+        }
+        guard hasRenderer,
+              !isHibernated,
+              effectivePerformanceProfile == .suspended else { return }
+        // Non-zero retry: an in-flight load makes `hibernateNow` return false,
+        // and a zero-dwell retry would spin until the load finishes.
+        armHibernationDwell(
+            \.pressureHibernationTask,
+            initialDwell: .zero,
+            retryDwell: .seconds(1)
+        )
+    }
+
+    /// Second hibernatable class (M4a): a user-paused wallpaper is not an
+    /// absence, so it keeps its own dwell and never touches the absence slot.
+    /// Called from every effective-profile fold; the slot guard makes repeats
+    /// idempotent instead of restarting the countdown.
+    private func reconcileManualPauseHibernation() {
+        guard !userIntendsToPlay,
+              hasRenderer,
+              !isHibernated else {
+            cancelHibernationDwell(\.pauseHibernationTask)
+            return
+        }
+        armHibernationDwell(
+            \.pauseHibernationTask,
+            initialDwell: userPauseHibernationDelay,
+            retryDwell: userPauseHibernationDelay
+        )
+    }
+
+    private func armHibernationDwell(
+        _ slot: ReferenceWritableKeyPath<SceneWallpaperSession, Task<Void, Never>?>,
+        initialDwell: Duration,
+        retryDwell: Duration
+    ) {
+        guard self[keyPath: slot] == nil else { return }
+        self[keyPath: slot] = Task { [weak self] in
             // The handle stays set for the whole body — not just the countdown —
             // so `cleanup()` can DRAIN an in-flight hibernate, and a transient
             // blocker (an in-flight load) re-dwells instead of dropping the
             // countdown (eligibility pushes are event-driven; a dropped
             // countdown would skip the entire absence).
+            var dwell = initialDwell
             while true {
-                try? await Task.sleep(for: hibernationDelay)
+                try? await Task.sleep(for: dwell)
                 guard !Task.isCancelled, let self else { return }
                 if await self.hibernateNow() {
-                    self.hibernationTask = nil
+                    // Cancelled mid-`hibernateNow` means the canceller already
+                    // cleared (and may have re-armed) the slot; clearing here
+                    // would orphan the replacement task.
+                    if !Task.isCancelled {
+                        self[keyPath: slot] = nil
+                    }
                     return
                 }
                 if Task.isCancelled { return }
+                dwell = retryDwell
             }
         }
+    }
+
+    private func cancelHibernationDwell(
+        _ slot: ReferenceWritableKeyPath<SceneWallpaperSession, Task<Void, Never>?>
+    ) {
+        self[keyPath: slot]?.cancel()
+        self[keyPath: slot] = nil
     }
 
     /// Returns false only on a transient blocker (an in-flight load/reload) so
@@ -485,9 +564,15 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
         scenePropertyMutationAuthority.advance()
         hasRenderer = false
         let hibernation = hibernationTask
+        let pauseHibernation = pauseHibernationTask
+        let pressureHibernation = pressureHibernationTask
         let wake = wakeTask
         hibernationTask?.cancel()
         hibernationTask = nil
+        pauseHibernationTask?.cancel()
+        pauseHibernationTask = nil
+        pressureHibernationTask?.cancel()
+        pressureHibernationTask = nil
         wakeTask?.cancel()
         wakeTask = nil
         scenePropertyPosterCommitGate.invalidate()
@@ -517,6 +602,8 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
             // A hibernate/wake may be mid-flight on the actor with no other
             // drainable handle; teardown must not overtake it.
             await hibernation?.value
+            await pauseHibernation?.value
+            await pressureHibernation?.value
             await wake?.value
             await actor.teardownRenderer()
             actor.shutdown()

--- a/LiveWallpaper/Runtime/Session/SceneWallpaperSession.swift
+++ b/LiveWallpaper/Runtime/Session/SceneWallpaperSession.swift
@@ -86,6 +86,21 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
 
     private var audioCaptureDemandRetained = false
     private let audioCaptureDemandController: any SystemAudioCaptureDemandControlling
+    /// Deep hibernate (P1.5): while suspended for an absence-like reason the
+    /// renderer's loaded resources are dropped after `hibernationDelay`; waking
+    /// runs a full `reload()`. Session-level flag — the renderer's own state is
+    /// simply "not loaded" while hibernated.
+    private(set) var isHibernated = false
+    private let hibernationDelay: Duration
+    private var hibernationTask: Task<Void, Never>?
+    /// Retains the wake reload spawned on the suspended→quality transition so
+    /// `cleanup()` can cancel it.
+    private var wakeTask: Task<Void, Never>?
+    /// Latest renderer activity mirror (frame/audio work under `.quality`).
+    /// Nil until the renderer's first publish; consumers treat nil as "may be
+    /// working" so the App Nap gate errs on holding.
+    private(set) var rendererRuntimeActivity: WPESceneRuntimeActivity?
+    var onRuntimeActivityChange: (@MainActor () -> Void)?
     /// Durable user play intent; effective = `userIntendsToPlay && profile == .quality`.
     private(set) var userIntendsToPlay = true
     private var isVisible = true
@@ -131,13 +146,15 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
         window: NSWindow,
         renderActor: WPEDisplayRenderActor,
         surface: WPERenderSurface,
-        audioCaptureDemandController: any SystemAudioCaptureDemandControlling = SystemAudioCaptureManager.shared
+        audioCaptureDemandController: any SystemAudioCaptureDemandControlling = SystemAudioCaptureManager.shared,
+        hibernationDelay: Duration = .seconds(20)
     ) {
         self.window = window
         self.renderActor = renderActor
         self.surface = surface
         self.rendererConfigAdapter = WPERendererConfigAdapter(renderActor: renderActor)
         self.audioCaptureDemandController = audioCaptureDemandController
+        self.hibernationDelay = hibernationDelay
     }
 
     private var effectivePerformanceProfile: WallpaperPerformanceProfile {
@@ -282,9 +299,12 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
 
     func commitScenePropertyPatch(
         _ prepared: PreparedScenePropertyPatch,
-        posterCommit: ScenePropertyPosterCommit
+        posterCommit: ScenePropertyPosterCommit,
+        updatedDescriptor: SceneDescriptor
     ) async -> Bool {
-        let didCommit = await renderActor.commitScenePropertyPatch(prepared)
+        let didCommit = await renderActor.commitScenePropertyPatch(
+            prepared, updatedDescriptor: updatedDescriptor
+        )
         scenePropertyPosterCommitGate.resolve(posterCommit, result: didCommit)
         return didCommit
     }
@@ -322,11 +342,97 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
 
     private func applyEffectivePerformanceProfile() {
         let effective = effectivePerformanceProfile
+        if effective == .quality {
+            // Any transition to playing cancels a pending hibernate countdown.
+            hibernationTask?.cancel()
+            hibernationTask = nil
+        }
         if lastAppliedPerformanceProfile != effective {
             lastAppliedPerformanceProfile = effective
             rendererConfigAdapter.applyPerformanceProfile(effective)
         }
+        if effective == .quality, isHibernated {
+            isHibernated = false
+            // Rebuild everything hibernate dropped; the profile command above
+            // (or the load tail's re-apply) restores pacing once loaded.
+            wakeTask = Task { [weak self] in
+                await self?.reload()
+            }
+        }
         reconcileSystemAudioCaptureDemand()
+    }
+
+    // MARK: - Deep hibernate (resource depth of the suspend path, not a profile)
+
+    /// `ScreenManager` marks the session eligible while it is suspended for an
+    /// absence-like reason (lock, display sleep, full-screen cover/occlusion).
+    /// After `hibernationDelay` of uninterrupted eligibility the renderer's
+    /// loaded resources are released; any flip back cancels the countdown.
+    func setHibernationEligible(_ eligible: Bool) {
+        guard eligible,
+              hasRenderer,
+              !isHibernated,
+              effectivePerformanceProfile == .suspended else {
+            hibernationTask?.cancel()
+            hibernationTask = nil
+            return
+        }
+        guard hibernationTask == nil else { return }
+        hibernationTask = Task { [weak self, hibernationDelay] in
+            // The handle stays set for the whole body — not just the countdown —
+            // so `cleanup()` can DRAIN an in-flight hibernate, and a transient
+            // blocker (an in-flight load) re-dwells instead of dropping the
+            // countdown (eligibility pushes are event-driven; a dropped
+            // countdown would skip the entire absence).
+            while true {
+                try? await Task.sleep(for: hibernationDelay)
+                guard !Task.isCancelled, let self else { return }
+                if await self.hibernateNow() {
+                    self.hibernationTask = nil
+                    return
+                }
+                if Task.isCancelled { return }
+            }
+        }
+    }
+
+    /// Returns false only on a transient blocker (an in-flight load/reload) so
+    /// the countdown re-arms; true when hibernated or no longer applicable.
+    private func hibernateNow() async -> Bool {
+        guard hasRenderer,
+              !isHibernated,
+              effectivePerformanceProfile == .suspended else { return true }
+        // Never tear down under an in-flight load/reload.
+        guard loadTask == nil else { return false }
+        let hibernated = await renderActor.hibernate()
+        guard hibernated, hasRenderer else { return true }
+        if effectivePerformanceProfile == .quality {
+            // Woken while the actor hop was in flight: rebuild immediately.
+            await reload()
+        } else {
+            isHibernated = true
+        }
+        return true
+    }
+
+    // MARK: - Runtime-activity mirror (App Nap gate)
+
+    /// Renderer push (dedup'd on its side); forwarded so `ScreenManager` can
+    /// re-evaluate the App Nap assertion on real transitions only.
+    func noteRendererRuntimeActivity(_ activity: WPESceneRuntimeActivity) {
+        guard activity != rendererRuntimeActivity else { return }
+        rendererRuntimeActivity = activity
+        onRuntimeActivityChange?()
+    }
+
+    /// Whether this session may be doing real work under `.quality` — the App
+    /// Nap assertion should stay held. Conservative: true until the renderer's
+    /// first activity push, and while a load/reload is in flight (preparing).
+    var mayPerformRuntimeWork: Bool {
+        guard let rendererRuntimeActivity else { return true }
+        return rendererRuntimeActivity.producesFrames
+            || rendererRuntimeActivity.audible
+            || loadTask != nil
     }
 
     /// Per-screen cursor-reactivity toggle (camera parallax + pointer shaders).
@@ -378,6 +484,12 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
         lifecycleGeneration += 1
         scenePropertyMutationAuthority.advance()
         hasRenderer = false
+        let hibernation = hibernationTask
+        let wake = wakeTask
+        hibernationTask?.cancel()
+        hibernationTask = nil
+        wakeTask?.cancel()
+        wakeTask = nil
         scenePropertyPosterCommitGate.invalidate()
         requiresSystemAudioCapture = false
         reconcileSystemAudioCaptureDemand()
@@ -402,6 +514,10 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
             await displayLinkStopTask?.value
             await startup?.value
             await load?.value
+            // A hibernate/wake may be mid-flight on the actor with no other
+            // drainable handle; teardown must not overtake it.
+            await hibernation?.value
+            await wake?.value
             await actor.teardownRenderer()
             actor.shutdown()
         }
@@ -462,6 +578,8 @@ final class SceneWallpaperSession: WallpaperRuntimeSession, WallpaperPlaybackCon
             loadError = .cacheRootMissing
             return
         }
+        // A reload rebuilds everything hibernate dropped, whatever triggered it.
+        isHibernated = false
         // Cancel+drain in-flight load before reload — cooperative cancel can append half-loaded state.
         loadTask?.cancel()
         if let previous = loadTask {

--- a/LiveWallpaper/Runtime/WPEMemoryTier.swift
+++ b/LiveWallpaper/Runtime/WPEMemoryTier.swift
@@ -54,5 +54,26 @@ enum WPEMemoryTier: CaseIterable, Equatable, Sendable {
         case .standard, .expansive: return 200_000_000
         }
     }
+
+    /// Process-wide budget for decoded animation frame bytes shared by every
+    /// lazy `.tex` source across all scenes/displays (replaces the former
+    /// per-source 4-frame cap, whose worst case scaled with animation count).
+    var animatedFrameCacheBudgetBytes: Int {
+        switch self {
+        case .constrained: return 96 * 1_048_576
+        case .standard: return 128 * 1_048_576
+        case .expansive: return 192 * 1_048_576
+        }
+    }
+
+    /// Single decoded frame admission cap: frames above this decode, upload,
+    /// and release without entering the process cache (and never prefetch).
+    var animatedFrameAdmissionByteCap: Int {
+        switch self {
+        case .constrained: return 32 * 1_048_576
+        case .standard: return 48 * 1_048_576
+        case .expansive: return 64 * 1_048_576
+        }
+    }
 }
 #endif

--- a/LiveWallpaper/Runtime/WPEMemoryTier.swift
+++ b/LiveWallpaper/Runtime/WPEMemoryTier.swift
@@ -2,10 +2,10 @@
 import Foundation
 
 /// Physical-memory tiers driving renderer resource defaults, so base-RAM Macs
-/// (8 GB M1/M2) get bounded texture residency out of the box while high-RAM
-/// machines keep the everything-resident behavior. Manual defaults always win
-/// (`WPEMetalTextureCacheBudgetMiB`; explicit 0 ⇒ unbounded).
-enum WPEMemoryTier: Equatable, Sendable {
+/// (8 GB M1/M2) get tight texture residency out of the box while high-RAM
+/// machines get a roomier — but still bounded — budget. Manual defaults always
+/// win (`WPEMetalTextureCacheBudgetMiB`; explicit 0 ⇒ unbounded).
+enum WPEMemoryTier: CaseIterable, Equatable, Sendable {
     case constrained
     case standard
     case expansive
@@ -21,11 +21,15 @@ enum WPEMemoryTier: Equatable, Sendable {
         return .expansive
     }
 
+    /// Every tier is bounded: nil here would skip LRU eviction entirely, so
+    /// hidden-layer / time-of-day texture variants stayed resident forever on
+    /// ≥24 GB machines. Unbounded remains available only via the manual
+    /// defaults override (explicit ≤0).
     var defaultTextureCacheBudgetBytes: Int? {
         switch self {
         case .constrained: return 256 * 1_048_576
         case .standard: return 512 * 1_048_576
-        case .expansive: return nil
+        case .expansive: return 768 * 1_048_576
         }
     }
 

--- a/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
+++ b/LiveWallpaper/VideoPlayback/WPEMetalBuiltins.metal
@@ -619,6 +619,32 @@ fragment half4 wpe_copy_fragment(
     return texture0.sample(linearSampler, in.uv);
 }
 
+struct WPEVideoYCbCrUniforms {
+    float3x3 colorMatrix;
+    float3 offset;
+};
+
+// Decoder NV12 plane pair (r8 luma + rg8 chroma) → the video source's reused
+// BGRA working texture. Matrix/offset come from the pixel buffer's colorimetry
+// attachments (BT.601/709/2020, video/full range), computed CPU-side in
+// `WPEVideoYCbCrConversion` so tests can pin the coefficients. Output is
+// gamma-encoded R'G'B' into a non-sRGB target; the renderer samples it through
+// an sRGB view — byte-identical to the old direct `.bgra8Unorm_srgb` CV wrap.
+fragment half4 wpe_video_nv12_convert_fragment(
+    WPEVertexOut in [[stage_in]],
+    texture2d<float, access::sample> luma [[texture(0)]],
+    texture2d<float, access::sample> chroma [[texture(1)]],
+    constant WPEVideoYCbCrUniforms& conversion [[buffer(0)]]
+) {
+    constexpr sampler linearSampler(address::clamp_to_edge, filter::linear);
+    float3 ycbcr = float3(
+        luma.sample(linearSampler, in.uv).r,
+        chroma.sample(linearSampler, in.uv).rg
+    );
+    float3 rgb = clamp(conversion.colorMatrix * (ycbcr - conversion.offset), 0.0, 1.0);
+    return half4(half3(rgb), 1.0h);
+}
+
 // Utility built-ins. `solidlayer` writes color * alpha into the
 // per-layer FBO. `util_copy` is the parallax-free copy used when chaining
 // `materials/util/copy.json` between FBOs. `compose` blends two layer

--- a/LiveWallpaperInfo.plist
+++ b/LiveWallpaperInfo.plist
@@ -43,8 +43,6 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
 	<true/>
-	<key>MetalCaptureEnabled</key>
-	<true/>
 	<key>NSAccentColorName</key>
 	<string>AccentColor</string>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/LiveWallpaperTests/AudioSpectrumBrokerTests.swift
+++ b/LiveWallpaperTests/AudioSpectrumBrokerTests.swift
@@ -1,5 +1,24 @@
+import os
 import Testing
 @testable import LiveWallpaper
+
+/// One-shot injection seam standing in for the capture-attached processor:
+/// hands out its frame on the first pull, nil afterwards, so later snapshots
+/// exercise the broker's cached copy. Shared by the script-runtime tests.
+final class SpectrumAnalyzerStub: AudioSpectrumAnalyzing, @unchecked Sendable {
+    private let pending: OSAllocatedUnfairLock<AudioSpectrumFrame?>
+
+    init(_ frame: AudioSpectrumFrame) {
+        pending = OSAllocatedUnfairLock(initialState: frame)
+    }
+
+    func analyzeIfDue(nowNanos: UInt64) -> AudioSpectrumFrame? {
+        pending.withLock { state in
+            defer { state = nil }
+            return state
+        }
+    }
+}
 
 @Suite("Audio spectrum broker")
 struct AudioSpectrumBrokerTests {
@@ -12,8 +31,8 @@ struct AudioSpectrumBrokerTests {
         #expect(snapshot == .silence)
     }
 
-    @Test("Publish then snapshot returns published normalized frame")
-    func publishThenSnapshotReturnsPublishedFrame() {
+    @Test("Analyzer frame is cached and returned normalized")
+    func analyzerFrameIsCachedNormalized() {
         let broker = AudioSpectrumBroker()
         let frame = AudioSpectrumFrame(
             left: [0.25, 0.5],
@@ -21,10 +40,13 @@ struct AudioSpectrumBrokerTests {
             timestampNanos: 42
         )
 
-        broker.publish(frame)
+        broker.attachAnalyzer(SpectrumAnalyzerStub(frame))
         let snapshot = broker.snapshot()
+        // Second pull hits the stub's nil — this is the cached copy.
+        let cached = broker.snapshot()
 
         #expect(snapshot == frame)
+        #expect(cached == frame)
         #expect(snapshot.left.count == AudioSpectrumFrame.binCount)
         #expect(snapshot.right.count == AudioSpectrumFrame.binCount)
         #expect(snapshot.left[0] == 0.25)
@@ -37,26 +59,32 @@ struct AudioSpectrumBrokerTests {
     @Test("Reset to silence clears latest frame")
     func resetToSilenceClearsLatestFrame() {
         let broker = AudioSpectrumBroker()
-        broker.publish(AudioSpectrumFrame(left: [0.4], right: [0.6], timestampNanos: 99))
+        broker.attachAnalyzer(
+            SpectrumAnalyzerStub(AudioSpectrumFrame(left: [0.4], right: [0.6], timestampNanos: 99))
+        )
+        #expect(broker.snapshot() != .silence)
 
+        broker.attachAnalyzer(nil)
         broker.resetToSilence()
 
         #expect(broker.snapshot() == .silence)
     }
 
-    @Test("Concurrent publish and snapshot stay memory-safe")
-    func concurrentPublishAndSnapshot() async {
+    @Test("Concurrent attach and snapshot stay memory-safe")
+    func concurrentAttachAndSnapshot() async {
         let broker = AudioSpectrumBroker()
 
         await withTaskGroup(of: Void.self) { group in
             group.addTask {
                 for index in 0..<1000 {
                     let value = Float(index % 2)
-                    broker.publish(
-                        AudioSpectrumFrame(
-                            left: [value],
-                            right: [value],
-                            timestampNanos: UInt64(index)
+                    broker.attachAnalyzer(
+                        SpectrumAnalyzerStub(
+                            AudioSpectrumFrame(
+                                left: [value],
+                                right: [value],
+                                timestampNanos: UInt64(index)
+                            )
                         )
                     )
                 }

--- a/LiveWallpaperTests/AudioSpectrumCadenceTests.swift
+++ b/LiveWallpaperTests/AudioSpectrumCadenceTests.swift
@@ -106,6 +106,41 @@ struct AudioSpectrumCadenceTests {
         #expect(control.left.contains { $0 > 0 })
     }
 
+    @Test("A producer lap during the window copy discards the analysis")
+    func lapDuringCopyDiscardsAnalysis() {
+        let processor = AudioSpectrumProcessor()
+        let tone = Self.orderSensitiveSignal(count: 2048)
+        processor.ingest(left: tone, right: tone, timestampNanos: 1)
+
+        // Ring capacity is 4x2048 = 8192; writing 8192 samples on top of the
+        // 2048-sample window laps its oldest sample mid-copy.
+        let flood = [Float](repeating: 0.25, count: 8192)
+        processor.afterWindowCopyForTesting = {
+            processor.ingest(left: flood, right: flood, timestampNanos: 2)
+        }
+        #expect(processor.analyzeIfDue(nowNanos: Self.interval) == nil)
+        processor.afterWindowCopyForTesting = nil
+
+        // The next pull analyzes the fresh (post-flood) data instead.
+        #expect(processor.analyzeIfDue(nowNanos: Self.interval * 2) != nil)
+    }
+
+    @Test("A concurrent write that stops short of a lap keeps the analysis")
+    func nearLapDuringCopyKeepsAnalysis() {
+        let processor = AudioSpectrumProcessor()
+        let tone = Self.orderSensitiveSignal(count: 2048)
+        processor.ingest(left: tone, right: tone, timestampNanos: 1)
+
+        // 6144 more samples put the write cursor exactly at windowStart +
+        // capacity — the window's oldest sample is still intact.
+        let nearFlood = [Float](repeating: 0.25, count: 6144)
+        processor.afterWindowCopyForTesting = {
+            processor.ingest(left: nearFlood, right: nearFlood, timestampNanos: 2)
+        }
+        defer { processor.afterWindowCopyForTesting = nil }
+        #expect(processor.analyzeIfDue(nowNanos: Self.interval) != nil)
+    }
+
     /// Ramp-enveloped two-tone signal: any cyclic shift of the window changes the
     /// windowed FFT, so spectrum equality implies sample order was preserved.
     private static func orderSensitiveSignal(count: Int) -> [Float] {

--- a/LiveWallpaperTests/AudioSpectrumCadenceTests.swift
+++ b/LiveWallpaperTests/AudioSpectrumCadenceTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+@Suite("Audio spectrum pull cadence")
+struct AudioSpectrumCadenceTests {
+    private static let interval = AudioSpectrumProcessor.minAnalysisIntervalNanos
+
+    @Test("Ring wrap-around: analysis sees the last window, in order")
+    func ringWrapAroundPreservesWindow() {
+        let processor = AudioSpectrumProcessor()
+        // Push the write cursor to 7000 so the final 2048-sample window
+        // (7000..<9048) crosses the 8192 ring boundary.
+        let silence = [Float](repeating: 0, count: 500)
+        for _ in 0..<14 {
+            processor.ingest(left: silence, right: silence, timestampNanos: 1)
+        }
+        // Silence analysis: smoothing state stays zero, hop resets to 2048 below.
+        #expect(processor.analyzeIfDue(nowNanos: Self.interval) != nil)
+
+        let window = Self.orderSensitiveSignal(count: 2048)
+        var offset = 0
+        while offset < window.count {
+            let chunk = Array(window[offset..<min(offset + 256, window.count)])
+            processor.ingest(left: chunk, right: chunk, timestampNanos: 2)
+            offset += 256
+        }
+        let wrapped = processor.analyzeIfDue(nowNanos: Self.interval * 3)
+
+        // Oracle: fresh processor fed the same window contiguously (no wrap),
+        // with the same hop (2048) and the same all-zero smoothing history.
+        let oracle = AudioSpectrumProcessor()
+        let expected = oracle.process(left: window, right: window, timestampNanos: 2)
+
+        #expect(expected.left.contains { $0 > 0 })
+        #expect(wrapped?.left == expected.left)
+        #expect(wrapped?.right == expected.right)
+    }
+
+    @Test("Two pulls inside the cadence cap run one analysis")
+    func cadenceGateDedupsPulls() {
+        let processor = AudioSpectrumProcessor()
+        let tone = Self.orderSensitiveSignal(count: 2048)
+        processor.ingest(left: tone, right: tone, timestampNanos: 1)
+
+        #expect(processor.analyzeIfDue(nowNanos: 1_000_000_000) != nil)
+
+        // New samples arrived, but the second pull lands inside the cap.
+        processor.ingest(left: tone, right: tone, timestampNanos: 2)
+        #expect(processor.analyzeIfDue(nowNanos: 1_000_000_000 + Self.interval - 1) == nil)
+
+        // Once the interval elapses, the pending samples are analyzed.
+        #expect(processor.analyzeIfDue(nowNanos: 1_000_000_000 + Self.interval) != nil)
+    }
+
+    @Test("No new samples means no new analysis, at any interval")
+    func noNewSamplesReturnsNil() {
+        let processor = AudioSpectrumProcessor()
+        #expect(processor.analyzeIfDue(nowNanos: 1) == nil)
+
+        let tone = Self.orderSensitiveSignal(count: 2048)
+        processor.ingest(left: tone, right: tone, timestampNanos: 1)
+        #expect(processor.analyzeIfDue(nowNanos: 1_000_000_000) != nil)
+        #expect(processor.analyzeIfDue(nowNanos: 60_000_000_000) == nil)
+    }
+
+    @Test("Broker generation advances only when a new spectrum is produced")
+    func brokerTimestampTracksAnalyses() {
+        let broker = AudioSpectrumBroker()
+        let processor = AudioSpectrumProcessor()
+        broker.attachAnalyzer(processor)
+
+        let tone = Self.orderSensitiveSignal(count: 2048)
+        processor.ingest(left: tone, right: tone, timestampNanos: 7)
+
+        let first = broker.snapshot()
+        #expect(first.timestampNanos == 7)
+        #expect(first.left.contains { $0 > 0 })
+        // No new samples: repeated snapshots return the cached frame unchanged.
+        #expect(broker.snapshot() == first)
+
+        // Detached: new samples no longer reach the cache.
+        broker.attachAnalyzer(nil)
+        processor.ingest(left: tone, right: tone, timestampNanos: 9)
+        #expect(broker.snapshot().timestampNanos == 7)
+    }
+
+    @Test("Oversized ingest keeps only the freshest samples")
+    func oversizedIngestKeepsTail() {
+        let processor = AudioSpectrumProcessor()
+        // 20k samples: loud noise everywhere except a silent 2048-sample tail.
+        var oversized = Self.orderSensitiveSignal(count: 20_000)
+        for index in (20_000 - 2048)..<20_000 {
+            oversized[index] = 0
+        }
+        let frame = processor.process(left: oversized, right: oversized, timestampNanos: 1)
+        #expect(frame.left.allSatisfy { $0 == 0 })
+
+        // Control: the loud head alone is not silent, so the zeros above prove
+        // the analysis window really is the tail.
+        let control = AudioSpectrumProcessor().process(
+            left: Array(oversized[0..<2048]),
+            right: Array(oversized[0..<2048]),
+            timestampNanos: 1
+        )
+        #expect(control.left.contains { $0 > 0 })
+    }
+
+    /// Ramp-enveloped two-tone signal: any cyclic shift of the window changes the
+    /// windowed FFT, so spectrum equality implies sample order was preserved.
+    private static func orderSensitiveSignal(count: Int) -> [Float] {
+        (0..<count).map { index in
+            let t = Float(index) / Float(count)
+            let ramp = 0.2 + 0.8 * t
+            return ramp * (0.5 * sinf(2 * .pi * 12 * t) + 0.3 * sinf(2 * .pi * 97 * t))
+        }
+    }
+}

--- a/LiveWallpaperTests/AudioSpectrumProcessorTests.swift
+++ b/LiveWallpaperTests/AudioSpectrumProcessorTests.swift
@@ -90,18 +90,21 @@ struct AudioSpectrumProcessorTests {
         #expect(Self.isNormalized(frame.left))
     }
 
-    @Test("Published fast-path frame survives the processor reusing its output buffers")
-    func publishedFrameSurvivesProcessorBufferReuse() {
+    @Test("Cached broker frame survives the processor reusing its output buffers")
+    func cachedFrameSurvivesProcessorBufferReuse() {
         let processor = AudioSpectrumProcessor()
         let broker = AudioSpectrumBroker()
 
         let loud = Self.sineWave(cycles: 12, amplitude: 1.0)
-        let published = processor.process(left: loud, right: loud, timestampNanos: 1)
-        let expectedLeft = published.left.map { $0 }
-        let expectedRight = published.right.map { $0 }
+        let analyzed = processor.process(left: loud, right: loud, timestampNanos: 1)
+        let expectedLeft = analyzed.left.map { $0 }
+        let expectedRight = analyzed.right.map { $0 }
         #expect(expectedLeft.contains { $0 > 0 })
 
-        broker.publish(published)
+        // Cache the frame (whose arrays share storage with the processor's
+        // output buffers), then make the processor reuse those buffers.
+        broker.attachAnalyzer(SpectrumAnalyzerStub(analyzed))
+        _ = broker.snapshot()
 
         let silence = [Float](repeating: 0, count: 2048)
         _ = processor.process(left: silence, right: silence, timestampNanos: 2)

--- a/LiveWallpaperTests/Doubles/FakeFullScreenDetector.swift
+++ b/LiveWallpaperTests/Doubles/FakeFullScreenDetector.swift
@@ -52,8 +52,13 @@ final class FakeFullScreenDetector: FullScreenDetecting {
         checkNowCallCount += 1
     }
 
+    /// Mirrors the real detector: the last value pushed, defaulting to live so
+    /// existing tests keep exercising the coverage-driven paths.
+    private(set) var isFallbackPollingEnabled = true
+
     func setFallbackPollingEnabled(_ enabled: Bool) {
         setFallbackPollingEnabledValues.append(enabled)
+        isFallbackPollingEnabled = enabled
     }
 
     func stop() {

--- a/LiveWallpaperTests/MetalCaptureLayerGuardTests.swift
+++ b/LiveWallpaperTests/MetalCaptureLayerGuardTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+
+/// `MetalCaptureEnabled` in an Info.plist makes Metal load GPUToolsCapture
+/// into every launch of the shipped app — no Xcode attachment required. Its
+/// per-draw encoder interposition grew the AGX `DataBufferAllocator` arena
+/// without bound (~40-60MB/min resident on a scene wallpaper; caught by
+/// breakpointing `AGX::DataBufferAllocator<45ul>::grow`, ledger §14). Debug
+/// captures use Xcode attach or an `MTL_CAPTURE_ENABLED=1` launch instead.
+@Suite("Metal capture layer stays out of shipped Info.plists")
+struct MetalCaptureLayerGuardTests {
+    @Test("No SKU Info.plist re-enables MetalCaptureEnabled",
+          arguments: ["LiveWallpaperInfo.plist", "LoomscreenInfo.plist"])
+    func plistDoesNotEnableMetalCapture(plist: String) throws {
+        let contents = try RepositoryRoot.source(plist)
+        #expect(
+            !contents.contains("MetalCaptureEnabled"),
+            Comment(rawValue: "\(plist) re-adds MetalCaptureEnabled; it ships GPUToolsCapture into release builds and leaks the AGX arena")
+        )
+    }
+}

--- a/LiveWallpaperTests/Monitor/OverlayVisibilityTests.swift
+++ b/LiveWallpaperTests/Monitor/OverlayVisibilityTests.swift
@@ -335,8 +335,8 @@ struct OverlayVisibilityLifecycleCharacterizationTests {
         )
         let detectorOcclusion = try sourceSlice(
             detector,
-            from: "for (screenID, cgScreenFrame) in screenFrames",
-            to: "updateIfChanged(result, occlusion, fractions)"
+            from: "for (screenID, fraction) in coverage",
+            to: "updateIfChanged(fullScreen, occlusion, fractions)"
         )
         let detectorNotifications = try sourceSlice(
             detector,

--- a/LiveWallpaperTests/Monitor/RuntimeV2PlumbingTests.swift
+++ b/LiveWallpaperTests/Monitor/RuntimeV2PlumbingTests.swift
@@ -29,12 +29,12 @@ struct RuntimeV2PlumbingTests {
     @Test("Each widget kind flips exactly its sampler gate")
     func kindMapsToItsGate() {
         #expect(Runtime.systemOptions(for: [.gpu]) == options(gpu: true, sensors: true))
-        #expect(Runtime.systemOptions(for: [.cpu]) == options(topProcesses: true, sensors: true))
+        #expect(Runtime.systemOptions(for: [.cpu]) == options(topProcesses: true, sensors: true, cpu: true))
         #expect(Runtime.systemOptions(for: [.processes]) == options(topProcesses: true))
-        #expect(Runtime.systemOptions(for: [.memory]) == options(topProcesses: true))
-        #expect(Runtime.systemOptions(for: [.disk]) == options(processIO: true))
+        #expect(Runtime.systemOptions(for: [.memory]) == options(topProcesses: true, memory: true))
+        #expect(Runtime.systemOptions(for: [.disk]) == options(processIO: true, disk: true))
         #expect(Runtime.systemOptions(for: [.aiEngine]) == options(ane: true))
-        #expect(Runtime.systemOptions(for: [.power]) == options(accessories: true, sensors: true))
+        #expect(Runtime.systemOptions(for: [.power]) == options(accessories: true, sensors: true, power: true))
     }
 
     // MARK: - Per-widget demand narrowing
@@ -98,11 +98,9 @@ struct RuntimeV2PlumbingTests {
                 == Runtime.systemOptions(for: kinds))
     }
 
-    @Test("A kind with no expensive sampler leaves every gate off")
+    @Test("A kind with no expensive sampler flips only its own base group")
     func inertKindKeepsAllGatesOff() {
-        #expect(Runtime.systemOptions(for: [.network]) == SystemMetricsSource.Options(
-            gpu: false, topProcesses: false, ane: false, accessories: false
-        ))
+        #expect(Runtime.systemOptions(for: [.network]) == options(network: true))
     }
 
     @Test("Empty kind set gates every expensive sampler off")
@@ -130,7 +128,7 @@ struct RuntimeV2PlumbingTests {
         let opts = Runtime.systemOptions(for: Set(MonitorWidgetKind.allCases))
         #expect(opts == SystemMetricsSource.Options(
             gpu: true, topProcesses: true, ane: true, accessories: true, sensors: true,
-            processIO: true
+            processIO: true, cpu: true, memory: true, network: true, disk: true, power: true
         ))
     }
 
@@ -149,8 +147,9 @@ struct RuntimeV2PlumbingTests {
 
         let merged = Runtime.merged([a, b])
         #expect(merged?.activeWidgetKinds == [.gpu, .cpu, .power])
-        #expect(Runtime.systemOptions(for: merged?.activeWidgetKinds ?? []) == SystemMetricsSource.Options(
-            gpu: true, topProcesses: true, ane: false, accessories: true, sensors: true
+        #expect(Runtime.systemOptions(for: merged?.activeWidgetKinds ?? []) == options(
+            gpu: true, topProcesses: true, accessories: true, sensors: true,
+            cpu: true, power: true
         ))
     }
 
@@ -180,11 +179,14 @@ struct RuntimeV2PlumbingTests {
 
     private func options(
         gpu: Bool = false, topProcesses: Bool = false, ane: Bool = false,
-        accessories: Bool = false, sensors: Bool = false, processIO: Bool = false
+        accessories: Bool = false, sensors: Bool = false, processIO: Bool = false,
+        cpu: Bool = false, memory: Bool = false, network: Bool = false,
+        disk: Bool = false, power: Bool = false
     ) -> SystemMetricsSource.Options {
         SystemMetricsSource.Options(
             gpu: gpu, topProcesses: topProcesses, ane: ane, accessories: accessories,
-            sensors: sensors, processIO: processIO
+            sensors: sensors, processIO: processIO,
+            cpu: cpu, memory: memory, network: network, disk: disk, power: power
         )
     }
 }

--- a/LiveWallpaperTests/Monitor/SampleDemandTests.swift
+++ b/LiveWallpaperTests/Monitor/SampleDemandTests.swift
@@ -1,0 +1,191 @@
+import Testing
+import Foundation
+import LiveWallpaperCore
+import os
+@testable import LiveWallpaper
+
+/// A board's widgets are the only subscribers of the system source. These prove
+/// that a metric group with no subscribed widget is not sampled at all — the
+/// probe is skipped, not just its result hidden.
+@Suite("Monitor sample demand")
+struct SampleDemandTests {
+    private actor MockSink: MonitorSnapshotSink {
+        private(set) var lastSystem: MonitorSystemSnapshot?
+        private(set) var systemUpdateCount = 0
+
+        func updateSystem(_ snapshot: MonitorSystemSnapshot) async {
+            lastSystem = snapshot
+            systemUpdateCount += 1
+        }
+        func updateAgents(sourceID: String, sessions: [MonitorAgentSessionState]) async {}
+        func updateHealth(_ health: MonitorSourceHealth) async {}
+
+        func system() -> MonitorSystemSnapshot? { lastSystem }
+        func count() -> Int { systemUpdateCount }
+    }
+
+    /// Runs the source until at least one snapshot lands, then stops it.
+    private func firstSnapshot(
+        options: SystemMetricsSource.Options,
+        loadAverageSampler: @escaping @Sendable () -> [Double]? = { [1.0, 1.0, 1.0] }
+    ) async -> MonitorSystemSnapshot? {
+        let sink = MockSink()
+        let source = SystemMetricsSource(
+            options: options,
+            interval: 60,
+            loadAverageSampler: loadAverageSampler
+        )
+        await source.start(sink: sink)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if await sink.count() >= 1 { break }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        await source.stop()
+        return await sink.system()
+    }
+
+    // MARK: - The probe itself must not run (injectable-seam proof)
+
+    @Test("No CPU widget on the board: the load-average sampler is never invoked", .timeLimit(.minutes(1)))
+    func noCPUWidgetSkipsLoadSampler() async {
+        let calls = OSAllocatedUnfairLock(initialState: 0)
+        let snapshot = await firstSnapshot(
+            options: Runtime.systemOptions(for: [.network]),
+            loadAverageSampler: {
+                calls.withLock { $0 += 1 }
+                return [9.0, 9.0, 9.0]
+            }
+        )
+        #expect(snapshot != nil)
+        #expect(calls.withLock { $0 } == 0)
+        #expect(snapshot?.loadAverage1 == nil)
+        #expect(snapshot?.cpuLoadAvg == nil)
+    }
+
+    @Test("A CPU widget keeps the load-average sampler running (control)", .timeLimit(.minutes(1)))
+    func cpuWidgetKeepsLoadSampler() async {
+        let calls = OSAllocatedUnfairLock(initialState: 0)
+        let snapshot = await firstSnapshot(
+            options: Runtime.systemOptions(for: [.cpu]),
+            loadAverageSampler: {
+                calls.withLock { $0 += 1 }
+                return [1.25, 0.75, 0.5]
+            }
+        )
+        #expect(calls.withLock { $0 } == 1)
+        #expect(snapshot?.loadAverage1 == 1.25)
+    }
+
+    // MARK: - Undemanded groups leave no trace in the snapshot
+
+    @Test("No CPU widget: host CPU, per-core, and CPU identity are unsampled", .timeLimit(.minutes(1)))
+    func noCPUWidgetSkipsCPUSampling() async {
+        let snapshot = await firstSnapshot(options: Runtime.systemOptions(for: [.network]))
+        #expect(snapshot?.cpuTotal == 0)
+        #expect(snapshot?.perCore == nil)
+        #expect(snapshot?.cpuInfo == nil)
+    }
+
+    @Test("No memory widget: memory, swap, and pressure are unsampled", .timeLimit(.minutes(1)))
+    func noMemoryWidgetSkipsMemorySampling() async {
+        let snapshot = await firstSnapshot(options: Runtime.systemOptions(for: [.cpu]))
+        #expect(snapshot?.memTotalBytes == 0)
+        #expect(snapshot?.memUsedBytes == 0)
+        #expect(snapshot?.memBreakdown == nil)
+        #expect(snapshot?.swapUsedBytes == nil)
+        // A demanded group still samples on the same tick (control group).
+        #expect(snapshot?.cpuInfo != nil)
+    }
+
+    @Test("No network widget: interfaces stay empty and the path monitor never starts", .timeLimit(.minutes(1)))
+    func noNetworkWidgetSkipsNetworkProbes() async {
+        let sink = MockSink()
+        let source = SystemMetricsSource(
+            options: Runtime.systemOptions(for: [.memory]),
+            interval: 60,
+            loadAverageSampler: { nil }
+        )
+        await source.start(sink: sink)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            if await sink.count() >= 1 { break }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #if DEBUG
+        #expect(source.debugNetPathStarted == false)
+        #endif
+        await source.stop()
+        let snapshot = await sink.system()
+        #expect(snapshot?.netInterfaces == nil)
+        #expect(snapshot?.netPath == nil)
+        // Control: the demanded memory group did sample.
+        #expect((snapshot?.memTotalBytes ?? 0) > 0)
+    }
+
+    @Test("A network widget starts the path monitor (control)", .timeLimit(.minutes(1)))
+    func networkWidgetStartsPathMonitor() async {
+        let sink = MockSink()
+        let source = SystemMetricsSource(
+            options: Runtime.systemOptions(for: [.network]),
+            interval: 60,
+            loadAverageSampler: { nil }
+        )
+        await source.start(sink: sink)
+        #if DEBUG
+        #expect(source.debugNetPathStarted == true)
+        #endif
+        await source.stop()
+    }
+
+    @Test("No power widget: battery and power-source probes are unsampled", .timeLimit(.minutes(1)))
+    func noPowerWidgetSkipsPowerSampling() async {
+        let snapshot = await firstSnapshot(options: Runtime.systemOptions(for: [.cpu]))
+        #expect(snapshot?.powerSource == nil)
+        #expect(snapshot?.batteryLevel == nil)
+        #expect(snapshot?.batteryCharging == nil)
+        #expect(snapshot?.lowPowerMode == nil)
+    }
+
+    // MARK: - Kind → base-group mapping
+
+    @Test("Each widget kind demands exactly its base metric group")
+    func kindDemandsItsBaseGroup() {
+        let cpuOnly = Runtime.systemOptions(for: [.cpu])
+        #expect(cpuOnly.cpu && !cpuOnly.memory && !cpuOnly.network && !cpuOnly.disk && !cpuOnly.power)
+
+        let memOnly = Runtime.systemOptions(for: [.memory])
+        #expect(!memOnly.cpu && memOnly.memory && !memOnly.network && !memOnly.disk && !memOnly.power)
+
+        let netOnly = Runtime.systemOptions(for: [.network])
+        #expect(!netOnly.cpu && !netOnly.memory && netOnly.network && !netOnly.disk && !netOnly.power)
+
+        let diskOnly = Runtime.systemOptions(for: [.disk])
+        #expect(!diskOnly.cpu && !diskOnly.memory && !diskOnly.network && diskOnly.disk && !diskOnly.power)
+
+        let powerOnly = Runtime.systemOptions(for: [.power])
+        #expect(!powerOnly.cpu && !powerOnly.memory && !powerOnly.network && !powerOnly.disk && powerOnly.power)
+    }
+
+    @Test("Kinds with no base-group needs leave every base gate off")
+    func inertKindsLeaveBaseGatesOff() {
+        let kindSets: [Set<MonitorWidgetKind>] = [[.processes], [.aiEngine], [.gpu], []]
+        for kinds in kindSets {
+            let opts = Runtime.systemOptions(for: kinds)
+            #expect(!opts.cpu && !opts.memory && !opts.network && !opts.disk && !opts.power)
+        }
+    }
+
+    @Test("Base groups union across kinds")
+    func baseGroupsUnionAcrossKinds() {
+        let opts = Runtime.systemOptions(for: [.cpu, .network, .power])
+        #expect(opts.cpu && opts.network && opts.power)
+        #expect(!opts.memory && !opts.disk)
+    }
+
+    @Test("The legacy no-widget-info path fails open: every base group stays on")
+    func legacyPathFailsOpen() {
+        let defaults = SystemMetricsSource.Options.default
+        #expect(defaults.cpu && defaults.memory && defaults.network && defaults.disk && defaults.power)
+    }
+}

--- a/LiveWallpaperTests/Monitor/SamplerOwnershipTests.swift
+++ b/LiveWallpaperTests/Monitor/SamplerOwnershipTests.swift
@@ -169,12 +169,10 @@
             #expect(menu.contains(".onDisappear(perform: releaseSystemMonitorLeaseIfNeeded)"))
 
             let app = try productionSource("LiveWallpaper/App/LiveWallpaperApp.swift")
-            let prewarm = try slice(
-                app,
-                from: "func prewarmSettingsWindow() {",
-                until: "func showSettings("
-            )
-            #expect(!prewarm.contains("startMonitoring()"))
+            // B4 removed the settings-window prewarm entirely (the window is
+            // destroyed on close and cold-built on demand), so no hidden-window
+            // code path exists that could acquire a monitor lease pre-visibility.
+            #expect(!app.contains("prewarmSettingsWindow"))
             let present = try slice(
                 app,
                 from: "private func presentSettingsWindow(",
@@ -184,13 +182,23 @@
             #expect(present.contains("acquireSettingsSystemMonitorLeaseIfNeeded()"))
             #expect(present.contains("featureCatalog.isEnabled(.systemMonitor) == true"))
             #expect(present.contains("SystemMonitor.shared.startMonitoring()"))
+            // B4: close destroys the settings window, so the lease release and
+            // the controller drop both live in `windowWillClose`.
             let close = try slice(
+                app,
+                from: "func windowWillClose(",
+                until: "func windowDidMiniaturize("
+            )
+            #expect(close.contains("releaseSettingsSystemMonitorLeaseIfNeeded()"))
+            #expect(close.contains("settingsWindowController = nil"))
+            // Destroy-on-close means `windowShouldClose` must not re-grow a
+            // keep-alive branch for the settings window.
+            let shouldClose = try slice(
                 app,
                 from: "func windowShouldClose(",
                 until: "func windowWillClose("
             )
-            #expect(close.contains("releaseSettingsSystemMonitorLeaseIfNeeded()"))
-            #expect(close.contains("sender.orderOut(nil)"))
+            #expect(!shouldClose.contains("settingsWindowController"))
             #expect(app.contains("func windowDidMiniaturize("))
             #expect(app.contains("func windowDidDeminiaturize("))
             #expect(app.contains("SystemMonitor.shared.shutdown()"))

--- a/LiveWallpaperTests/Monitor/SystemMetricsSourceTests.swift
+++ b/LiveWallpaperTests/Monitor/SystemMetricsSourceTests.swift
@@ -82,6 +82,100 @@ struct SystemMetricsSourceTests {
         #expect(snapshot?.cpuLoadAvg == [1.25, 0.75, 0.5])
     }
 
+    private struct WalkRecord: Sendable {
+        var calls = 0
+        var intervals: [TimeInterval] = []
+        var previousCounters: [[Int32: SystemMetricsSamplers.ProcessCPUCounters]] = []
+    }
+
+    private static let walkSamples = [
+        MonitorProcessSample(name: "WalkFixture", cpuPercent: 42, memBytes: 1_024, pid: 7)
+    ]
+
+    private static func recordingWalkSampler(
+        into record: OSAllocatedUnfairLock<WalkRecord>
+    ) -> SystemMetricsSource.TopProcessesSampler {
+        { previous, interval, _ in
+            record.withLock {
+                $0.calls += 1
+                $0.intervals.append(interval)
+                $0.previousCounters.append(previous)
+            }
+            return SystemMetricsSamplers.TopProcessesResult(
+                samples: walkSamples,
+                ioSamples: [],
+                counters: [7: SystemMetricsSamplers.ProcessCPUCounters(totalTimeNanos: 123)]
+            )
+        }
+    }
+
+    private func quietOptions() -> SystemMetricsSource.Options {
+        var options = SystemMetricsSource.Options.default
+        options.topProcesses = true
+        options.gpu = false
+        options.accessories = false
+        return options
+    }
+
+    @Test("The process walk runs on its own slower cadence, not every base tick", .timeLimit(.minutes(1)))
+    func processWalkSkipsBaseTicks() async {
+        let sink = MockSink()
+        let record = OSAllocatedUnfairLock(initialState: WalkRecord())
+        let source = SystemMetricsSource(
+            options: quietOptions(),
+            interval: 0.1,
+            topProcessesSampler: Self.recordingWalkSampler(into: record)
+        )
+
+        await source.start(sink: sink)
+        let deadline = Date().addingTimeInterval(3.0)
+        while Date() < deadline {
+            if await sink.count() >= 4 { break }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        await source.stop()
+
+        let updateCount = await sink.count()
+        let walkCalls = record.withLock { $0.calls }
+        #expect(updateCount >= 4)
+        // Default 5s wall-clock cadence vs a 0.1s base tick: only the first
+        // tick may walk within this test's 3s window.
+        #expect(walkCalls == 1)
+        // Skipped ticks republish the cached list instead of dropping it.
+        #expect(await sink.system()?.topProcesses == Self.walkSamples)
+    }
+
+    @Test("A walk after skipped ticks gets the elapsed time since the previous walk", .timeLimit(.minutes(1)))
+    func processWalkIntervalSpansSkippedTicks() async {
+        let sink = MockSink()
+        let record = OSAllocatedUnfairLock(initialState: WalkRecord())
+        let source = SystemMetricsSource(
+            options: quietOptions(),
+            interval: 0.05,
+            topProcessSampleSeconds: 0.15,
+            topProcessesSampler: Self.recordingWalkSampler(into: record)
+        )
+
+        await source.start(sink: sink)
+        let deadline = Date().addingTimeInterval(3.0)
+        while Date() < deadline {
+            if record.withLock({ $0.calls }) >= 2 { break }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        await source.stop()
+
+        let snapshot = record.withLock { $0 }
+        guard snapshot.calls >= 2 else {
+            Issue.record("second process walk never happened within the timeout")
+            return
+        }
+        // CPU%/IO deltas divide by the span between walks, not the base tick —
+        // a per-tick elapsed here would inflate CPU% by the skip factor.
+        #expect(snapshot.intervals[1] >= 0.14)
+        // Counter bookkeeping survives the skipped ticks.
+        #expect(snapshot.previousCounters[1][7]?.totalTimeNanos == 123)
+    }
+
     @Test("Stopping halts further updates")
     func stopHaltsUpdates() async {
         let sink = MockSink()

--- a/LiveWallpaperTests/OracleCorpusCaptureTests.swift
+++ b/LiveWallpaperTests/OracleCorpusCaptureTests.swift
@@ -302,7 +302,11 @@ struct OracleCorpusCaptureTests {
                     descriptor: summary
                 )
             }
-            let texture = try renderer.renderCurrentFrame(inputs: renderer.makeFrameInputs())
+            // Drain per frame like WPERenderThread does in-app; without this the
+            // loop accumulates every autoreleased Metal object (measured ~0.5 MB/frame).
+            let texture = try autoreleasepool {
+                try renderer.renderCurrentFrame(inputs: renderer.makeFrameInputs())
+            }
             guard isLast else { continue }
             if perPass {
                 renderer.dumpScenePassesIfRequested(suffix: "-f\(index)")

--- a/LiveWallpaperTests/SettingsWindowLifecycleTests.swift
+++ b/LiveWallpaperTests/SettingsWindowLifecycleTests.swift
@@ -1,0 +1,97 @@
+#if !LITE_BUILD
+    import AppKit
+    import LiveWallpaperCore
+    @testable import LiveWallpaper
+    import Testing
+
+    /// B4: closing the settings window must destroy the whole SwiftUI hierarchy
+    /// and hosting window instead of hiding it, so a background app does not
+    /// keep the settings content tree resident.
+    @Suite("Settings window destroy-on-close", .serialized)
+    @MainActor
+    struct SettingsWindowLifecycleTests {
+        private func makeDelegate() -> AppDelegate {
+            let delegate = AppDelegate()
+            delegate.screenManager = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+                restoreSavedWallpapers: false,
+                startAutomation: false,
+                powerMonitor: FakePowerMonitor(),
+                fullScreenDetector: FakeFullScreenDetector(),
+                playableVideoLoader: FakePlayableVideoLoader(),
+                displayRegistry: FakeDisplayRegistry(),
+                featureCatalog: .unconfigured
+            ))
+            return delegate
+        }
+
+        /// AppKit autoreleases window bookkeeping and SwiftUI tears its tree
+        /// down on the next runloop turns, so releases are polled rather than
+        /// asserted synchronously after `close()`.
+        private func drainRunLoop(until released: () -> Bool) {
+            for _ in 0 ..< 100 {
+                if released() { return }
+                autoreleasepool {
+                    RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+                }
+            }
+        }
+
+        @Test("closing releases the controller, window, and hosting view")
+        func closeDestroysWindowHierarchy() throws {
+            let delegate = makeDelegate()
+
+            weak var weakController: NSWindowController?
+            weak var weakWindow: NSWindow?
+            weak var weakContentView: NSView?
+
+            try autoreleasepool {
+                delegate.showSettings()
+                let controller = try #require(delegate.settingsWindowControllerForTesting)
+                let window = try #require(controller.window)
+                weakController = controller
+                weakWindow = window
+                weakContentView = window.contentView
+                #expect(weakContentView != nil)
+
+                // Contract half 1: the close button must be allowed to close
+                // (the previous behavior returned false and only orderOut'd).
+                #expect(delegate.windowShouldClose(window))
+
+                // Contract half 2: an actual close must drop every strong
+                // reference the delegate holds.
+                window.close()
+            }
+
+            drainRunLoop {
+                weakController == nil && weakWindow == nil && weakContentView == nil
+            }
+
+            #expect(delegate.settingsWindowControllerForTesting == nil)
+            #expect(weakController == nil)
+            #expect(weakWindow == nil)
+            #expect(weakContentView == nil)
+        }
+
+        @Test("reopening after close cold-builds a fresh window")
+        func reopenAfterCloseBuildsFreshWindow() throws {
+            let delegate = makeDelegate()
+
+            var firstWindowID: ObjectIdentifier?
+            try autoreleasepool {
+                delegate.showSettings()
+                let window = try #require(delegate.settingsWindowControllerForTesting?.window)
+                firstWindowID = ObjectIdentifier(window)
+                window.close()
+            }
+            drainRunLoop { delegate.settingsWindowControllerForTesting == nil }
+            #expect(delegate.settingsWindowControllerForTesting == nil)
+
+            delegate.showSettings()
+            let reopened = try #require(delegate.settingsWindowControllerForTesting?.window)
+            #expect(ObjectIdentifier(reopened) != firstWindowID)
+            #expect(reopened.contentView != nil)
+            reopened.close()
+            drainRunLoop { delegate.settingsWindowControllerForTesting == nil }
+        }
+    }
+#endif

--- a/LiveWallpaperTests/VideoResolutionContractCharacterizationTests.swift
+++ b/LiveWallpaperTests/VideoResolutionContractCharacterizationTests.swift
@@ -111,6 +111,10 @@ struct VideoResolutionContractCharacterizationTests {
         #expect(compactPublishPath.contains("let height = CVPixelBufferGetHeight(pixelBuffer)"))
         #expect(compactPublishPath.contains(".bgra8Unorm_srgb, width, height, 0"))
         #expect(compactPublishPath.contains(".bgra8Unorm, width, height, 0"))
+        // NV12 planes mirror the decoder's per-plane dimensions the same way.
+        #expect(compactPublishPath.contains("CVPixelBufferGetWidthOfPlane(pixelBuffer, 0)"))
+        #expect(compactPublishPath.contains(".r8Unorm, lumaWidth, lumaHeight, 0"))
+        #expect(compactPublishPath.contains(".rg8Unorm, chromaWidth, chromaHeight, 1"))
     }
 
     private enum SourceContractError: Error {

--- a/LiveWallpaperTests/WPEAnimatedFrameByteLRUTests.swift
+++ b/LiveWallpaperTests/WPEAnimatedFrameByteLRUTests.swift
@@ -1,0 +1,146 @@
+#if !LITE_BUILD
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+@Suite("WPEAnimatedFrameByteCache byte LRU")
+struct WPEAnimatedFrameByteLRUTests {
+
+    private func makeCache(budget: Int = 1_000, admissionCap: Int = 1_000) -> WPEAnimatedFrameByteCache {
+        WPEAnimatedFrameByteCache(budgetBytes: budget, admissionByteCap: admissionCap)
+    }
+
+    private func bytes(_ count: Int, fill: UInt8 = 0xAB) -> Data {
+        Data(repeating: fill, count: count)
+    }
+
+    @Test("Store and lookup round-trips per source")
+    func storeLookupRoundTrip() {
+        let cache = makeCache()
+        let a = cache.registerSource()
+        let b = cache.registerSource()
+
+        cache.store(bytes(10, fill: 1), source: a, imageID: 0, speculative: false)
+        cache.store(bytes(10, fill: 2), source: b, imageID: 0, speculative: false)
+
+        #expect(cache.lookup(source: a, imageID: 0) == bytes(10, fill: 1))
+        #expect(cache.lookup(source: b, imageID: 0) == bytes(10, fill: 2))
+        #expect(cache.lookup(source: a, imageID: 1) == nil)
+        #expect(cache.totalBytes == 20)
+    }
+
+    @Test("Over-budget prune evicts speculative entries before consumed ones")
+    func speculativeEvictsFirst() {
+        let cache = makeCache(budget: 100)
+        let source = cache.registerSource()
+
+        // Entry 0: consumed, UNPINNED, and least-recently used. Entry 1:
+        // speculative but more recent. A plain LRU sweep would take 0;
+        // speculative-first must take 1 instead — this ordering is what
+        // discriminates the policy from generic LRU.
+        cache.store(bytes(40), source: source, imageID: 0, speculative: false)
+        cache.store(bytes(40), source: source, imageID: 1, speculative: true)
+        cache.store(bytes(40), source: source, imageID: 2, speculative: false)
+
+        #expect(!cache.contains(source: source, imageID: 1))
+        #expect(cache.contains(source: source, imageID: 0))
+        #expect(cache.contains(source: source, imageID: 2))
+    }
+
+    @Test("Prune applies hysteresis down to 80% of budget")
+    func pruneHysteresisTo80Percent() {
+        let cache = makeCache(budget: 100)
+        let source = cache.registerSource()
+
+        // 6 speculative entries of 20B = 120B > 100B budget triggers a prune
+        // that must continue to ≤80B, not stop at 100B.
+        for imageID in 0..<6 {
+            cache.store(bytes(20), source: source, imageID: imageID, speculative: true)
+        }
+        #expect(cache.totalBytes <= 80)
+    }
+
+    @Test("Pinned current frame survives critical trim; speculative trim keeps consumed entries")
+    func pinnedSurvivesTrims() {
+        let cache = makeCache()
+        let source = cache.registerSource()
+
+        cache.store(bytes(10), source: source, imageID: 0, speculative: false)
+        _ = cache.lookup(source: source, imageID: 0) // pins imageID 0
+        cache.store(bytes(10), source: source, imageID: 1, speculative: true)
+        cache.store(bytes(10), source: source, imageID: 2, speculative: false)
+
+        cache.removeSpeculative()
+        #expect(!cache.contains(source: source, imageID: 1))
+        #expect(cache.contains(source: source, imageID: 0))
+        #expect(cache.contains(source: source, imageID: 2))
+
+        cache.removeAllUnpinned()
+        #expect(cache.contains(source: source, imageID: 0))
+        #expect(!cache.contains(source: source, imageID: 2))
+    }
+
+    @Test("Frames above the admission cap are never stored")
+    func oversizeFramesBypassCache() {
+        let cache = makeCache(budget: 1_000, admissionCap: 64)
+        let source = cache.registerSource()
+
+        #expect(!cache.store(bytes(65), source: source, imageID: 0, speculative: false))
+        #expect(!cache.contains(source: source, imageID: 0))
+        #expect(cache.totalBytes == 0)
+
+        #expect(cache.store(bytes(64), source: source, imageID: 1, speculative: false))
+        #expect(cache.contains(source: source, imageID: 1))
+    }
+
+    @Test("Unregistering a source returns its lease")
+    func unregisterReturnsLease() {
+        let cache = makeCache()
+        let a = cache.registerSource()
+        let b = cache.registerSource()
+        cache.store(bytes(30), source: a, imageID: 0, speculative: false)
+        _ = cache.lookup(source: a, imageID: 0)
+        cache.store(bytes(30), source: b, imageID: 0, speculative: false)
+
+        cache.unregisterSource(a)
+        #expect(!cache.contains(source: a, imageID: 0))
+        #expect(cache.contains(source: b, imageID: 0))
+        #expect(cache.totalBytes == 30)
+
+        // The dropped pin must not shield anything from a later trim: b was
+        // never looked up, so nothing is pinned and the trim must empty the cache.
+        cache.removeAllUnpinned()
+        #expect(cache.totalBytes == 0)
+        #expect(!cache.contains(source: b, imageID: 0))
+    }
+
+    @Test("A live pin survives another source's unregistration and a trim")
+    func pinSurvivesUnregisterAndTrim() {
+        let cache = makeCache()
+        let a = cache.registerSource()
+        let b = cache.registerSource()
+        cache.store(bytes(30), source: a, imageID: 0, speculative: false)
+        cache.store(bytes(30), source: b, imageID: 0, speculative: false)
+        _ = cache.lookup(source: b, imageID: 0)
+
+        cache.unregisterSource(a)
+        cache.removeAllUnpinned()
+        #expect(cache.contains(source: b, imageID: 0))
+        #expect(cache.totalBytes == 30)
+    }
+
+    @Test("Lookup consumes the speculative flag")
+    func lookupConsumesSpeculativeFlag() {
+        let cache = makeCache()
+        let source = cache.registerSource()
+        cache.store(bytes(10), source: source, imageID: 0, speculative: true)
+        _ = cache.lookup(source: source, imageID: 0)
+        cache.store(bytes(10), source: source, imageID: 1, speculative: false)
+
+        cache.removeSpeculative()
+        // Once consumed, the former speculative entry must survive the trim.
+        #expect(cache.contains(source: source, imageID: 0))
+        #expect(cache.contains(source: source, imageID: 1))
+    }
+}
+#endif

--- a/LiveWallpaperTests/WPEFrameDemandTests.swift
+++ b/LiveWallpaperTests/WPEFrameDemandTests.swift
@@ -1,0 +1,310 @@
+#if !LITE_BUILD
+import CoreGraphics
+import Foundation
+import LiveWallpaperCore
+import LiveWallpaperProWPE
+import Metal
+import MetalKit
+import os
+import Testing
+@testable import LiveWallpaper
+
+// MARK: - Particle permanent-idle classification (unit level)
+
+struct WPEParticlePermanentIdleTests {
+    private func makeSystem(
+        _ json: [String: Any],
+        device: MTLDevice
+    ) throws -> WPEParticleSystem {
+        let definition = WPEParticleDefinitionParser.parse(dictionary: json)
+        return try #require(WPEParticleSystem(definition: definition, device: device, seed: 0xB3))
+    }
+
+    @Test("A one-shot burst is idle only after it fired and every particle died")
+    func oneShotBurstBecomesPermanentlyIdle() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let system = try makeSystem([
+            "maxcount": 8,
+            "emitter": [["rate": 0, "instantaneous": 4]],
+            "initializer": [["name": "lifetimerandom", "min": 0.05, "max": 0.1]],
+        ], device: device)
+
+        system.tick(now: 0)
+        #expect(system.liveInstanceCount == 4)
+        #expect(!system.isPermanentlyIdle)
+
+        system.tick(now: 1)
+        #expect(system.liveInstanceCount == 0)
+        #expect(system.isPermanentlyIdle)
+    }
+
+    @Test("A rate emitter is never idle, even between births with nothing alive")
+    func rateEmitterStaysLive() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let system = try makeSystem([
+            "maxcount": 8,
+            "emitter": [["rate": 1]],
+            "initializer": [["name": "lifetimerandom", "min": 0.05, "max": 0.05]],
+        ], device: device)
+
+        // First tick has dt == 0: nothing spawned yet, but the emitter can.
+        system.tick(now: 0)
+        #expect(system.liveInstanceCount == 0)
+        #expect(!system.isPermanentlyIdle)
+    }
+
+    @Test("A duration-bounded rate emitter goes idle once the window closed and all died")
+    func durationBoundedEmitterBecomesIdle() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let system = try makeSystem([
+            "maxcount": 64,
+            "emitter": [["rate": 60, "duration": 0.2]],
+            "initializer": [["name": "lifetimerandom", "min": 0.05, "max": 0.1]],
+        ], device: device)
+
+        var sawLiveParticles = false
+        var t = 0.0
+        while t <= 1.5 {
+            system.tick(now: t)
+            if system.liveInstanceCount > 0 { sawLiveParticles = true }
+            // Inside the emission window the system must never classify idle.
+            if t <= 0.2 { #expect(!system.isPermanentlyIdle) }
+            t += 0.05
+        }
+        #expect(sawLiveParticles)
+        #expect(system.liveInstanceCount == 0)
+        #expect(system.isPermanentlyIdle)
+    }
+
+    @Test("An unfired burst behind a start delay is not idle")
+    func unfiredDelayedBurstStaysLive() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let system = try makeSystem([
+            "maxcount": 8,
+            "starttime": 100,
+            "emitter": [["rate": 0, "instantaneous": 2]],
+            "initializer": [["name": "lifetimerandom", "min": 0.05, "max": 0.1]],
+        ], device: device)
+
+        system.tick(now: 0)
+        system.tick(now: 1)
+        #expect(system.liveInstanceCount == 0)
+        #expect(!system.isPermanentlyIdle)
+    }
+
+    @Test("An eventfollow child without a duration stays live for future parent births")
+    func eventFollowChildStaysLive() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let system = try makeSystem([
+            "maxcount": 8,
+            "emitter": [["rate": 0, "instantaneous": 1]],
+            "initializer": [["name": "lifetimerandom", "min": 0.05, "max": 0.1]],
+        ], device: device)
+        system.requiresFollowParent = true
+
+        system.tick(now: 0)
+        system.tick(now: 1000)
+        #expect(system.liveInstanceCount == 0)
+        #expect(!system.isPermanentlyIdle)
+    }
+}
+
+// MARK: - Renderer frame demand (loaded static fixture)
+
+@MainActor
+@Suite("WPE frame demand", .serialized)
+struct WPEFrameDemandTests {
+    @Test("A static scene reports an empty frame demand")
+    func staticSceneHasEmptyDemand() async throws {
+        let fixture = try FrameDemandFixture.make()
+        defer { fixture.cleanup() }
+        let stack = try FrameDemandRendererStack.make(fixture)
+        let renderer = stack.renderer
+        defer { renderer.cleanup() }
+        try await stack.load()
+
+        #expect(renderer.frameDemand == [])
+        #expect(!renderer.needsContinuousFrames)
+        #expect(stack.surface.mtkView.isPaused)
+    }
+
+    @Test("Fully released on-demand videos carry no demand; a rebuilt source re-arms the loop")
+    func releasedOnDemandVideoSettlesAndRebuildRearms() async throws {
+        let fixture = try FrameDemandFixture.make()
+        defer { fixture.cleanup() }
+        let stack = try FrameDemandRendererStack.make(fixture)
+        let renderer = stack.renderer
+        defer { renderer.cleanup() }
+        try await stack.load()
+
+        // Scene has releasable videos, all currently released (hidden).
+        renderer.onDemandVideoKeyByID = ["layer-1": "video/clip.mp4"]
+        #expect(!renderer.needsContinuousFrames)
+
+        // Reveal path: `rebuildOnDemandVideo` re-inserts the source; the didSet
+        // must re-arm pacing without waiting for a profile event.
+        renderer.dynamicTextureSources["video/clip.mp4"] = StubDynamicTextureSource()
+        #expect(renderer.frameDemand.contains(.dynamicTextures))
+        #expect(renderer.needsContinuousFrames)
+        #expect(stack.surface.mtkView.isPaused == false)
+
+        // Hide path: releasing the last source settles the loop again.
+        renderer.dynamicTextureSources.removeValue(forKey: "video/clip.mp4")
+        #expect(!renderer.needsContinuousFrames)
+        #expect(stack.surface.mtkView.isPaused)
+        #expect(stack.surface.mtkView.enableSetNeedsDisplay)
+    }
+
+    @Test("Finished particle systems stop demanding frames; live emitters keep them")
+    func particleDemandFollowsLiveness() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try FrameDemandFixture.make()
+        defer { fixture.cleanup() }
+        let stack = try FrameDemandRendererStack.make(fixture)
+        let renderer = stack.renderer
+        defer { renderer.cleanup() }
+        try await stack.load()
+
+        let finished = try #require(WPEParticleSystem(
+            definition: WPEParticleDefinitionParser.parse(dictionary: [
+                "maxcount": 8,
+                "emitter": [["rate": 0, "instantaneous": 2]],
+                "initializer": [["name": "lifetimerandom", "min": 0.05, "max": 0.1]],
+            ]),
+            device: device,
+            seed: 0xB3
+        ))
+        finished.tick(now: 0)
+        finished.tick(now: 1)
+        #expect(finished.isPermanentlyIdle)
+
+        renderer.particleSystems = [finished]
+        renderer.synchronizeFrameDemand()
+        #expect(!renderer.frameDemand.contains(.particles))
+        #expect(!renderer.needsContinuousFrames)
+        #expect(stack.surface.mtkView.isPaused)
+
+        let live = try #require(WPEParticleSystem(
+            definition: WPEParticleDefinitionParser.parse(dictionary: [
+                "maxcount": 8,
+                "emitter": [["rate": 5]],
+            ]),
+            device: device,
+            seed: 0xB3
+        ))
+        renderer.particleSystems = [finished, live]
+        renderer.synchronizeFrameDemand()
+        #expect(renderer.frameDemand.contains(.particles))
+        #expect(renderer.needsContinuousFrames)
+        #expect(stack.surface.mtkView.isPaused == false)
+    }
+
+    @Test("The runtime-activity mirror publishes idle for a static scene and flips with demand")
+    func runtimeActivityMirrorFollowsDemand() async throws {
+        let fixture = try FrameDemandFixture.make()
+        defer { fixture.cleanup() }
+        let stack = try FrameDemandRendererStack.make(fixture)
+        let renderer = stack.renderer
+        defer { renderer.cleanup() }
+
+        let published = OSAllocatedUnfairLock<[WPESceneRuntimeActivity]>(initialState: [])
+        renderer.onRuntimeActivityChange = { activity in
+            published.withLock { $0.append(activity) }
+        }
+        try await stack.load()
+
+        let afterLoad = published.withLock { $0.last }
+        #expect(afterLoad == WPESceneRuntimeActivity(producesFrames: false, audible: false))
+
+        renderer.setClickCaptureEnabled(true)
+        let afterCapture = published.withLock { $0.last }
+        #expect(afterCapture == WPESceneRuntimeActivity(producesFrames: true, audible: false))
+
+        renderer.setClickCaptureEnabled(false)
+        let afterRelease = published.withLock { $0.last }
+        #expect(afterRelease == WPESceneRuntimeActivity(producesFrames: false, audible: false))
+    }
+}
+
+// MARK: - Shared fixture (mirrors the RR03 liveness harness)
+
+private final class StubDynamicTextureSource: WPEDynamicTextureSource {
+    func texture(at time: TimeInterval) -> MTLTexture? { nil }
+    func applyPerformanceProfile(_ profile: WallpaperPerformanceProfile) {}
+    func invalidate() {}
+}
+
+@MainActor
+struct FrameDemandRendererStack {
+    let renderer: WPEMetalSceneRenderer
+    let surface: WPERenderSurface
+    let actor: WPEDisplayRenderActor
+
+    static func make(_ fixture: FrameDemandFixture) throws -> Self {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let surface = WPERenderSurface(frame: CGRect(x: 0, y: 0, width: 64, height: 64), device: device)
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.root,
+            projectManifestRootURL: fixture.root,
+            dependencyMounts: [],
+            surfaceControl: surface,
+            mailbox: surface.mailbox,
+            presentLayer: WPEPresentLayer(layer: surface.metalLayer),
+            drawableSize: surface.metalLayer.drawableSize,
+            device: device,
+            pointerSampler: .fixed(SIMD2<Double>(0.5, 0.5))
+        )
+        return Self(renderer: renderer, surface: surface, actor: WPEDisplayRenderActor(backing: .main))
+    }
+
+    func load() async throws {
+        await actor.adopt(WPERendererHandoff(renderer: renderer).renderer)
+        try await actor.load()
+    }
+}
+
+struct FrameDemandFixture {
+    let root: URL
+    let descriptor: SceneDescriptor
+
+    static func make() throws -> Self {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("frame-demand-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let scene = try JSONSerialization.data(withJSONObject: [
+            "camera": ["center": "0 0 0"],
+            "general": ["orthogonalprojection": ["width": 64, "height": 64, "auto": true]],
+            "objects": [[
+                "id": "solid",
+                "name": "Solid",
+                "type": "image",
+                "image": "models/util/solidlayer.json",
+                "color": "0 0 1",
+                "alpha": 1,
+                "visible": true,
+            ]],
+        ], options: [.sortedKeys])
+        try scene.write(to: root.appendingPathComponent("scene.json"))
+        let project = try JSONSerialization.data(withJSONObject: [
+            "workshopid": "frame-demand-fixture",
+            "type": "scene",
+            "file": "scene.json",
+        ], options: [.sortedKeys])
+        try project.write(to: root.appendingPathComponent("project.json"))
+        return Self(
+            root: root,
+            descriptor: SceneDescriptor(
+                workshopID: "frame-demand-fixture",
+                cacheRelativePath: "wpe-cache/frame-demand-fixture",
+                entryFile: "scene.json",
+                capabilityTier: .imageOnly
+            )
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}
+#endif

--- a/LiveWallpaperTests/WPEMappedPackageWriteFenceTests.swift
+++ b/LiveWallpaperTests/WPEMappedPackageWriteFenceTests.swift
@@ -1,0 +1,257 @@
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+/// The renderer keeps a Workshop `scene.pkg` memory-mapped for the whole scene
+/// lifetime (`WPEPackageSceneAssetProvider.mappedWindow`). On APFS, deleting or
+/// rename-replacing the file under a live mapping is safe — the vnode survives —
+/// but rewriting or truncating it in place SIGBUSes the mapping process on the
+/// next page fault. This suite pins both halves of that invariant:
+/// the sanctioned operations (delete, write-temp + rename) keep a live window
+/// readable, and the production tree keeps no write-capable open that could hit
+/// a mapped file in place.
+@Suite("WPE mapped package write fence")
+struct WPEMappedPackageWriteFenceTests {
+    /// Large enough that `.mappedIfSafe` genuinely maps instead of heap-reading,
+    /// so the survival tests exercise page faults against a real vnode.
+    private static let payloadSize = 4 * 1024 * 1024
+
+    private static func makePayload(fill: UInt8) -> Data {
+        Data(repeating: fill, count: payloadSize)
+    }
+
+    private static func makePackageData(_ entries: [(name: String, data: Data)]) -> Data {
+        func u32(_ value: UInt32) -> Data {
+            withUnsafeBytes(of: value.littleEndian) { Data($0) }
+        }
+        var header = Data()
+        let magic = "PKGV0001"
+        header.append(u32(UInt32(magic.utf8.count)))
+        header.append(contentsOf: magic.utf8)
+        header.append(u32(UInt32(entries.count)))
+        var blob = Data()
+        var offset: UInt32 = 0
+        for entry in entries {
+            let nameBytes = Array(entry.name.utf8)
+            header.append(u32(UInt32(nameBytes.count)))
+            header.append(contentsOf: nameBytes)
+            header.append(u32(offset))
+            header.append(u32(UInt32(entry.data.count)))
+            blob.append(entry.data)
+            offset += UInt32(entry.data.count)
+        }
+        return header + blob
+    }
+
+    private static func makeScratchDirectory() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pkg-write-fence-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - Sanctioned operations keep a live mapping readable
+
+    @Test("A live mapped window survives deletion of the package")
+    func mappedWindowSurvivesDelete() throws {
+        let dir = try Self.makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let payload = Self.makePayload(fill: 0xA5)
+        let pkgURL = dir.appendingPathComponent("scene.pkg")
+        try Self.makePackageData([(name: "materials/a.tex", data: payload)]).write(to: pkgURL)
+
+        let provider = try WPEPackageSceneAssetProvider(packageURL: pkgURL)
+        let window = try provider.mappedWindow(atRelativePath: "materials/a.tex")
+
+        try FileManager.default.removeItem(at: pkgURL)
+
+        // Full read faults every page; the unlinked vnode must still back them.
+        #expect(window.materializedData() == payload)
+    }
+
+    @Test("A live mapped window survives write-temp + rename replacement")
+    func mappedWindowSurvivesRenameReplace() throws {
+        let dir = try Self.makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let oldPayload = Self.makePayload(fill: 0x11)
+        let newPayload = Self.makePayload(fill: 0xEE)
+        let pkgURL = dir.appendingPathComponent("scene.pkg")
+        try Self.makePackageData([(name: "materials/a.tex", data: oldPayload)]).write(to: pkgURL)
+
+        let provider = try WPEPackageSceneAssetProvider(packageURL: pkgURL)
+        let window = try provider.mappedWindow(atRelativePath: "materials/a.tex")
+
+        // The sanctioned replacement idiom: write the new package to a temp
+        // sibling, then swap it in by rename.
+        let replacement = dir.appendingPathComponent("scene.pkg.tmp")
+        try Self.makePackageData([(name: "materials/a.tex", data: newPayload)]).write(to: replacement)
+        _ = try FileManager.default.replaceItemAt(pkgURL, withItemAt: replacement)
+
+        // The live window still reads the superseded vnode, byte for byte.
+        #expect(window.materializedData() == oldPayload)
+
+        // A fresh open sees the replacement.
+        let reopened = try WPEPackageSceneAssetProvider(packageURL: pkgURL)
+        let newWindow = try reopened.mappedWindow(atRelativePath: "materials/a.tex")
+        #expect(newWindow.materializedData() == newPayload)
+    }
+
+    @Test("The connector's workshop delete leaves a live mapping readable")
+    func deleteWorkshopItemLeavesLiveMappingReadable() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("pkg-write-fence-steam-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+        let itemID = "3725117707"
+        let item = SteamLibraryPaths.workshopContentRoot(steamRoot: root)
+            .appendingPathComponent(itemID, isDirectory: true)
+        try fm.createDirectory(at: item, withIntermediateDirectories: true)
+        let payload = Self.makePayload(fill: 0x3C)
+        let pkgURL = item.appendingPathComponent("scene.pkg")
+        try Self.makePackageData([(name: "materials/a.tex", data: payload)]).write(to: pkgURL)
+
+        let provider = try WPEPackageSceneAssetProvider(packageURL: pkgURL)
+        let window = try provider.mappedWindow(atRelativePath: "materials/a.tex")
+
+        let result = SteamLibraryWriter.deleteWorkshopItem(workshopID: itemID, steamRoot: root)
+
+        #expect(result.outcome == .deleted)
+        var info = stat()
+        #expect(lstat(item.path(percentEncoded: false), &info) != 0)
+        #expect(window.materializedData() == payload)
+    }
+
+    // MARK: - Source fence: no in-place writer may appear
+    //
+    // The behaviour tests above cannot police the write side: `.mappedIfSafe`
+    // maps MAP_PRIVATE, so a same-inode rewrite is snapshot-isolated from an
+    // already-created window (probed 2026-08-16 — even unfaulted pages keep the
+    // old bytes). The remaining hazard is a SIGBUS while the file is truncated
+    // mid-rewrite, a cross-process race no in-process test can stage. The two
+    // source audits below are therefore the enforcement, mutation-verified: a
+    // planted `FileHandle(forUpdating:)` + bare `data.write(to:)` in
+    // WPECachedContentResolver turned both red.
+
+    private static let productionRoots = [
+        "LiveWallpaper",
+        "SteamConnector",
+        "Packages/LiveWallpaperCore/Sources",
+        "Packages/LiveWallpaperProWPE/Sources",
+    ]
+
+    /// `FileHandle(forUpdating:)` / `forUpdatingAtPath:` open an existing file
+    /// for in-place rewriting — exactly the operation that SIGBUSes a mapped
+    /// reader. There is no legitimate use anywhere in production.
+    @Test("The in-place update API is absent from all production sources")
+    func inPlaceUpdateAPIIsAbsent() throws {
+        var hits: [String] = []
+        for root in Self.productionRoots {
+            for file in RepositoryRoot.swiftFiles(under: root) where !file.path.contains("/Tests/") {
+                let source = try String(contentsOf: file, encoding: .utf8)
+                if source.contains("forUpdating") {
+                    hits.append(file.path)
+                }
+            }
+        }
+        #expect(
+            hits.isEmpty,
+            Comment(rawValue: "FileHandle(forUpdating…) rewrites a file in place and will SIGBUS any process mapping it (scene.pkg stays mapped for the whole scene lifetime). Replace via write-temp + rename instead:\n\(hits.joined(separator: "\n"))")
+        )
+    }
+
+    /// Content-handling surface: everything that touches workshop items,
+    /// installed scenes, scene caches, or the Steam library. Any write-capable
+    /// file open added here must be re-audited against the mmap invariant
+    /// (mapped files may be deleted or rename-replaced, never rewritten in
+    /// place) and then recorded below with its occurrence count.
+    private static let fencedRoots = [
+        "LiveWallpaper/Infrastructure",
+        "LiveWallpaper/VideoPlayback",
+        "LiveWallpaper/Runtime",
+        "SteamConnector",
+        "Packages/LiveWallpaperProWPE/Sources",
+    ]
+
+    private static let writePatterns = [
+        "FileHandle(forWritingTo",
+        "forWritingAtPath",
+        "forWriting:",
+        ".write(to",
+        "createFile(",
+        "ftruncate",
+        "truncateFile",
+        "O_WRONLY",
+        "O_RDWR",
+    ]
+
+    /// Audited 2026-08-16: every entry writes to a fresh temp/staging/cache
+    /// path or uses `.atomic` (write-temp + rename). None opens an existing
+    /// mapped file for writing.
+    private static let auditedWriteSites: [String: [String: Int]] = [
+        "LiveWallpaper/Infrastructure/Workshop/WorkshopQueryCache.swift": [".write(to": 1],
+        "LiveWallpaper/Infrastructure/Workshop/WorkshopKeychainStore.swift": [".write(to": 1],
+        "LiveWallpaper/Infrastructure/Platform/DesktopPictureFrameExtractor.swift": [".write(to": 1],
+        "LiveWallpaper/Infrastructure/Diagnostics/WPESceneDebugArtifacts.swift": [
+            "createFile(": 1,
+            "FileHandle(forWritingTo": 1,
+            ".write(to": 2,
+        ],
+        "LiveWallpaper/Infrastructure/Assets/WallpaperEnginePackage.swift": [
+            "createFile(": 1,
+            "FileHandle(forWritingTo": 1,
+        ],
+        "LiveWallpaper/Infrastructure/Assets/WPEPackageSceneAssetProvider.swift": [
+            "createFile(": 1,
+            "FileHandle(forWritingTo": 1,
+        ],
+        "LiveWallpaper/Infrastructure/Assets/WPEVideoTextureDiskCache.swift": [".write(to": 1],
+        "LiveWallpaper/VideoPlayback/OggAudioTranscoder.swift": ["forWriting:": 1],
+        "LiveWallpaper/Runtime/Metal/WPEMetalSceneRenderer+Debug.swift": [".write(to": 2],
+        "LiveWallpaper/Runtime/Metal/WPEMetalPassGPUProfiler.swift": [".write(to": 1],
+        "SteamConnector/SteamConnectorProtocol.swift": [".write(to": 1],
+    ]
+
+    @Test("Write-capable file opens in the content surface stay on the audited allowlist")
+    func writeCapableOpensStayAudited() throws {
+        var sweptFiles = 0
+        var observed: [String: [String: Int]] = [:]
+        for root in Self.fencedRoots {
+            for file in RepositoryRoot.swiftFiles(under: root) where !file.path.contains("/Tests/") {
+                sweptFiles += 1
+                let source = try String(contentsOf: file, encoding: .utf8)
+                let relativePath = file.path.replacingOccurrences(
+                    of: RepositoryRoot.url.path + "/",
+                    with: ""
+                )
+                for pattern in Self.writePatterns {
+                    let count = source.components(separatedBy: pattern).count - 1
+                    if count > 0 {
+                        observed[relativePath, default: [:]][pattern] = count
+                    }
+                }
+            }
+        }
+        #expect(sweptFiles > 100, "Content-surface sweep collapsed to \(sweptFiles) files")
+
+        var violations: [String] = []
+        for (file, patterns) in observed {
+            for (pattern, count) in patterns where count > (Self.auditedWriteSites[file]?[pattern] ?? 0) {
+                violations.append("\(file): `\(pattern)` ×\(count) (audited ×\(Self.auditedWriteSites[file]?[pattern] ?? 0))")
+            }
+        }
+        let stale = Self.auditedWriteSites.flatMap { file, patterns in
+            patterns.compactMap { pattern, expected -> String? in
+                let actual = observed[file]?[pattern] ?? 0
+                return actual == expected ? nil : "\(file): `\(pattern)` audited ×\(expected), found ×\(actual)"
+            }
+        }
+        #expect(
+            violations.isEmpty,
+            Comment(rawValue: "Unaudited write-capable open in the content surface. Mapped files (scene.pkg, loose scene assets) may be deleted or rename-replaced, never opened for in-place writing — audit the new site, then record it:\n\(violations.sorted().joined(separator: "\n"))")
+        )
+        #expect(
+            stale.isEmpty,
+            Comment(rawValue: "Write-site allowlist drifted; shrink or re-audit it:\n\(stale.sorted().joined(separator: "\n"))")
+        )
+    }
+}

--- a/LiveWallpaperTests/WPEMetalSnapshotQueueCacheTests.swift
+++ b/LiveWallpaperTests/WPEMetalSnapshotQueueCacheTests.swift
@@ -1,0 +1,60 @@
+import AppKit
+import Metal
+import Testing
+import os
+@testable import LiveWallpaper
+
+// B6 guard: the poster downsample path caches one MTLCommandQueue per device
+// (process lifetime) instead of creating a queue per capture. Needs a real
+// MTLDevice, so this suite stays out of the headless fast-app-contract shard
+// (that shard is an explicit allowlist in scripts/fast_app_contract_tests.sh).
+
+@Suite("WPEMetalTextureSnapshotter downsample queue cache")
+struct WPEMetalSnapshotQueueCacheTests {
+
+    @Test("the same device resolves to the same cached queue instance")
+    func sameDeviceSameQueueInstance() throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let first = try #require(WPEMetalTextureSnapshotter.commandQueue(for: device))
+        let second = try #require(WPEMetalTextureSnapshotter.commandQueue(for: device))
+        #expect(first === second)
+        #expect(first.label == "com.livewallpaper.wpe-metal.poster-downsample")
+    }
+
+    @Test("repeated poster snapshots reuse the cached queue: zero creations once primed")
+    func repeatedSnapshotsDoNotRecreateQueue() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let primed = try #require(WPEMetalTextureSnapshotter.commandQueue(for: device))
+
+        // Wider than posterMaxDimension so snapshotAsync must take the GPU
+        // downsample path — the cached queue's only consumer.
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .rgba8Unorm,
+            width: 2048,
+            height: 64,
+            mipmapped: false
+        )
+        descriptor.usage = [.shaderRead]
+        descriptor.storageMode = .shared
+        let texture = try #require(device.makeTexture(descriptor: descriptor))
+
+        let creationsBefore = WPEMetalTextureSnapshotter.downsampleQueueCreationsForTesting.withLock { $0 }
+        let snapshotter = WPEMetalTextureSnapshotter(label: "test.queue-cache.readback")
+        for _ in 0 ..< 3 {
+            let image = await snapshotter.snapshotAsync(
+                from: WPEMetalTextureSnapshotter.SnapshotSource(texture: texture)
+            )
+            let poster = try #require(image)
+            // 2048 → 1440 proves the downsample actually ran; a 2048-wide poster
+            // would mean the fallback path executed and the counts below are vacuous.
+            #expect(Int(poster.size.width) == WPEMetalTextureSnapshotter.posterMaxDimension)
+        }
+        let creationsAfter = WPEMetalTextureSnapshotter.downsampleQueueCreationsForTesting.withLock { $0 }
+        #expect(
+            creationsAfter - creationsBefore == 0,
+            "downsampling created \(creationsAfter - creationsBefore) new queue(s) for an already-cached device"
+        )
+        let cachedAfter = try #require(WPEMetalTextureSnapshotter.commandQueue(for: device))
+        #expect(cachedAfter === primed)
+    }
+}

--- a/LiveWallpaperTests/WPEMetalSnapshotQueueCacheTests.swift
+++ b/LiveWallpaperTests/WPEMetalSnapshotQueueCacheTests.swift
@@ -57,4 +57,34 @@ struct WPEMetalSnapshotQueueCacheTests {
         let cachedAfter = try #require(WPEMetalTextureSnapshotter.commandQueue(for: device))
         #expect(cachedAfter === primed)
     }
+
+    /// The review flagged that the sRGB branch takes a differing-format texture
+    /// view, which Apple documents as needing `.pixelFormatView` — a usage the
+    /// renderer's output textures do not carry. This pins what the shipping
+    /// descriptor actually does: same format/usage as `makeOutputTexture`, and
+    /// the poster must come back downsampled rather than through the
+    /// full-resolution fallback.
+    @Test("an sRGB poster built with the renderer's own descriptor still downsamples on GPU")
+    func srgbPosterWithRendererDescriptorDownsamples() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .rgba8Unorm_srgb,
+            width: 2048,
+            height: 64,
+            mipmapped: false
+        )
+        // Verbatim from WPEMetalRenderExecutor.makeOutputTexture.
+        descriptor.usage = [.renderTarget, .shaderRead]
+        descriptor.storageMode = .shared
+        let texture = try #require(device.makeTexture(descriptor: descriptor))
+
+        let snapshotter = WPEMetalTextureSnapshotter(label: "test.queue-cache.srgb")
+        let poster = try #require(await snapshotter.snapshotAsync(
+            from: WPEMetalTextureSnapshotter.SnapshotSource(texture: texture)
+        ))
+        #expect(
+            Int(poster.size.width) == WPEMetalTextureSnapshotter.posterMaxDimension,
+            "sRGB poster came back at \(poster.size.width)px — the GPU downsample was skipped"
+        )
+    }
 }

--- a/LiveWallpaperTests/WPEMetalTextureByteEstimatorTests.swift
+++ b/LiveWallpaperTests/WPEMetalTextureByteEstimatorTests.swift
@@ -1,0 +1,98 @@
+#if !LITE_BUILD
+import Foundation
+import Metal
+import Testing
+@testable import LiveWallpaper
+
+@Suite("WPE Metal texture byte estimator")
+struct WPEMetalTextureByteEstimatorTests {
+    @Test("BC3 counts compressed blocks, not pixels")
+    func bc3BlockMath() {
+        // 4096x4096 bc3 = 1024x1024 blocks x 16 bytes = 16 MiB (not the 64 MiB
+        // the old per-pixel census math reported).
+        #expect(WPEMetalTextureByteEstimator.estimatedBytes(
+            pixelFormat: .bc3_rgba,
+            width: 4096,
+            height: 4096
+        ) == 16_777_216)
+    }
+
+    @Test("Full mip chain is the exact per-level sum with block rounding")
+    func bc3FullMipChain() {
+        // 4096 -> 1 is 13 levels; per-level block counts hand-derived from
+        // max((dim + 3) / 4, 1). Sub-4px tails still occupy one block per axis.
+        let blockCounts = [1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 1, 1]
+        let expected = blockCounts.map { $0 * $0 * 16 }.reduce(0, +)
+        #expect(expected == 22_369_648)
+        #expect(WPEMetalTextureByteEstimator.estimatedBytes(
+            pixelFormat: .bc3_rgba,
+            width: 4096,
+            height: 4096,
+            mipmapLevelCount: 13
+        ) == expected)
+    }
+
+    @Test("Odd dimensions round up to whole blocks")
+    func oddDimensionBlockRounding() {
+        #expect(WPEMetalTextureByteEstimator.estimatedBytes(
+            pixelFormat: .bc3_rgba,
+            width: 5,
+            height: 5
+        ) == 2 * 2 * 16)
+    }
+
+    @Test("BC1 is half of BC3 at the same size")
+    func bc1HalfOfBC3() {
+        let bc1 = WPEMetalTextureByteEstimator.estimatedBytes(
+            pixelFormat: .bc1_rgba,
+            width: 4096,
+            height: 4096
+        )
+        let bc3 = WPEMetalTextureByteEstimator.estimatedBytes(
+            pixelFormat: .bc3_rgba,
+            width: 4096,
+            height: 4096
+        )
+        #expect(bc1 == 8_388_608)
+        #expect(bc3 == bc1 * 2)
+    }
+
+    @Test("Uncompressed formats bill per pixel")
+    func uncompressedPerPixel() {
+        #expect(WPEMetalTextureByteEstimator.estimatedBytes(
+            pixelFormat: .rgba8Unorm,
+            width: 4096,
+            height: 4096
+        ) == 67_108_864)
+        #expect(WPEMetalTextureByteEstimator.estimatedBytes(
+            pixelFormat: .r8Unorm,
+            width: 1024,
+            height: 1024
+        ) == 1_048_576)
+    }
+
+    @Test("Cube and array multiply the slice footprint")
+    func cubeAndArraySlices() {
+        #expect(WPEMetalTextureByteEstimator.estimatedBytes(
+            pixelFormat: .rgba8Unorm,
+            width: 512,
+            height: 512,
+            isCube: true
+        ) == 512 * 512 * 4 * 6)
+        #expect(WPEMetalTextureByteEstimator.estimatedBytes(
+            pixelFormat: .bc3_rgba,
+            width: 4096,
+            height: 4096,
+            arrayLength: 3
+        ) == 16_777_216 * 3)
+    }
+
+    @Test("Every memory tier ships a bounded texture-cache budget")
+    func everyTierIsBounded() {
+        for tier in WPEMemoryTier.allCases {
+            #expect(tier.defaultTextureCacheBudgetBytes != nil)
+        }
+        #expect(WPEMemoryTier.expansive.defaultTextureCacheBudgetBytes == 768 * 1_048_576)
+    }
+}
+#endif

--- a/LiveWallpaperTests/WPEMetalTextureCacheBudgetTests.swift
+++ b/LiveWallpaperTests/WPEMetalTextureCacheBudgetTests.swift
@@ -37,7 +37,7 @@ struct WPEMetalTextureCacheBudgetTests {
     func memoryTierDefaults() {
         #expect(WPEMemoryTier.constrained.defaultTextureCacheBudgetBytes == 256 * 1_048_576)
         #expect(WPEMemoryTier.standard.defaultTextureCacheBudgetBytes == 512 * 1_048_576)
-        #expect(WPEMemoryTier.expansive.defaultTextureCacheBudgetBytes == nil)
+        #expect(WPEMemoryTier.expansive.defaultTextureCacheBudgetBytes == 768 * 1_048_576)
         #expect(WPEMemoryTier.constrained.lazyAnimationRawByteThreshold == 100_000_000)
         #expect(WPEMemoryTier.standard.lazyAnimationRawByteThreshold == 200_000_000)
         #expect(WPEMemoryTier.expansive.lazyAnimationRawByteThreshold == 200_000_000)
@@ -113,8 +113,10 @@ struct WPEMetalTextureCacheBudgetTests {
         let flat = try makeTexture(mipmapped: false)
         let mipped = try makeTexture(mipmapped: true)
         let base = 64 * 64 * 4
+        // Exact per-level sum for the 7-level chain, not the old x4/3 shortcut.
+        let mipChain = (64 * 64 + 32 * 32 + 16 * 16 + 8 * 8 + 4 * 4 + 2 * 2 + 1) * 4
         #expect(WPEMetalSceneRenderer.textureResidentBytes(for: flat) == base)
-        #expect(WPEMetalSceneRenderer.textureResidentBytes(for: mipped) == base * 4 / 3)
+        #expect(WPEMetalSceneRenderer.textureResidentBytes(for: mipped) == mipChain)
     }
 
     @Test("LRU evicts least-recently-used inactive entries")

--- a/LiveWallpaperTests/WPEMmapPayloadSpanTests.swift
+++ b/LiveWallpaperTests/WPEMmapPayloadSpanTests.swift
@@ -1,0 +1,230 @@
+#if !LITE_BUILD
+import CoreGraphics
+import Foundation
+import LiveWallpaperProWPE
+import Testing
+@testable import LiveWallpaper
+
+@Suite("WPE mmap payload spans")
+struct WPEMmapPayloadSpanTests {
+
+    // MARK: - Span semantics
+
+    @Test("Span windows the owner without copying")
+    func spanWindowsOwnerWithoutCopy() {
+        // >14 bytes: keep the owner heap-backed (inline small-Data storage
+        // has no stable address, which would fail the aliasing assertion).
+        let owner = Data((0..<64).map { UInt8($0) })
+        let span = WPEMappedByteSpan(owner: owner, range: 2..<6)
+
+        #expect(span.count == 4)
+        #expect(span.byte(at: 0) == 2)
+        #expect(span.byte(at: 3) == 5)
+        #expect(span.materializedData() == Data([2, 3, 4, 5]))
+
+        let ownerBase = owner.withUnsafeBytes { $0.baseAddress! }
+        span.withUnsafeBytes { buffer in
+            #expect(buffer.count == 4)
+            #expect(buffer.baseAddress == ownerBase + 2)
+        }
+    }
+
+    @Test("Span prefix clamps and stays within the window")
+    func spanPrefixClamps() {
+        let owner = Data([9, 8, 7, 6, 5])
+        let span = WPEMappedByteSpan(owner: owner, range: 1..<4)
+        #expect(span.prefix(2).materializedData() == Data([8, 7]))
+        #expect(span.prefix(99).materializedData() == Data([8, 7, 6]))
+        #expect(span.prefix(0).isEmpty)
+    }
+
+    @Test("Span equality is content equality")
+    func spanEqualityIsContentEquality() {
+        let a = WPEMappedByteSpan(owner: Data([0, 1, 2, 3]), range: 1..<3)
+        let b = WPEMappedByteSpan(owner: Data([9, 1, 2]), range: 1..<3)
+        let c = WPEMappedByteSpan(owner: Data([1, 2, 3]), range: 0..<3)
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    // MARK: - Decoder produces zero-copy spans
+
+    @Test("Streaming payload mip spans alias the source container bytes")
+    func streamingPayloadSpansAliasSourceBytes() throws {
+        let raw = Data(repeating: 0x5A, count: 4 * 4 * 4)
+        let container = makeStreamingTexContainer(width: 4, height: 4, payloads: [raw, raw])
+
+        let payload = try WPETexDecoder().extractStreamingPayload(data: container).get()
+
+        let containerBase = container.withUnsafeBytes { $0.baseAddress! }
+        for image in payload.compressedImages {
+            let mip = try #require(image.payloads.first)
+            mip.compressedBytes.withUnsafeBytes { buffer in
+                // Aliasing the container proves the parser did not copy the
+                // compressed payload onto the heap (the P1.2 contract).
+                #expect(buffer.baseAddress! >= containerBase)
+                #expect(buffer.baseAddress! + buffer.count <= containerBase + container.count)
+            }
+        }
+    }
+
+    @Test("Windowed parse honors the entry end bound inside a larger owner")
+    func windowedParseHonorsEndBound() throws {
+        let raw = Data(repeating: 0x33, count: 2 * 2 * 4)
+        let container = makeStreamingTexContainer(width: 2, height: 2, payloads: [raw])
+        var packed = Data([0xDE, 0xAD])
+        let start = packed.count
+        packed.append(container)
+        packed.append(Data([0xBE, 0xEF, 0xFE]))
+
+        let window = WPEMappedByteSpan(owner: packed, range: start..<(start + container.count))
+        let payload = try WPETexDecoder().extractStreamingPayload(span: window).get()
+        #expect(payload.compressedImages.count == 1)
+
+        // A short window must fail with truncation, not read the trailer.
+        let shortWindow = WPEMappedByteSpan(owner: packed, range: start..<(start + container.count - 4))
+        #expect(throws: (any Error).self) {
+            try WPETexDecoder().extractStreamingPayload(span: shortWindow).get()
+        }
+    }
+
+    // MARK: - Package provider windows
+
+    @Test("Package provider vends entry windows out of one shared mapping")
+    func packageProviderVendsSharedMappingWindows() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mmap-span-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let texBytes = makeStreamingTexContainer(
+            width: 2, height: 2, payloads: [Data(repeating: 0x44, count: 16)]
+        )
+        let sceneJSON = #"{"k":"v"}"#.data(using: .utf8)!
+        let pkg = makePackageData([
+            (name: "scene.json", data: sceneJSON),
+            (name: "materials/a.tex", data: texBytes)
+        ])
+        let pkgURL = dir.appendingPathComponent("scene.pkg")
+        try pkg.write(to: pkgURL)
+
+        let provider = try WPEPackageSceneAssetProvider(packageURL: pkgURL)
+
+        let texWindow = try provider.mappedWindow(atRelativePath: "materials/a.tex")
+        #expect(texWindow.materializedData() == texBytes)
+
+        let jsonWindow = try provider.mappedWindow(atRelativePath: "scene.json")
+        #expect(jsonWindow.materializedData() == sceneJSON)
+
+        // Both windows share one package mapping (single owner allocation).
+        let texBase = texWindow.owner.withUnsafeBytes { $0.baseAddress! }
+        let jsonBase = jsonWindow.owner.withUnsafeBytes { $0.baseAddress! }
+        #expect(texBase == jsonBase)
+
+        // The window decodes end-to-end.
+        let payload = try WPETexDecoder().extractStreamingPayload(span: texWindow).get()
+        #expect(payload.compressedImages.count == 1)
+
+        #expect(throws: WPESceneAssetProviderError.self) {
+            _ = try provider.mappedWindow(atRelativePath: "missing.tex")
+        }
+    }
+
+    @Test("Directory provider default window wraps the mapped file")
+    func directoryProviderDefaultWindow() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mmap-span-dir-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let bytes = Data((0..<64).map { UInt8($0) })
+        try bytes.write(to: dir.appendingPathComponent("materials.tex"))
+
+        let provider = WPEDirectorySceneAssetProvider(rootURL: dir)
+        let window = try provider.mappedWindow(atRelativePath: "materials.tex")
+        #expect(window.count == bytes.count)
+        #expect(window.materializedData() == bytes)
+    }
+
+    // MARK: - Fixtures
+
+    private func makePackageData(_ entries: [(name: String, data: Data)]) -> Data {
+        func u32(_ value: UInt32) -> Data {
+            withUnsafeBytes(of: value.littleEndian) { Data($0) }
+        }
+        var header = Data()
+        let magic = "PKGV0001"
+        header.append(u32(UInt32(magic.utf8.count)))
+        header.append(contentsOf: magic.utf8)
+        header.append(u32(UInt32(entries.count)))
+        var blob = Data()
+        var offset: UInt32 = 0
+        for entry in entries {
+            let nameBytes = Array(entry.name.utf8)
+            header.append(u32(UInt32(nameBytes.count)))
+            header.append(contentsOf: nameBytes)
+            header.append(u32(offset))
+            header.append(u32(UInt32(entry.data.count)))
+            blob.append(entry.data)
+            offset += UInt32(entry.data.count)
+        }
+        return header + blob
+    }
+
+    /// Minimal TEXV0005 container: TEXB0004 with N uncompressed RGBA8888
+    /// images + a TEXS0002 schedule (multi-frame ⇒ streaming-extractable).
+    private func makeStreamingTexContainer(width: Int, height: Int, payloads: [Data]) -> Data {
+        var buffer = Data()
+        func magic(_ value: String) {
+            buffer.append(contentsOf: value.utf8)
+            buffer.append(0x00)
+        }
+        func i32(_ value: Int32) {
+            withUnsafeBytes(of: value.littleEndian) { buffer.append(contentsOf: $0) }
+        }
+        func u32(_ value: UInt32) {
+            withUnsafeBytes(of: value.littleEndian) { buffer.append(contentsOf: $0) }
+        }
+        func f32(_ value: Float) {
+            withUnsafeBytes(of: value.bitPattern.littleEndian) { buffer.append(contentsOf: $0) }
+        }
+
+        magic("TEXV0005")
+        magic("TEXI0001")
+        i32(Int32(WPETexFormat.rgba8888.rawValue))
+        u32(0)
+        i32(Int32(width))
+        i32(Int32(height))
+        i32(Int32(width))
+        i32(Int32(height))
+        i32(0)
+
+        magic("TEXB0004")
+        i32(Int32(payloads.count))
+        i32(-1)
+        i32(0)
+        for payload in payloads {
+            i32(1) // mip count
+            i32(Int32(width))
+            i32(Int32(height))
+            u32(0) // not LZ4
+            u32(UInt32(payload.count))
+            u32(UInt32(payload.count))
+            buffer.append(payload)
+        }
+
+        magic("TEXS0002")
+        i32(Int32(payloads.count))
+        for imageID in payloads.indices {
+            i32(Int32(imageID))
+            f32(0.1)
+            f32(0)
+            f32(0)
+            f32(Float(width))
+            f32(0)
+            f32(0)
+            f32(Float(height))
+        }
+        return buffer
+    }
+}
+#endif

--- a/LiveWallpaperTests/WPEParticleSlotIndexTests.swift
+++ b/LiveWallpaperTests/WPEParticleSlotIndexTests.swift
@@ -1,0 +1,86 @@
+import Testing
+@testable import LiveWallpaper
+
+/// The slot index must reproduce the old linear pool scans exactly: lowest-free
+/// selection and ascending live iteration preserve RNG consumption order, draw
+/// order, and spawn-event order.
+struct WPEParticleSlotIndexTests {
+
+    @Test("Lowest free slot matches a linear scan, across word boundaries")
+    func lowestFreeSelection() {
+        var index = WPEParticleSlotIndex(capacity: 200)
+        #expect(index.lowestFreeSlot == 0)
+        for slot in 0..<200 { index.markLive(slot) }
+        #expect(index.lowestFreeSlot == nil)
+        index.markDead(137)
+        #expect(index.lowestFreeSlot == 137)
+        index.markDead(64)  // first bit of the second word
+        #expect(index.lowestFreeSlot == 64)
+        index.markDead(63)  // last bit of the first word
+        #expect(index.lowestFreeSlot == 63)
+        index.markLive(63)
+        index.markLive(64)
+        #expect(index.lowestFreeSlot == 137)
+    }
+
+    @Test("Live iteration is ascending and crosses word boundaries")
+    func ascendingIteration() {
+        var index = WPEParticleSlotIndex(capacity: 200)
+        let slots = [0, 5, 63, 64, 65, 127, 128, 199]
+        for slot in slots.shuffled() { index.markLive(slot) }
+        var seen: [Int] = []
+        index.forEachLiveSlot { seen.append($0) }
+        #expect(seen == slots)
+    }
+
+    @Test("markDead removes exactly one slot")
+    func deathClearsOneSlot() {
+        var index = WPEParticleSlotIndex(capacity: 128)
+        for slot in [3, 64, 66] { index.markLive(slot) }
+        index.markDead(64)
+        var seen: [Int] = []
+        index.forEachLiveSlot { seen.append($0) }
+        #expect(seen == [3, 66])
+        #expect(!index.isLive(64))
+        #expect(index.isLive(66))
+    }
+
+    @Test("Capacity not divisible by 64 never yields a phantom free slot")
+    func partialTailWord() {
+        var index = WPEParticleSlotIndex(capacity: 70)
+        for slot in 0..<70 { index.markLive(slot) }
+        #expect(index.lowestFreeSlot == nil)
+        index.markDead(69)
+        #expect(index.lowestFreeSlot == 69)
+    }
+
+    @Test("8192-capacity edge: last slot allocates, frees, and iterates")
+    func absoluteCapEdge() {
+        let cap = WPEParticleSystem.absoluteCap
+        var index = WPEParticleSlotIndex(capacity: cap)
+        for slot in 0..<cap { index.markLive(slot) }
+        #expect(index.lowestFreeSlot == nil)
+        index.markDead(cap - 1)
+        #expect(index.lowestFreeSlot == cap - 1)
+        var count = 0
+        var last = -1
+        index.forEachLiveSlot { slot in
+            #expect(slot > last)
+            last = slot
+            count += 1
+        }
+        #expect(count == cap - 1)
+        #expect(last == cap - 2)
+    }
+
+    @Test("removeAll clears every word")
+    func removeAllClears() {
+        var index = WPEParticleSlotIndex(capacity: 8192)
+        for slot in stride(from: 0, to: 8192, by: 61) { index.markLive(slot) }
+        index.removeAll()
+        var seen = 0
+        index.forEachLiveSlot { _ in seen += 1 }
+        #expect(seen == 0)
+        #expect(index.lowestFreeSlot == 0)
+    }
+}

--- a/LiveWallpaperTests/WPEPointerMailboxTests.swift
+++ b/LiveWallpaperTests/WPEPointerMailboxTests.swift
@@ -220,6 +220,27 @@ struct WPEPointerPublisherTests {
         #expect(publisher.isRunning == false)
     }
 
+    @Test("isRunning tracks monitor installation, not the start/stop lifecycle")
+    func isRunningTracksMonitorInstallation() {
+        let publisher = WPEPointerPublisher(mailbox: WPEPointerMailbox(), view: nil)
+        publisher.start()
+        defer { publisher.stop() }
+        // Relative asserts: monitor installation can fail in a headless runner,
+        // so compare against the started+enabled state instead of literal true.
+        let runningWhileEnabled = publisher.isRunning
+
+        publisher.setMouseMonitoringEnabled(false)
+        #expect(publisher.isRunning == false)
+
+        publisher.setMouseMonitoringEnabled(true)
+        #expect(publisher.isRunning == runningWhileEnabled)
+
+        // Gating while stopped installs nothing.
+        publisher.stop()
+        publisher.setMouseMonitoringEnabled(true)
+        #expect(publisher.isRunning == false)
+    }
+
     @Test("start seeds geometry into the mailbox")
     func startSeedsGeometry() {
         let mailbox = WPEPointerMailbox()

--- a/LiveWallpaperTests/WPERenderThreadDrainRuntimeTests.swift
+++ b/LiveWallpaperTests/WPERenderThreadDrainRuntimeTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import LiveWallpaper
+
+// C4 runtime lock: autoreleased objects created by render-thread ticks must be
+// released at tick cadence, never accumulate until thread exit (~0.5 MB/frame
+// of fabricated growth when this regressed). Scope, established by probes on
+// Darwin 27 (2026-08): CoreFoundation wraps every run-loop callout in its own
+// autorelease pool, so tick workloads drain even with the explicit
+// per-iteration `autoreleasepool` removed — this suite verifies the end-to-end
+// cadence property on the real loop but CANNOT distinguish our pool from the
+// OS's on current macOS; `runLoopUsesIterationAutoreleasePool` (source
+// characterization) remains the guard for the wrapper itself.
+
+private final class TickCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    func increment() { lock.lock(); value += 1; lock.unlock() }
+    var count: Int { lock.lock(); defer { lock.unlock() }; return value }
+}
+
+/// NSObject so `Unmanaged.autorelease()` parks a +1 in the render thread's
+/// innermost pool; `deinit` fires only when that pool pops.
+private final class PoolCanary: NSObject {
+    private let onDeinit: @Sendable () -> Void
+    init(onDeinit: @escaping @Sendable () -> Void) { self.onDeinit = onDeinit }
+    deinit { onDeinit() }
+}
+
+private final class DrainProbe: @unchecked Sendable {
+    let executed = TickCounter()
+    let deallocated = TickCounter()
+}
+
+/// One "frame": runs on the render thread per signaled source0 tick. Source
+/// handling is what makes `CFRunLoopRunInMode(..., true)` return, so a drained
+/// loop must release the canary right after this returns — a display-link
+/// frame stand-in without any Metal dependency.
+private func drainProbeTick(_ info: UnsafeMutableRawPointer?) {
+    guard let info else { return }
+    let probe = Unmanaged<DrainProbe>.fromOpaque(info).takeUnretainedValue()
+    let canary = PoolCanary { probe.deallocated.increment() }
+    Unmanaged.passRetained(canary).autorelease()
+    probe.executed.increment()
+}
+
+private final class SourceHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedSource: CFRunLoopSource?
+    private var storedLoop: CFRunLoop?
+
+    func store(source: CFRunLoopSource, loop: CFRunLoop) {
+        lock.lock()
+        storedSource = source
+        storedLoop = loop
+        lock.unlock()
+    }
+
+    var pair: (source: CFRunLoopSource, loop: CFRunLoop)? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let storedSource, let storedLoop else { return nil }
+        return (storedSource, storedLoop)
+    }
+}
+
+struct WPERenderThreadDrainRuntimeTests {
+
+    @Test("each handled tick's autoreleased objects are released before the next tick, not at thread exit")
+    func autoreleasedTickObjectsDrainPerIteration() async {
+        let thread = WPERenderThread(label: "test.drain.runtime")
+        let probe = DrainProbe()
+        let holder = SourceHolder()
+
+        thread.perform {
+            var context = CFRunLoopSourceContext()
+            context.info = Unmanaged.passUnretained(probe).toOpaque()
+            context.perform = drainProbeTick
+            guard let source = CFRunLoopSourceCreate(nil, 0, &context) else { return }
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .defaultMode)
+            holder.store(source: source, loop: CFRunLoopGetCurrent())
+        }
+        let installed = await eventually { holder.pair != nil }
+        #expect(installed, "tick source never installed on the render loop")
+        guard let (source, loop) = holder.pair else {
+            thread.shutdown()
+            return
+        }
+
+        let ticks = 5
+        for tick in 1 ... ticks {
+            CFRunLoopSourceSignal(source)
+            CFRunLoopWakeUp(loop)
+            let ran = await eventually { probe.executed.count == tick }
+            #expect(ran, "tick \(tick) never ran (executed=\(probe.executed.count))")
+            let drained = await eventually { probe.deallocated.count == tick }
+            #expect(
+                drained,
+                """
+                tick \(tick)'s autoreleased canary is still alive after the loop pass \
+                (deallocated=\(probe.deallocated.count), executed=\(probe.executed.count)) — \
+                no autorelease pool is draining tick temporaries at tick cadence
+                """
+            )
+        }
+
+        #expect(probe.executed.count == ticks)
+        #expect(probe.deallocated.count == ticks)
+        thread.shutdown()
+    }
+}
+
+private func eventually(
+    timeout: Duration = .seconds(5),
+    _ condition: @escaping @Sendable () -> Bool
+) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while clock.now < deadline {
+        if condition() { return true }
+        try? await Task.sleep(for: .milliseconds(1))
+    }
+    return condition()
+}

--- a/LiveWallpaperTests/WPERendererOwnershipCharacterizationTests.swift
+++ b/LiveWallpaperTests/WPERendererOwnershipCharacterizationTests.swift
@@ -405,6 +405,9 @@
                     "previousFrameHistory = nil",
                     "outputTexturePool.removeAll()",
                     "bootstrapPreviousTextureCache.removeAll()",
+                    // Size/format-keyed; rebuilt on miss, so stale-scene entries
+                    // are dropped with the other transients instead of leaking.
+                    "sceneReadHazardSnapshotCache.removeAll()",
                     "compiledShaderResultByPassID.removeAll()",
                 ]
             )
@@ -415,7 +418,6 @@
                 "customSamplerStateCache",
                 "textGlyphPipelineCache",
                 "particlePipelineCache",
-                "sceneReadHazardSnapshotCache",
                 "refractionBackground",
                 "pipelineCache",
                 "depthCache",

--- a/LiveWallpaperTests/WPERendererOwnershipCharacterizationTests.swift
+++ b/LiveWallpaperTests/WPERendererOwnershipCharacterizationTests.swift
@@ -53,13 +53,16 @@
                         "let metalLayer: WPEPresentLayer",
                         "let executor: WPEMetalRenderExecutor",
                         "var outputTexture: MTLTexture?",
+                        // Mutable since committed property patches update it
+                        // (actor-side) so in-place reloads rebuild the patched
+                        // scene instead of reverting edits.
+                        "var descriptor: SceneDescriptor",
                     ]
                 ),
                 SourceEvidence(
                     owner: "currently per-renderer immutable inputs and helpers",
                     source: renderer,
                     needles: [
-                        "let descriptor: SceneDescriptor",
                         "let dependencyMounts: [WPEAssetMount]",
                         "let resourceResolver: WPEMultiRootResourceResolver",
                         "let textureLoader: WPEMetalTextureLoader",
@@ -284,6 +287,7 @@
             let load = try sourceBlock(loadSource, from: "func load(on actor: isolated WPEDisplayRenderActor) async throws")
             let performLoad = try sourceBlock(loadSource, from: "private func performLoad(")
             let reload = try sourceBlock(lifecycleSource, from: "func reload(on actor: isolated WPEDisplayRenderActor) async throws")
+            let retire = try sourceBlock(lifecycleSource, from: "func retireRuntimeState(on actor: isolated WPEDisplayRenderActor) async")
             let cleanup = try sourceBlock(lifecycleSource, from: "func cleanup()")
             let releaseDynamic = try sourceBlock(textureSource, from: "func releaseDynamicTextureSources()")
             let renderFrame = try sourceBlock(frameSource, from: "func renderCurrentFrame(inputs: WPEFrameInputs) throws")
@@ -322,8 +326,18 @@
                     "didLoad = true",
                 ]
             )
+            // The teardown body moved into `retireRuntimeState` (shared with
+            // hibernate); `reload` must stay exactly retire-then-load.
+            expectOrder(
+                [
+                    "await retireRuntimeState(on: actor)",
+                    "try await load(on: actor)",
+                ],
+                in: reload,
+                owner: "reload teardown"
+            )
             expectContains(
-                reload,
+                retire,
                 owner: "reload teardown",
                 [
                     "loadGeneration &+= 1",
@@ -331,7 +345,6 @@
                     "releaseDynamicTextureSources()",
                     "clearSceneScriptRuntimeState()",
                     "executor.releaseTransientResources()",
-                    "try await load(on: actor)",
                 ]
             )
             expectContains(
@@ -523,6 +536,7 @@
             let upload = try sourceBlock(uploadSource, from: "func perform<T>(")
             let rendererLoad = try sourceBlock(loadSource, from: "func load(on actor: isolated WPEDisplayRenderActor) async throws")
             let rendererReload = try sourceBlock(lifecycleSource, from: "func reload(on actor: isolated WPEDisplayRenderActor) async throws")
+            let rendererRetire = try sourceBlock(lifecycleSource, from: "func retireRuntimeState(on actor: isolated WPEDisplayRenderActor) async")
             let rendererCleanup = try sourceBlock(lifecycleSource, from: "func cleanup()")
 
             expectContains(
@@ -601,6 +615,13 @@
                     "loadGeneration &+= 1",
                     "await staticTextureReloadDrain.wait()",
                     "releaseDynamicTextureSources()",
+                ],
+                in: rendererRetire,
+                owner: "renderer reload task drain"
+            )
+            expectOrder(
+                [
+                    "await retireRuntimeState(on: actor)",
                     "try await load(on: actor)",
                 ],
                 in: rendererReload,

--- a/LiveWallpaperTests/WPESceneHibernateTests.swift
+++ b/LiveWallpaperTests/WPESceneHibernateTests.swift
@@ -7,6 +7,7 @@ import LiveWallpaperCore
 import LiveWallpaperProWPE
 import Metal
 import MetalKit
+import os
 import Testing
 @testable import LiveWallpaper
 
@@ -182,6 +183,212 @@ struct WPESceneHibernateTests {
         #expect(snapshot?.isLoaded == true)
     }
 
+    @Test("Manually paused session hibernates after its own dwell and unpause reloads")
+    func manualPauseHibernatesAfterOwnDwell() async throws {
+        // Absence dwell is effectively infinite so only the pause class can fire.
+        let harness = try HibernateSessionHarness.make(
+            hibernationDelay: .seconds(3600),
+            userPauseHibernationDelay: .milliseconds(50)
+        )
+        defer { harness.teardown() }
+        let session = harness.session
+        try await Self.poll("initial load") {
+            await harness.actor.rendererStateSnapshot()?.isLoaded == true
+        }
+
+        session.pause()
+        // Routine policy refreshes push absence ineligibility constantly; they
+        // must not cancel the pause-class dwell.
+        session.setHibernationEligible(false)
+        try await Self.poll("hibernate after pause dwell") { session.isHibernated }
+        let hibernatedSnapshot = await harness.actor.rendererStateSnapshot()
+        #expect(hibernatedSnapshot?.isLoaded == false)
+
+        session.play()
+        try await Self.poll("wake reload after unpause") {
+            guard session.isHibernated == false else { return false }
+            return await harness.actor.rendererStateSnapshot()?.isLoaded == true
+        }
+        #expect(session.loadError == nil)
+    }
+
+    @Test("Unpausing before the pause dwell elapses cancels it")
+    func unpauseBeforePauseDwellCancels() async throws {
+        let harness = try HibernateSessionHarness.make(
+            hibernationDelay: .seconds(3600),
+            userPauseHibernationDelay: .milliseconds(120)
+        )
+        defer { harness.teardown() }
+        let session = harness.session
+        try await Self.poll("initial load") {
+            await harness.actor.rendererStateSnapshot()?.isLoaded == true
+        }
+
+        session.pause()
+        session.play()
+        try await Task.sleep(for: .milliseconds(400))
+        #expect(!session.isHibernated)
+        let snapshot = await harness.actor.rendererStateSnapshot()
+        #expect(snapshot?.isLoaded == true)
+    }
+
+    @Test("Critical memory pressure hibernates immediately, bypassing every dwell")
+    func criticalPressureBypassesDwell() async throws {
+        let harness = try HibernateSessionHarness.make(
+            hibernationDelay: .seconds(3600),
+            userPauseHibernationDelay: .seconds(3600)
+        )
+        defer { harness.teardown() }
+        let session = harness.session
+        try await Self.poll("initial load") {
+            await harness.actor.rendererStateSnapshot()?.isLoaded == true
+        }
+
+        session.applyPerformanceProfile(.suspended)
+        session.setCriticalMemoryPressureActive(true)
+        try await Self.poll("immediate hibernate") { session.isHibernated }
+        let hibernatedSnapshot = await harness.actor.rendererStateSnapshot()
+        #expect(hibernatedSnapshot?.isLoaded == false)
+
+        // Pressure cleared: the policy refresh restores quality and wakes.
+        session.applyPerformanceProfile(.quality)
+        try await Self.poll("wake reload after pressure clears") {
+            guard session.isHibernated == false else { return false }
+            return await harness.actor.rendererStateSnapshot()?.isLoaded == true
+        }
+        #expect(session.loadError == nil)
+    }
+
+    @Test("Critical pressure from the watcher hibernates an installed scene session")
+    func criticalPressureWatcherHibernatesInstalledScene() async throws {
+        let nsScreen = try #require(NSScreen.screens.first)
+        let screen = Screen(nsScreen: nsScreen)
+        let watcher = HibernateFakePressureWatcher()
+        let harness = try HibernateSessionHarness.make(
+            hibernationDelay: .seconds(3600),
+            userPauseHibernationDelay: .seconds(3600)
+        )
+        let manager = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: FakePlayableVideoLoader(),
+            displayRegistry: FakeDisplayRegistry(screens: [screen]),
+            memoryPressureWatcher: watcher,
+            featureCatalog: FeatureCatalog(capabilities: .pro)
+        ))
+        defer {
+            manager.tearDownForTermination()
+            harness.fixture.cleanup()
+        }
+        let liveScreen = try #require(manager.screens.first(where: { $0.id == screen.id }))
+        liveScreen.installRuntimeSession(harness.session)
+        try await Self.poll("initial load") {
+            await harness.actor.rendererStateSnapshot()?.isLoaded == true
+        }
+
+        watcher.emit(.critical)
+        try await Self.poll("watcher-driven immediate hibernate") {
+            harness.session.isHibernated
+        }
+        #expect(manager.isUnderMemoryPressure)
+        let snapshot = await harness.actor.rendererStateSnapshot()
+        #expect(snapshot?.isLoaded == false)
+    }
+
+    @Test("A scene installed while pressure is already critical still hibernates")
+    func sessionInstalledUnderCriticalPressureHibernates() async throws {
+        let nsScreen = try #require(NSScreen.screens.first)
+        let screen = Screen(nsScreen: nsScreen)
+        let watcher = HibernateFakePressureWatcher()
+        let harness = try HibernateSessionHarness.make(
+            hibernationDelay: .seconds(3600),
+            userPauseHibernationDelay: .seconds(3600)
+        )
+        let manager = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: FakePlayableVideoLoader(),
+            displayRegistry: FakeDisplayRegistry(screens: [screen]),
+            memoryPressureWatcher: watcher,
+            featureCatalog: FeatureCatalog(capabilities: .pro)
+        ))
+        defer {
+            manager.tearDownForTermination()
+            harness.fixture.cleanup()
+        }
+
+        // Pressure is critical BEFORE the wallpaper exists — the restore-at-launch
+        // and swap-in cases. A level-change-only push never reaches this session.
+        watcher.emit(.critical)
+        // The watcher hop is a MainActor Task — drain it so the level change is
+        // fully applied BEFORE the session exists. Without this barrier the
+        // install races ahead and the test degenerates into the already-covered
+        // "pressure arrives after install" ordering.
+        try await Self.poll("pressure applied before install") {
+            manager.isUnderMemoryPressure
+        }
+        let liveScreen = try #require(manager.screens.first(where: { $0.id == screen.id }))
+        liveScreen.installRuntimeSession(harness.session)
+        try await Self.poll("initial load") {
+            await harness.actor.rendererStateSnapshot()?.isLoaded == true
+        }
+        manager.refreshPerformancePolicyForAllScreens()
+
+        try await Self.poll("hibernate under standing critical pressure") {
+            harness.session.isHibernated
+        }
+        let snapshot = await harness.actor.rendererStateSnapshot()
+        #expect(snapshot?.isLoaded == false)
+    }
+
+    @Test("Pressure returning to normal revokes the critical-pressure dwell")
+    func normalPressureRevokesCriticalDwell() async throws {
+        let nsScreen = try #require(NSScreen.screens.first)
+        let screen = Screen(nsScreen: nsScreen)
+        let watcher = HibernateFakePressureWatcher()
+        // Long dwells: only the critical path could hibernate inside the poll
+        // window, so a hibernate here proves the emergency outlived the emergency.
+        let harness = try HibernateSessionHarness.make(
+            hibernationDelay: .seconds(3600),
+            userPauseHibernationDelay: .seconds(3600)
+        )
+        let manager = ScreenManager(startupOptions: ScreenManagerStartupOptions(
+            restoreSavedWallpapers: false,
+            startAutomation: false,
+            powerMonitor: FakePowerMonitor(),
+            fullScreenDetector: FakeFullScreenDetector(),
+            playableVideoLoader: FakePlayableVideoLoader(),
+            displayRegistry: FakeDisplayRegistry(screens: [screen]),
+            memoryPressureWatcher: watcher,
+            featureCatalog: FeatureCatalog(capabilities: .pro)
+        ))
+        defer {
+            manager.tearDownForTermination()
+            harness.fixture.cleanup()
+        }
+        let liveScreen = try #require(manager.screens.first(where: { $0.id == screen.id }))
+        liveScreen.installRuntimeSession(harness.session)
+        try await Self.poll("initial load") {
+            await harness.actor.rendererStateSnapshot()?.isLoaded == true
+        }
+
+        // User pauses (its own 3600s dwell), then a pressure spike comes and goes
+        // while the session stays suspended for that unrelated reason.
+        harness.session.pause()
+        watcher.emit(.critical)
+        watcher.emit(.normal)
+
+        try? await Task.sleep(for: .milliseconds(1500))
+        #expect(
+            harness.session.isHibernated == false,
+            "Critical-pressure dwell survived the pressure and hibernated on its 1s retry cadence, bypassing the manual-pause dwell"
+        )
+    }
+
     // MARK: - Helpers
 
     private static func poll(
@@ -218,6 +425,88 @@ struct WPESceneHibernateTests {
         return SHA256.hash(data: Data(bytes))
             .map { String(format: "%02x", $0) }
             .joined()
+    }
+}
+
+/// Loaded-session fixture for dwell-policy tests: real renderer + actor +
+/// window, with both hibernation dwells injectable.
+@MainActor
+private struct HibernateSessionHarness {
+    let fixture: FrameDemandFixture
+    let actor: WPEDisplayRenderActor
+    let session: SceneWallpaperSession
+
+    static func make(
+        hibernationDelay: Duration,
+        userPauseHibernationDelay: Duration
+    ) throws -> Self {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try FrameDemandFixture.make()
+        let surface = WPERenderSurface(frame: CGRect(x: 0, y: 0, width: 64, height: 64), device: device)
+        let actor = WPEDisplayRenderActor(backing: .main)
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.root,
+            projectManifestRootURL: fixture.root,
+            dependencyMounts: [],
+            surfaceControl: surface,
+            mailbox: surface.mailbox,
+            presentLayer: WPEPresentLayer(layer: surface.metalLayer),
+            drawableSize: surface.metalLayer.drawableSize,
+            device: device,
+            pointerSampler: .fixed(SIMD2<Double>(0.5, 0.5))
+        )
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 64, height: 64),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: true
+        )
+        window.isReleasedWhenClosed = false
+        let session = SceneWallpaperSession(
+            window: window,
+            renderActor: actor,
+            surface: surface,
+            audioCaptureDemandController: HibernateStubAudioDemand(),
+            hibernationDelay: hibernationDelay,
+            userPauseHibernationDelay: userPauseHibernationDelay
+        )
+        session.startAdoptingRenderer(WPERendererHandoff(renderer: renderer))
+        return Self(fixture: fixture, actor: actor, session: session)
+    }
+
+    func teardown() {
+        session.cleanup()
+        fixture.cleanup()
+    }
+}
+
+private final class HibernateFakePressureWatcher: MemoryPressureWatching {
+    private struct State {
+        var level = SystemMemoryPressureLevel.normal
+        var handler: SystemMemoryPressureChangeHandler?
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func start(onChange: SystemMemoryPressureChangeHandler?) {
+        state.withLock { $0.handler = onChange }
+    }
+
+    func stop() {
+        state.withLock { $0.handler = nil }
+    }
+
+    func currentLevel() -> SystemMemoryPressureLevel {
+        state.withLock { $0.level }
+    }
+
+    func emit(_ level: SystemMemoryPressureLevel) {
+        let handler = state.withLock { state -> SystemMemoryPressureChangeHandler? in
+            state.level = level
+            return state.handler
+        }
+        handler?(level)
     }
 }
 

--- a/LiveWallpaperTests/WPESceneHibernateTests.swift
+++ b/LiveWallpaperTests/WPESceneHibernateTests.swift
@@ -1,0 +1,235 @@
+#if !LITE_BUILD
+import AppKit
+import CoreGraphics
+import CryptoKit
+import Foundation
+import LiveWallpaperCore
+import LiveWallpaperProWPE
+import Metal
+import MetalKit
+import Testing
+@testable import LiveWallpaper
+
+@MainActor
+@Suite("WPE deep hibernate", .serialized)
+struct WPESceneHibernateTests {
+    @Test("Hibernate releases the loaded runtime state and reload restores the same frame")
+    func hibernateReleasesAndReloadRestoresFrame() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try FrameDemandFixture.make()
+        defer { fixture.cleanup() }
+        let stack = try FrameDemandRendererStack.make(fixture)
+        let renderer = stack.renderer
+        defer { renderer.cleanup() }
+        try await stack.load()
+
+        let hashBefore = try Self.textureSHA256(try #require(renderer.outputTexture))
+
+        // Sentinels prove the release paths run even though the fixture scene is
+        // texture-free: hibernate must sweep static textures, dynamic sources,
+        // particles, and on-demand bookkeeping alike.
+        renderer.loadedTextures["sentinel"] = try Self.makeTexture(device: device)
+        renderer.dynamicTextureSources["sentinel"] = HibernateStubSource()
+        renderer.onDemandVideoKeyByID = ["obj": "sentinel"]
+        renderer.particleSystems = [try #require(WPEParticleSystem(
+            definition: WPEParticleDefinitionParser.parse(dictionary: [
+                "maxcount": 8,
+                "emitter": [["rate": 5]],
+            ]),
+            device: device,
+            seed: 0xB3
+        ))]
+
+        renderer.applyPerformanceProfile(.suspended)
+        #expect(stack.surface.mtkView.isPaused)
+
+        let hibernated = await stack.actor.hibernate()
+        #expect(hibernated)
+        #expect(!renderer.didLoad)
+        #expect(renderer.loadedTextures.isEmpty)
+        #expect(renderer.dynamicTextureSources.isEmpty)
+        #expect(renderer.onDemandVideoKeyByID.isEmpty)
+        #expect(renderer.particleSystems.isEmpty)
+        #expect(renderer.renderPipeline == nil)
+        #expect(renderer.outputTexture == nil)
+        #expect(renderer.soundRuntime == nil)
+        // Production side stays stopped while hibernated: the surface is paused
+        // and a stray draw callback renders nothing.
+        #expect(stack.surface.mtkView.isPaused)
+        renderer.renderAndPresentFrame()
+        #expect(renderer.outputTexture == nil)
+
+        // Wake = plain reload; the rebuilt first frame must match the original.
+        try await stack.actor.reload()
+        renderer.applyPerformanceProfile(.quality)
+        #expect(renderer.didLoad)
+        let hashAfter = try Self.textureSHA256(try #require(renderer.outputTexture))
+        #expect(hashAfter == hashBefore)
+    }
+
+    @Test("Hibernate refuses when nothing is loaded")
+    func hibernateWithoutLoadIsRejected() async throws {
+        let fixture = try FrameDemandFixture.make()
+        defer { fixture.cleanup() }
+        let stack = try FrameDemandRendererStack.make(fixture)
+        defer { stack.renderer.cleanup() }
+        await stack.actor.adopt(WPERendererHandoff(renderer: stack.renderer).renderer)
+
+        let hibernated = await stack.actor.hibernate()
+        #expect(hibernated == false)
+    }
+
+    @Test("Session hibernates after the eligibility dwell and wakes with a reload")
+    func sessionHibernatesAndWakes() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try FrameDemandFixture.make()
+        defer { fixture.cleanup() }
+        let surface = WPERenderSurface(frame: CGRect(x: 0, y: 0, width: 64, height: 64), device: device)
+        let actor = WPEDisplayRenderActor(backing: .main)
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.root,
+            projectManifestRootURL: fixture.root,
+            dependencyMounts: [],
+            surfaceControl: surface,
+            mailbox: surface.mailbox,
+            presentLayer: WPEPresentLayer(layer: surface.metalLayer),
+            drawableSize: surface.metalLayer.drawableSize,
+            device: device,
+            pointerSampler: .fixed(SIMD2<Double>(0.5, 0.5))
+        )
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 64, height: 64),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: true
+        )
+        window.isReleasedWhenClosed = false
+        let session = SceneWallpaperSession(
+            window: window,
+            renderActor: actor,
+            surface: surface,
+            audioCaptureDemandController: HibernateStubAudioDemand(),
+            hibernationDelay: .milliseconds(50)
+        )
+        defer { session.cleanup() }
+        session.startAdoptingRenderer(WPERendererHandoff(renderer: renderer))
+        try await Self.poll("initial load") {
+            await actor.rendererStateSnapshot()?.isLoaded == true
+        }
+
+        session.applyPerformanceProfile(.suspended)
+        session.setHibernationEligible(true)
+        try await Self.poll("hibernate after dwell") { session.isHibernated }
+        let hibernatedSnapshot = await actor.rendererStateSnapshot()
+        #expect(hibernatedSnapshot?.isLoaded == false)
+
+        session.applyPerformanceProfile(.quality)
+        try await Self.poll("wake reload") {
+            // `&&`'s right operand is a non-async autoclosure, so the await
+            // must live in its own statement.
+            guard session.isHibernated == false else { return false }
+            return await actor.rendererStateSnapshot()?.isLoaded == true
+        }
+        #expect(session.loadError == nil)
+    }
+
+    @Test("Eligibility flapping cancels the dwell instead of hibernating")
+    func eligibilityFlapCancelsDwell() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let fixture = try FrameDemandFixture.make()
+        defer { fixture.cleanup() }
+        let surface = WPERenderSurface(frame: CGRect(x: 0, y: 0, width: 64, height: 64), device: device)
+        let actor = WPEDisplayRenderActor(backing: .main)
+        let renderer = try WPEMetalSceneRenderer(
+            descriptor: fixture.descriptor,
+            cacheRootURL: fixture.root,
+            projectManifestRootURL: fixture.root,
+            dependencyMounts: [],
+            surfaceControl: surface,
+            mailbox: surface.mailbox,
+            presentLayer: WPEPresentLayer(layer: surface.metalLayer),
+            drawableSize: surface.metalLayer.drawableSize,
+            device: device,
+            pointerSampler: .fixed(SIMD2<Double>(0.5, 0.5))
+        )
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 64, height: 64),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: true
+        )
+        window.isReleasedWhenClosed = false
+        let session = SceneWallpaperSession(
+            window: window,
+            renderActor: actor,
+            surface: surface,
+            audioCaptureDemandController: HibernateStubAudioDemand(),
+            hibernationDelay: .milliseconds(80)
+        )
+        defer { session.cleanup() }
+        session.startAdoptingRenderer(WPERendererHandoff(renderer: renderer))
+        try await Self.poll("initial load") {
+            await actor.rendererStateSnapshot()?.isLoaded == true
+        }
+
+        session.applyPerformanceProfile(.suspended)
+        session.setHibernationEligible(true)
+        session.setHibernationEligible(false)
+        try await Task.sleep(for: .milliseconds(250))
+        #expect(!session.isHibernated)
+        let snapshot = await actor.rendererStateSnapshot()
+        #expect(snapshot?.isLoaded == true)
+    }
+
+    // MARK: - Helpers
+
+    private static func poll(
+        _ label: String,
+        timeout: Duration = .seconds(10),
+        until condition: @MainActor () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        Issue.record("Timed out waiting for: \(label)")
+    }
+
+    private static func makeTexture(device: MTLDevice) throws -> MTLTexture {
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .rgba8Unorm, width: 4, height: 4, mipmapped: false
+        )
+        return try #require(device.makeTexture(descriptor: descriptor))
+    }
+
+    private static func textureSHA256(_ texture: MTLTexture) throws -> String {
+        try #require(texture.pixelFormat == .rgba8Unorm || texture.pixelFormat == .rgba8Unorm_srgb)
+        let bytesPerRow = texture.width * 4
+        var bytes = [UInt8](repeating: 0, count: bytesPerRow * texture.height)
+        texture.getBytes(
+            &bytes,
+            bytesPerRow: bytesPerRow,
+            from: MTLRegionMake2D(0, 0, texture.width, texture.height),
+            mipmapLevel: 0
+        )
+        return SHA256.hash(data: Data(bytes))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}
+
+private final class HibernateStubSource: WPEDynamicTextureSource {
+    func texture(at time: TimeInterval) -> MTLTexture? { nil }
+    func applyPerformanceProfile(_ profile: WallpaperPerformanceProfile) {}
+    func invalidate() {}
+}
+
+@MainActor
+private final class HibernateStubAudioDemand: SystemAudioCaptureDemandControlling {
+    func retain() {}
+    func release() {}
+}
+#endif

--- a/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
+++ b/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
@@ -2820,6 +2820,8 @@ export function init(value) {
         )
 
         #expect(instance.tick(pointerPosition: SIMD2<Double>(0.5, 0.5)) == nil)
+        // WPEScriptFaultPolicy backoff: the tick after a failure is skipped.
+        #expect(instance.tick(pointerPosition: SIMD2<Double>(0.5, 0.5)) == nil)
         #expect(
             instance.tick(pointerPosition: SIMD2<Double>(0.5, 0.5)) == SIMD3<Double>(999, 20, 30)
         )
@@ -2945,6 +2947,8 @@ export function init(value) {
             shared: shared
         )
         _ = producer.tick(runtimeSeconds: 0, pointerFrame: .neutral)
+        // WPEScriptFaultPolicy backoff: the tick after the throw is skipped.
+        #expect(instance.tickString() == "placeholder")
         #expect(instance.tickString() == "[1.50]")
     }
 

--- a/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
+++ b/LiveWallpaperTests/WPESceneScriptRuntimeTests.swift
@@ -621,12 +621,13 @@ struct WPESceneScriptRuntimeTests {
         left[61] = 0.25
         right[60] = 0.25
         right[61] = 0.25
-        SystemAudioCaptureManager.broker.publish(
-            AudioSpectrumFrame(left: left, right: right, timestampNanos: 1)
+        SystemAudioCaptureManager.broker.attachAnalyzer(
+            SpectrumAnalyzerStub(AudioSpectrumFrame(left: left, right: right, timestampNanos: 1))
         )
         SystemAudioCaptureManager.setCapturingForTesting(true)
         defer {
             SystemAudioCaptureManager.setCapturingForTesting(false)
+            SystemAudioCaptureManager.broker.attachAnalyzer(nil)
             SystemAudioCaptureManager.broker.resetToSilence()
         }
         let script = """
@@ -647,10 +648,13 @@ struct WPESceneScriptRuntimeTests {
     func engineAudioBuffersSilentWhenCaptureOff() throws {
         var left = [Float](repeating: 0, count: AudioSpectrumFrame.binCount)
         left[0] = 1
-        SystemAudioCaptureManager.broker.publish(
-            AudioSpectrumFrame(left: left, right: left, timestampNanos: 1)
+        SystemAudioCaptureManager.broker.attachAnalyzer(
+            SpectrumAnalyzerStub(AudioSpectrumFrame(left: left, right: left, timestampNanos: 1))
         )
-        defer { SystemAudioCaptureManager.broker.resetToSilence() }
+        defer {
+            SystemAudioCaptureManager.broker.attachAnalyzer(nil)
+            SystemAudioCaptureManager.broker.resetToSilence()
+        }
         let script = """
         let audioBuffer = engine.registerAudioBuffers(engine.AUDIO_RESOLUTION_16);
         export function update(value) { return String(audioBuffer.average[0]); }
@@ -663,12 +667,13 @@ struct WPESceneScriptRuntimeTests {
     func transformScriptsReadLiveSpectrum() throws {
         var bins = [Float](repeating: 0, count: AudioSpectrumFrame.binCount)
         for index in bins.indices { bins[index] = 0.5 }
-        SystemAudioCaptureManager.broker.publish(
-            AudioSpectrumFrame(left: bins, right: bins, timestampNanos: 1)
+        SystemAudioCaptureManager.broker.attachAnalyzer(
+            SpectrumAnalyzerStub(AudioSpectrumFrame(left: bins, right: bins, timestampNanos: 1))
         )
         SystemAudioCaptureManager.setCapturingForTesting(true)
         defer {
             SystemAudioCaptureManager.setCapturingForTesting(false)
+            SystemAudioCaptureManager.broker.attachAnalyzer(nil)
             SystemAudioCaptureManager.broker.resetToSilence()
         }
         let instance = try LiveWallpaper.WPEDynamicTransformScriptInstance(
@@ -877,12 +882,13 @@ export function init(value) {
     func corpusAudioScaleTemplateUsesItsSeed() throws {
         var bins = [Float](repeating: 0, count: AudioSpectrumFrame.binCount)
         for index in bins.indices { bins[index] = 1 }
-        SystemAudioCaptureManager.broker.publish(
-            AudioSpectrumFrame(left: bins, right: bins, timestampNanos: 1)
+        SystemAudioCaptureManager.broker.attachAnalyzer(
+            SpectrumAnalyzerStub(AudioSpectrumFrame(left: bins, right: bins, timestampNanos: 1))
         )
         SystemAudioCaptureManager.setCapturingForTesting(true)
         defer {
             SystemAudioCaptureManager.setCapturingForTesting(false)
+            SystemAudioCaptureManager.broker.attachAnalyzer(nil)
             SystemAudioCaptureManager.broker.resetToSilence()
         }
         let instance = try LiveWallpaper.WPEDynamicTransformScriptInstance(
@@ -913,12 +919,13 @@ export function init(value) {
         // batch dispatch (what the frame loop uses) and a real shared state.
         var bins = [Float](repeating: 0, count: AudioSpectrumFrame.binCount)
         for index in bins.indices { bins[index] = 1 }
-        SystemAudioCaptureManager.broker.publish(
-            AudioSpectrumFrame(left: bins, right: bins, timestampNanos: 1)
+        SystemAudioCaptureManager.broker.attachAnalyzer(
+            SpectrumAnalyzerStub(AudioSpectrumFrame(left: bins, right: bins, timestampNanos: 1))
         )
         SystemAudioCaptureManager.setCapturingForTesting(true)
         defer {
             SystemAudioCaptureManager.setCapturingForTesting(false)
+            SystemAudioCaptureManager.broker.attachAnalyzer(nil)
             SystemAudioCaptureManager.broker.resetToSilence()
         }
         let instance = try LiveWallpaper.WPEDynamicTransformScriptInstance(

--- a/LiveWallpaperTests/WPEScriptFaultPolicyTests.swift
+++ b/LiveWallpaperTests/WPEScriptFaultPolicyTests.swift
@@ -1,0 +1,136 @@
+#if !LITE_BUILD
+    import Foundation
+    @testable import LiveWallpaper
+    import Testing
+
+    @Suite("WPE script fault policy")
+    struct WPEScriptFaultPolicyTests {
+        /// Drives the policy to the given number of consecutive failures of one
+        /// entry point, attempting only when the policy allows it. Returns the
+        /// last verdict and the advanced clock.
+        private func fail(
+            _ policy: inout WPEScriptFaultPolicy,
+            entryPoint: String = "update",
+            times: Int,
+            startingAt now: Double = 0
+        ) -> (verdict: WPEScriptFaultVerdict, now: Double) {
+            var verdict = WPEScriptFaultVerdict.probing
+            var clock = now
+            var recorded = 0
+            while recorded < times {
+                if policy.shouldAttempt(entryPoint: entryPoint, at: clock) {
+                    verdict = policy.recordFailure(entryPoint: entryPoint, at: clock)
+                    recorded += 1
+                }
+                clock += WPEScriptFaultPolicy.probeInterval
+            }
+            return (verdict, clock)
+        }
+
+        // Mutating calls are hoisted into lets throughout: #expect's macro
+        // captures the receiver immutably, so it cannot call them inline.
+
+        @Test("Backoff sequence skips 1, then 8, then 64 frames")
+        func backoffSequence() {
+            var policy = WPEScriptFaultPolicy()
+            let now = 0.0
+            let firstAttempt = policy.shouldAttempt(entryPoint: "update", at: now)
+            #expect(firstAttempt)
+            let firstVerdict = policy.recordFailure(entryPoint: "update", at: now)
+            #expect(firstVerdict == .backoff(skippedFrames: 1))
+            let skippedOnce = policy.shouldAttempt(entryPoint: "update", at: now)
+            #expect(!skippedOnce)
+            let secondAttempt = policy.shouldAttempt(entryPoint: "update", at: now)
+            #expect(secondAttempt)
+            let secondVerdict = policy.recordFailure(entryPoint: "update", at: now)
+            #expect(secondVerdict == .backoff(skippedFrames: 8))
+            for _ in 0 ..< 8 {
+                let skipped = policy.shouldAttempt(entryPoint: "update", at: now)
+                #expect(!skipped)
+            }
+            let thirdAttempt = policy.shouldAttempt(entryPoint: "update", at: now)
+            #expect(thirdAttempt)
+            let thirdVerdict = policy.recordFailure(entryPoint: "update", at: now)
+            #expect(thirdVerdict == .backoff(skippedFrames: 64))
+            for _ in 0 ..< 64 {
+                let skipped = policy.shouldAttempt(entryPoint: "update", at: now)
+                #expect(!skipped)
+            }
+            let probeAttempt = policy.shouldAttempt(entryPoint: "update", at: now)
+            #expect(probeAttempt)
+        }
+
+        @Test("After backoff is exhausted, probes are spaced one second apart")
+        func probeCadence() {
+            var policy = WPEScriptFaultPolicy()
+            let (verdict, now) = fail(&policy, times: 4)
+            #expect(verdict == .probing)
+            let early = policy.shouldAttempt(entryPoint: "update", at: now - 0.5)
+            #expect(!early)
+            let due = policy.shouldAttempt(entryPoint: "update", at: now)
+            #expect(due)
+            let lateDue = policy.shouldAttempt(entryPoint: "update", at: now + 100)
+            #expect(lateDue)
+        }
+
+        @Test("A success resets the escalation back to the first backoff step")
+        func successResets() {
+            var policy = WPEScriptFaultPolicy()
+            let (_, now) = fail(&policy, times: 4)
+            policy.recordSuccess(entryPoint: "update")
+            let attempt = policy.shouldAttempt(entryPoint: "update", at: now)
+            #expect(attempt)
+            let verdict = policy.recordFailure(entryPoint: "update", at: now)
+            #expect(verdict == .backoff(skippedFrames: 1))
+        }
+
+        @Test("Twelve failed probes hard-quarantine the entry point")
+        func quarantineAfterFailedProbes() {
+            var policy = WPEScriptFaultPolicy()
+            // 3 backoff failures + 11 probing failures, then the 12th probe.
+            let (beforeLast, now) = fail(&policy, times: 14)
+            #expect(beforeLast == .probing)
+            let (last, after) = fail(&policy, times: 1, startingAt: now)
+            #expect(last == .quarantined)
+            let attempt = policy.shouldAttempt(entryPoint: "update", at: after + 10_000)
+            #expect(!attempt)
+        }
+
+        @Test("An entry point that ever succeeded is never quarantined")
+        func everSucceededExemptsQuarantine() {
+            var policy = WPEScriptFaultPolicy()
+            policy.recordSuccess(entryPoint: "update")
+            let (verdict, now) = fail(&policy, times: 40)
+            #expect(verdict == .probing)
+            let attempt = policy.shouldAttempt(
+                entryPoint: "update", at: now + WPEScriptFaultPolicy.probeInterval
+            )
+            #expect(attempt)
+        }
+
+        @Test("Entry points back off independently (event-callback isolation)")
+        func entryPointIsolation() {
+            var policy = WPEScriptFaultPolicy()
+            _ = fail(&policy, entryPoint: "cursorClick", times: 15)
+            let quarantined = policy.shouldAttempt(entryPoint: "cursorClick", at: 10_000)
+            #expect(!quarantined)
+            let updateAttempt = policy.shouldAttempt(entryPoint: "update", at: 10_000)
+            #expect(updateAttempt)
+            let moveAttempt = policy.shouldAttempt(entryPoint: "cursorMove", at: 10_000)
+            #expect(moveAttempt)
+        }
+
+        @Test("Escalation keeps advancing across failures, never restarting")
+        func escalationNeverRestarts() {
+            var policy = WPEScriptFaultPolicy()
+            let (_, now) = fail(&policy, times: 4)
+            let attempt = policy.shouldAttempt(entryPoint: "update", at: now)
+            #expect(attempt)
+            // Regression guard: keying escalation on the exception message let a
+            // script throwing `Error("t=" + Date.now())` restart at step 1 every
+            // tick and never reach quarantine.
+            let verdict = policy.recordFailure(entryPoint: "update", at: now)
+            #expect(verdict == .probing)
+        }
+    }
+#endif

--- a/LiveWallpaperTests/WPETexDecoderTests.swift
+++ b/LiveWallpaperTests/WPETexDecoderTests.swift
@@ -346,7 +346,7 @@ struct WPETexDecoderTests {
         let payload = try WPETexDecoder().extractStreamingPayload(data: buffer).get()
 
         #expect(payload.compressedImages.count == 2)
-        #expect(payload.compressedImages[0].payloads[0].compressedBytes == compressed0)
+        #expect(payload.compressedImages[0].payloads[0].compressedBytes.materializedData() == compressed0)
         #expect(payload.compressedImages[0].payloads[0].isCompressed == true)
         #expect(payload.compressedImages[0].payloads[0].decompressedByteCount == width * height * 4)
         #expect(payload.frames.count == 4)

--- a/LiveWallpaperTests/WPEVideoHDRAndLegacyOutputTests.swift
+++ b/LiveWallpaperTests/WPEVideoHDRAndLegacyOutputTests.swift
@@ -1,0 +1,269 @@
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import Foundation
+import Metal
+import Testing
+import VideoToolbox
+@testable import LiveWallpaper
+
+/// End-to-end coverage for two branches the hermetic NV12 tests cannot reach:
+/// the HDR (PQ) fallback driven by a real 10-bit HEVC clip, and the
+/// pre-macOS-15 item-level (`AVPlayerItemVideoOutput`) frame path.
+@MainActor
+@Suite("WPEVideoTextureSource HDR and legacy output", .serialized)
+struct WPEVideoHDRAndLegacyOutputTests {
+
+    // MARK: - Task: real HDR (PQ) end-to-end
+
+    @Test("A real 10-bit HEVC PQ clip pins outputs to BGRA exactly once and keeps publishing")
+    func hdrPQClipTakesBGRAFallbackEndToEnd() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticHDRVideoFixture.writeHEVCMain10(transfer: .pq)
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+
+        // Fixture sanity: the container must genuinely carry HEVC + PQ tags,
+        // otherwise the assertions below prove nothing.
+        let asset = AVURLAsset(url: videoURL)
+        let track = try #require(try await asset.loadTracks(withMediaType: .video).first)
+        let formatDescription = try #require(try await track.load(.formatDescriptions).first)
+        #expect(CMFormatDescriptionGetMediaSubType(formatDescription) == kCMVideoCodecType_HEVC)
+        let transfer = CMFormatDescriptionGetExtension(
+            formatDescription, extensionKey: kCMFormatDescriptionExtension_TransferFunction
+        ) as? String
+        #expect(transfer == (kCMFormatDescriptionTransferFunction_SMPTE_ST_2084_PQ as String),
+                "fixture must be PQ-tagged, got \(transfer ?? "nil")")
+
+        let source = try WPEVideoTextureSource(device: device, videoURL: videoURL)
+        defer { source.invalidate() }
+        source.applyPerformanceProfile(.quality)
+
+        var texture: MTLTexture?
+        var sawBiPlanarPublish = false
+        let deadline = Date().addingTimeInterval(8.0)
+        while Date() < deadline {
+            texture = source.texture(at: 0)
+            if source.lastPublishPathForTesting == .biPlanar { sawBiPlanarPublish = true }
+            if texture != nil { break }
+            try await Task.sleep(for: .milliseconds(30))
+        }
+
+        // (a) HDR detection fired and the outputs rebuilt to BGRA exactly once.
+        #expect(source.didForceBGRAOutputForTesting, "PQ clip must trigger the HDR fallback")
+        #expect(source.bgraFallbackRebuildCountForTesting == 1,
+                "outputs must rebuild exactly once, got \(source.bgraFallbackRebuildCountForTesting)")
+        // (b) Frames still publish after the rebuild.
+        let frame = try #require(texture, "HDR clip must still publish frames after the BGRA rebuild")
+        #expect(frame.width == 64)
+        #expect(frame.height == 64)
+        #expect(frame.pixelFormat == .bgra8Unorm_srgb || frame.pixelFormat == .bgra8Unorm)
+        // (c) No NV12 conversion was ever attempted on the HDR clip.
+        #expect(!sawBiPlanarPublish, "PQ frames must never take the NV12 matrix path")
+        #expect(source.lastPublishPathForTesting == .bgra)
+    }
+
+    // MARK: - Task: legacy item-level output path
+
+    @Test("Forced item-level output (macOS 14 path) publishes frames from an SDR clip")
+    func legacyItemLevelOutputPublishesFrames() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticHDRVideoFixture.writeSDRH264()
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+
+        let source = try WPEVideoTextureSource(
+            device: device,
+            videoURL: videoURL,
+            forceLegacyItemLevelOutputForTesting: true
+        )
+        defer { source.invalidate() }
+        source.applyPerformanceProfile(.quality)
+
+        var texture: MTLTexture?
+        let deadline = Date().addingTimeInterval(5.0)
+        while Date() < deadline {
+            texture = source.texture(at: 0)
+            if texture != nil { break }
+            try await Task.sleep(for: .milliseconds(30))
+        }
+        let frame = try #require(texture, "item-level output must publish a frame within 5s")
+        #expect(frame.width == 64)
+        #expect(frame.height == 64)
+        #expect(frame.pixelFormat == .bgra8Unorm_srgb || frame.pixelFormat == .bgra8Unorm)
+        let path = try #require(source.lastPublishPathForTesting)
+        #expect(path == .biPlanar || path == .bgra)
+    }
+}
+
+// MARK: - Fixtures
+
+private enum SyntheticHDRVideoFixture {
+    enum Transfer {
+        case pq
+        case hlg
+    }
+
+    /// 64x64, 10 frames, HEVC Main10 from P010-style
+    /// (`kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange`) source buffers with
+    /// BT.2020 primaries/matrix and the requested transfer function.
+    static func writeHEVCMain10(transfer: Transfer) async throws -> URL {
+        let transferFunction: (video: String, cv: CFString)
+        switch transfer {
+        case .pq:
+            transferFunction = (
+                AVVideoTransferFunction_SMPTE_ST_2084_PQ,
+                kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ
+            )
+        case .hlg:
+            transferFunction = (
+                AVVideoTransferFunction_ITU_R_2100_HLG,
+                kCVImageBufferTransferFunction_ITU_R_2100_HLG
+            )
+        }
+        let width = 64
+        let height = 64
+        let videoSettings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.hevc,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+            AVVideoCompressionPropertiesKey: [
+                kVTCompressionPropertyKey_ProfileLevel as String: kVTProfileLevel_HEVC_Main10_AutoLevel
+            ],
+            AVVideoColorPropertiesKey: [
+                AVVideoColorPrimariesKey: AVVideoColorPrimaries_ITU_R_2020,
+                AVVideoTransferFunctionKey: transferFunction.video,
+                AVVideoYCbCrMatrixKey: AVVideoYCbCrMatrix_ITU_R_2020
+            ]
+        ]
+        return try await write(
+            videoSettings: videoSettings,
+            sourcePixelFormat: kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
+            frameCount: 10
+        ) { buffer, frameIndex in
+            CVBufferSetAttachment(
+                buffer, kCVImageBufferColorPrimariesKey,
+                kCVImageBufferColorPrimaries_ITU_R_2020, .shouldPropagate
+            )
+            CVBufferSetAttachment(
+                buffer, kCVImageBufferTransferFunctionKey,
+                transferFunction.cv, .shouldPropagate
+            )
+            CVBufferSetAttachment(
+                buffer, kCVImageBufferYCbCrMatrixKey,
+                kCVImageBufferYCbCrMatrix_ITU_R_2020, .shouldPropagate
+            )
+            // 10-bit biplanar: samples are left-justified in 16-bit words.
+            let luma10 = UInt16(200 + frameIndex * 40) << 6
+            let chroma10 = UInt16(512) << 6
+            CVPixelBufferLockBaseAddress(buffer, [])
+            defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+            if let base = CVPixelBufferGetBaseAddressOfPlane(buffer, 0) {
+                let rowBytes = CVPixelBufferGetBytesPerRowOfPlane(buffer, 0)
+                for row in 0..<CVPixelBufferGetHeightOfPlane(buffer, 0) {
+                    let rowPointer = (base + row * rowBytes).bindMemory(to: UInt16.self, capacity: width)
+                    for column in 0..<width { rowPointer[column] = luma10 }
+                }
+            }
+            if let base = CVPixelBufferGetBaseAddressOfPlane(buffer, 1) {
+                let rowBytes = CVPixelBufferGetBytesPerRowOfPlane(buffer, 1)
+                for row in 0..<CVPixelBufferGetHeightOfPlane(buffer, 1) {
+                    let rowPointer = (base + row * rowBytes).bindMemory(to: UInt16.self, capacity: width)
+                    for column in 0..<width { rowPointer[column] = chroma10 }
+                }
+            }
+        }
+    }
+
+    /// Plain 64x64 SDR H.264 clip (BGRA source frames) for the legacy path.
+    static func writeSDRH264() async throws -> URL {
+        let videoSettings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: 64,
+            AVVideoHeightKey: 64
+        ]
+        return try await write(
+            videoSettings: videoSettings,
+            sourcePixelFormat: kCVPixelFormatType_32BGRA,
+            frameCount: 24
+        ) { buffer, frameIndex in
+            CVPixelBufferLockBaseAddress(buffer, [])
+            defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+            if let base = CVPixelBufferGetBaseAddress(buffer) {
+                memset(base, Int32(60 + (frameIndex * 5) % 160),
+                       CVPixelBufferGetBytesPerRow(buffer) * CVPixelBufferGetHeight(buffer))
+            }
+        }
+    }
+
+    private static func write(
+        videoSettings: [String: Any],
+        sourcePixelFormat: OSType,
+        frameCount: Int,
+        fill: (CVPixelBuffer, Int) -> Void
+    ) async throws -> URL {
+        let width = videoSettings[AVVideoWidthKey] as? Int ?? 64
+        let height = videoSettings[AVVideoHeightKey] as? Int ?? 64
+        let frameRate: Int32 = 24
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wpe-hdr-fixture-\(UUID().uuidString).mp4")
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
+        input.expectsMediaDataInRealTime = false
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: sourcePixelFormat,
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height
+            ]
+        )
+        guard writer.canAdd(input) else {
+            throw FixtureError.writerFailed("cannot add input for settings \(videoSettings)")
+        }
+        writer.add(input)
+        guard writer.startWriting() else {
+            throw FixtureError.writerFailed(writer.error.map { "\($0)" } ?? "startWriting failed")
+        }
+        writer.startSession(atSourceTime: .zero)
+        for index in 0..<frameCount {
+            while !input.isReadyForMoreMediaData { await Task.yield() }
+            var pixelBuffer: CVPixelBuffer?
+            var status = kCVReturnError
+            if let pool = adaptor.pixelBufferPool {
+                status = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pixelBuffer)
+            }
+            if status != kCVReturnSuccess {
+                status = CVPixelBufferCreate(
+                    kCFAllocatorDefault, width, height, sourcePixelFormat, nil, &pixelBuffer
+                )
+            }
+            guard status == kCVReturnSuccess, let buffer = pixelBuffer else {
+                throw FixtureError.writerFailed("pixel buffer create returned \(status)")
+            }
+            fill(buffer, index)
+            let pts = CMTime(value: Int64(index), timescale: frameRate)
+            guard adaptor.append(buffer, withPresentationTime: pts) else {
+                throw FixtureError.writerFailed(writer.error.map { "\($0)" } ?? "append failed at frame \(index)")
+            }
+        }
+        input.markAsFinished()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            writer.finishWriting { continuation.resume() }
+        }
+        guard writer.status == .completed else {
+            throw FixtureError.writerFailed(
+                writer.error.map { "\($0)" } ?? "finishWriting status \(writer.status.rawValue)"
+            )
+        }
+        return outputURL
+    }
+
+    private enum FixtureError: Error, CustomStringConvertible {
+        case writerFailed(String)
+
+        var description: String {
+            switch self {
+            case let .writerFailed(message): return "AVAssetWriter fixture failed: \(message)"
+            }
+        }
+    }
+}

--- a/LiveWallpaperTests/WPEVideoNV12ConversionTests.swift
+++ b/LiveWallpaperTests/WPEVideoNV12ConversionTests.swift
@@ -1,0 +1,380 @@
+import AVFoundation
+import CoreMedia
+import CoreVideo
+import Foundation
+import Metal
+import simd
+import Testing
+@testable import LiveWallpaper
+
+/// NV12 (biplanar YCbCr) video decode path: coefficient pins against the
+/// published BT.601/709/2020 constants, colorimetry-attachment selection,
+/// HDR→BGRA fallback, and a hermetic shader-vs-CPU numeric check on a
+/// hand-built NV12 pixel buffer.
+@MainActor
+@Suite("WPEVideoTextureSource NV12", .serialized)
+struct WPEVideoNV12ConversionTests {
+
+    // MARK: - Matrix coefficient pins (CPU reference)
+
+    @Test("BT.601 video-range coefficients match the published constants")
+    func bt601VideoRangeCoefficients() {
+        let c = WPEVideoYCbCrConversion.make(kind: .bt601, fullRange: false)
+        // Columns: 0 = Y, 1 = Cb, 2 = Cr; rows R, G, B.
+        #expect(abs(c.matrix.columns.0.x - 1.1644) < 0.001)
+        #expect(abs(c.matrix.columns.0.y - 1.1644) < 0.001)
+        #expect(abs(c.matrix.columns.0.z - 1.1644) < 0.001)
+        #expect(abs(c.matrix.columns.2.x - 1.596) < 0.001)   // Cr → R
+        #expect(abs(c.matrix.columns.1.y - -0.3918) < 0.001) // Cb → G
+        #expect(abs(c.matrix.columns.2.y - -0.813) < 0.001)  // Cr → G
+        #expect(abs(c.matrix.columns.1.z - 2.017) < 0.001)   // Cb → B
+        #expect(c.matrix.columns.1.x == 0)                   // Cb → R
+        #expect(c.matrix.columns.2.z == 0)                   // Cr → B
+        #expect(abs(c.offset.x - 16.0 / 255.0) < 0.0001)
+        #expect(abs(c.offset.y - 128.0 / 255.0) < 0.0001)
+    }
+
+    @Test("BT.709 video-range coefficients match the published constants")
+    func bt709VideoRangeCoefficients() {
+        let c = WPEVideoYCbCrConversion.make(kind: .bt709, fullRange: false)
+        #expect(abs(c.matrix.columns.2.x - 1.7927) < 0.001)   // Cr → R
+        #expect(abs(c.matrix.columns.1.y - -0.2132) < 0.001)  // Cb → G
+        #expect(abs(c.matrix.columns.2.y - -0.5329) < 0.001)  // Cr → G
+        #expect(abs(c.matrix.columns.1.z - 2.1124) < 0.001)   // Cb → B
+    }
+
+    @Test("BT.2020 and full-range variants")
+    func bt2020AndFullRange() {
+        let bt2020 = WPEVideoYCbCrConversion.make(kind: .bt2020, fullRange: false)
+        // 2 * (1 - 0.2627) * 255/224
+        #expect(abs(bt2020.matrix.columns.2.x - 1.6787) < 0.001)
+
+        let full601 = WPEVideoYCbCrConversion.make(kind: .bt601, fullRange: true)
+        #expect(full601.matrix.columns.0.x == 1.0)
+        #expect(abs(full601.matrix.columns.2.x - 1.402) < 0.001) // Cr → R without range expansion
+        #expect(full601.offset.x == 0)
+        #expect(abs(full601.offset.y - 128.0 / 255.0) < 0.0001)
+    }
+
+    @Test("Video-range black and white map to 0 and 1")
+    func videoRangeEndpoints() {
+        let c = WPEVideoYCbCrConversion.make(kind: .bt709, fullRange: false)
+        let black = c.apply(SIMD3(16.0 / 255.0, 128.0 / 255.0, 128.0 / 255.0))
+        let white = c.apply(SIMD3(235.0 / 255.0, 128.0 / 255.0, 128.0 / 255.0))
+        #expect(simd_length(black) < 0.005)
+        #expect(simd_length(white - SIMD3<Float>(1, 1, 1)) < 0.005)
+    }
+
+    // MARK: - Colorimetry attachment selection
+
+    @Test("Matrix kind follows the attachment, with an SD/HD heuristic fallback")
+    func matrixKindSelection() {
+        #expect(WPEVideoYCbCrConversion.kind(
+            matrixAttachment: kCVImageBufferYCbCrMatrix_ITU_R_709_2 as String, sourceHeight: 480
+        ) == .bt709)
+        #expect(WPEVideoYCbCrConversion.kind(
+            matrixAttachment: kCVImageBufferYCbCrMatrix_ITU_R_601_4 as String, sourceHeight: 2160
+        ) == .bt601)
+        #expect(WPEVideoYCbCrConversion.kind(
+            matrixAttachment: kCVImageBufferYCbCrMatrix_ITU_R_2020 as String, sourceHeight: 2160
+        ) == .bt2020)
+        #expect(WPEVideoYCbCrConversion.kind(matrixAttachment: nil, sourceHeight: 480) == .bt601)
+        #expect(WPEVideoYCbCrConversion.kind(matrixAttachment: nil, sourceHeight: 1080) == .bt709)
+    }
+
+    // MARK: - HDR detection
+
+    @Test("PQ/HLG transfer functions are flagged HDR; SDR transfers are not")
+    func hdrTransferDetection() throws {
+        let pq = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 128, cb: 128, cr: 128)
+        CVBufferSetAttachment(
+            pq, kCVImageBufferTransferFunctionKey,
+            kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ, .shouldPropagate
+        )
+        #expect(WPEVideoTextureSource.isHDRTransfer(pq))
+
+        let hlg = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 128, cb: 128, cr: 128)
+        CVBufferSetAttachment(
+            hlg, kCVImageBufferTransferFunctionKey,
+            kCVImageBufferTransferFunction_ITU_R_2100_HLG, .shouldPropagate
+        )
+        #expect(WPEVideoTextureSource.isHDRTransfer(hlg))
+
+        let sdr = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 128, cb: 128, cr: 128)
+        CVBufferSetAttachment(
+            sdr, kCVImageBufferTransferFunctionKey,
+            kCVImageBufferTransferFunction_ITU_R_709_2, .shouldPropagate
+        )
+        #expect(!WPEVideoTextureSource.isHDRTransfer(sdr))
+
+        let untagged = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 128, cb: 128, cr: 128)
+        #expect(!WPEVideoTextureSource.isHDRTransfer(untagged))
+    }
+
+    // MARK: - Hermetic shader-vs-CPU numeric check
+
+    @Test("NV12 ingest converts through the shader to the CPU reference values")
+    func nv12IngestMatchesCPUReference() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticNV12VideoFixture.writeMP4(durationSeconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+        let source = try WPEVideoTextureSource(device: device, videoURL: videoURL)
+        defer { source.invalidate() }
+
+        // Mid-range YCbCr with real chroma so a wrong matrix, offset, or
+        // swapped Cb/Cr shows up as a large channel error.
+        let (y, cb, cr): (UInt8, UInt8, UInt8) = (120, 90, 170)
+        let buffer = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: y, cb: cb, cr: cr)
+        CVBufferSetAttachment(
+            buffer, kCVImageBufferYCbCrMatrixKey,
+            kCVImageBufferYCbCrMatrix_ITU_R_601_4, .shouldPropagate
+        )
+        source.ingestForTesting(pixelBuffer: buffer)
+
+        #expect(source.lastPublishPathForTesting == .biPlanar)
+        let texture = try #require(source.texture(at: 0))
+        #expect(texture.pixelFormat == .bgra8Unorm_srgb)
+        #expect(texture.width == 64)
+        #expect(texture.height == 64)
+
+        let reference = WPEVideoYCbCrConversion.make(kind: .bt601, fullRange: false)
+            .apply(SIMD3(Float(y) / 255.0, Float(cb) / 255.0, Float(cr) / 255.0))
+        let expected = SIMD3<Int>(
+            Int((reference.x * 255).rounded()),
+            Int((reference.y * 255).rounded()),
+            Int((reference.z * 255).rounded())
+        )
+        // The conversion pass runs on the source's own queue in tests — poll the
+        // readback until the GPU pass lands.
+        let matched = try await Self.pollReadbackBGRA(texture: texture, device: device) { bgra in
+            abs(Int(bgra[2]) - expected.x) <= 2
+                && abs(Int(bgra[1]) - expected.y) <= 2
+                && abs(Int(bgra[0]) - expected.z) <= 2
+                && bgra[3] == 255
+        }
+        #expect(matched, "shader output must match CPU reference \(expected) within ±2")
+    }
+
+    // MARK: - Explicit fallback branches
+
+    @Test("HDR-tagged NV12 pins outputs to BGRA and never enters the matrix path")
+    func hdrIngestPinsBGRAOutputs() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticNV12VideoFixture.writeMP4(durationSeconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+        let source = try WPEVideoTextureSource(device: device, videoURL: videoURL)
+        defer { source.invalidate() }
+
+        let pq = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 128, cb: 128, cr: 128)
+        CVBufferSetAttachment(
+            pq, kCVImageBufferTransferFunctionKey,
+            kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ, .shouldPropagate
+        )
+        source.ingestForTesting(pixelBuffer: pq)
+
+        #expect(source.didForceBGRAOutputForTesting)
+        #expect(source.lastPublishPathForTesting == nil, "HDR frame must not publish through the NV12 path")
+        #expect(source.texture(at: 0) == nil)
+
+        // After the fallback, BGRA buffers take the legacy wrap path unchanged.
+        let bgra = try Self.makeBGRAPixelBuffer(width: 64, height: 64, fillByte: 90)
+        source.ingestForTesting(pixelBuffer: bgra)
+        #expect(source.lastPublishPathForTesting == .bgra)
+        let texture = try #require(source.texture(at: 0))
+        #expect(texture.pixelFormat == .bgra8Unorm_srgb || texture.pixelFormat == .bgra8Unorm)
+    }
+
+    // MARK: - AVFoundation integration (format negotiation)
+
+    @Test("A playing SDR H.264 source negotiates the biplanar path end-to-end")
+    func avPlayerDeliversBiPlanarFrames() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticNV12VideoFixture.writeMP4(durationSeconds: 1.0)
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+        let source = try WPEVideoTextureSource(device: device, videoURL: videoURL)
+        defer { source.invalidate() }
+        source.applyPerformanceProfile(.quality)
+
+        var texture: MTLTexture?
+        let deadline = Date().addingTimeInterval(3.0)
+        while Date() < deadline {
+            texture = source.texture(at: 0)
+            if texture != nil { break }
+            try await Task.sleep(for: .milliseconds(30))
+        }
+        let frame = try #require(texture, "AVPlayer-backed source must publish a frame within 3s")
+        #expect(source.lastPublishPathForTesting == .biPlanar,
+                "SDR H.264 must negotiate NV12, not fall back to BGRA")
+        #expect(frame.pixelFormat == .bgra8Unorm_srgb)
+        #expect(frame.width == 64)
+        #expect(frame.height == 64)
+
+        // The fixture is uniform gray per frame — conversion must keep it gray.
+        source.applyPerformanceProfile(.suspended)
+        let isGray = try await Self.pollReadbackBGRA(texture: frame, device: device) { bgra in
+            let channels = [Int(bgra[0]), Int(bgra[1]), Int(bgra[2])]
+            let spread = (channels.max() ?? 0) - (channels.min() ?? 0)
+            return spread <= 12 && bgra[3] == 255 && channels[0] > 20 && channels[0] < 250
+        }
+        #expect(isGray, "uniform gray input must stay gray through the YCbCr matrix")
+    }
+
+    // MARK: - Helpers
+
+    /// Polls a 1-pixel (0,0) readback until `predicate` passes or 2s elapse.
+    private static func pollReadbackBGRA(
+        texture: MTLTexture,
+        device: MTLDevice,
+        predicate: ([UInt8]) -> Bool
+    ) async throws -> Bool {
+        let queue = try #require(device.makeCommandQueue())
+        let deadline = Date().addingTimeInterval(2.0)
+        while Date() < deadline {
+            let bgra = try readbackPixel(texture: texture, queue: queue)
+            if predicate(bgra) { return true }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        return false
+    }
+
+    private static func readbackPixel(texture: MTLTexture, queue: MTLCommandQueue) throws -> [UInt8] {
+        let buffer = try #require(queue.device.makeBuffer(length: 4, options: .storageModeShared))
+        let commandBuffer = try #require(queue.makeCommandBuffer())
+        let blit = try #require(commandBuffer.makeBlitCommandEncoder())
+        blit.copy(
+            from: texture, sourceSlice: 0, sourceLevel: 0,
+            sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+            sourceSize: MTLSize(width: 1, height: 1, depth: 1),
+            to: buffer, destinationOffset: 0,
+            destinationBytesPerRow: 4, destinationBytesPerImage: 4
+        )
+        blit.endEncoding()
+        commandBuffer.commit()
+        commandBuffer.waitUntilCompleted()
+        let pointer = buffer.contents().bindMemory(to: UInt8.self, capacity: 4)
+        return [pointer[0], pointer[1], pointer[2], pointer[3]]
+    }
+
+    private static func makeNV12PixelBuffer(
+        width: Int, height: Int, luma: UInt8, cb: UInt8, cr: UInt8
+    ) throws -> CVPixelBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        let attributes: CFDictionary = [
+            kCVPixelBufferMetalCompatibilityKey: true,
+            kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary
+        ] as CFDictionary
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault, width, height,
+            kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+            attributes, &pixelBuffer
+        )
+        guard status == kCVReturnSuccess, let buffer = pixelBuffer else {
+            throw FixtureError.pixelBufferCreateFailed(status)
+        }
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+        let lumaBase = try #require(CVPixelBufferGetBaseAddressOfPlane(buffer, 0))
+        let lumaRowBytes = CVPixelBufferGetBytesPerRowOfPlane(buffer, 0)
+        for row in 0..<height {
+            memset(lumaBase + row * lumaRowBytes, Int32(luma), width)
+        }
+        let chromaBase = try #require(CVPixelBufferGetBaseAddressOfPlane(buffer, 1))
+            .bindMemory(to: UInt8.self, capacity: CVPixelBufferGetBytesPerRowOfPlane(buffer, 1) * (height / 2))
+        let chromaRowBytes = CVPixelBufferGetBytesPerRowOfPlane(buffer, 1)
+        for row in 0..<(height / 2) {
+            for column in 0..<(width / 2) {
+                chromaBase[row * chromaRowBytes + column * 2] = cb
+                chromaBase[row * chromaRowBytes + column * 2 + 1] = cr
+            }
+        }
+        return buffer
+    }
+
+    private static func makeBGRAPixelBuffer(width: Int, height: Int, fillByte: UInt8) throws -> CVPixelBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        let attributes: CFDictionary = [
+            kCVPixelBufferMetalCompatibilityKey: true,
+            kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary
+        ] as CFDictionary
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA, attributes, &pixelBuffer
+        )
+        guard status == kCVReturnSuccess, let buffer = pixelBuffer else {
+            throw FixtureError.pixelBufferCreateFailed(status)
+        }
+        CVPixelBufferLockBaseAddress(buffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(buffer, []) }
+        let base = try #require(CVPixelBufferGetBaseAddress(buffer))
+        memset(base, Int32(fillByte), CVPixelBufferGetBytesPerRow(buffer) * height)
+        return buffer
+    }
+
+    private enum FixtureError: Error {
+        case pixelBufferCreateFailed(CVReturn)
+    }
+}
+
+// MARK: - Synthetic MP4 fixture (uniform gray frames)
+
+private enum SyntheticNV12VideoFixture {
+    static func writeMP4(durationSeconds: TimeInterval) async throws -> URL {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wpe-nv12-\(UUID().uuidString).mp4")
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        let width = 64
+        let height = 64
+        let frameRate: Int32 = 24
+        let videoSettings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height
+        ]
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
+        input.expectsMediaDataInRealTime = false
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height
+            ]
+        )
+        guard writer.canAdd(input) else { throw WriterError.setupFailed("cannot add input") }
+        writer.add(input)
+        guard writer.startWriting() else {
+            throw WriterError.setupFailed(writer.error?.localizedDescription ?? "startWriting failed")
+        }
+        writer.startSession(atSourceTime: .zero)
+        let totalFrames = max(2, Int(Double(frameRate) * durationSeconds))
+        for index in 0..<totalFrames {
+            while !input.isReadyForMoreMediaData { await Task.yield() }
+            var pixelBuffer: CVPixelBuffer?
+            let status = CVPixelBufferCreate(
+                kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA, nil, &pixelBuffer
+            )
+            guard status == kCVReturnSuccess, let buffer = pixelBuffer else {
+                throw WriterError.setupFailed("CVPixelBufferCreate returned \(status)")
+            }
+            CVPixelBufferLockBaseAddress(buffer, [])
+            let base = CVPixelBufferGetBaseAddress(buffer)
+            memset(base, Int32(60 + (index * 5) % 160), CVPixelBufferGetBytesPerRow(buffer) * height)
+            CVPixelBufferUnlockBaseAddress(buffer, [])
+            let pts = CMTime(value: Int64(index), timescale: frameRate)
+            guard adaptor.append(buffer, withPresentationTime: pts) else {
+                throw WriterError.setupFailed(writer.error?.localizedDescription ?? "append failed")
+            }
+        }
+        input.markAsFinished()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            writer.finishWriting { continuation.resume() }
+        }
+        guard writer.status == .completed else {
+            throw WriterError.setupFailed(writer.error?.localizedDescription ?? "status \(writer.status.rawValue)")
+        }
+        return outputURL
+    }
+
+    private enum WriterError: Error {
+        case setupFailed(String)
+    }
+}

--- a/LiveWallpaperTests/WPEVideoNV12ConversionTests.swift
+++ b/LiveWallpaperTests/WPEVideoNV12ConversionTests.swift
@@ -219,6 +219,108 @@ struct WPEVideoNV12ConversionTests {
         #expect(isGray, "uniform gray input must stay gray through the YCbCr matrix")
     }
 
+    // MARK: - Wrapper lifetime (retirement fences)
+
+    @Test("Replaced frames keep their CV wrappers until a GPU fence completes")
+    func replacedFrameWrappersOutliveTheirPublish() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticNV12VideoFixture.writeMP4(durationSeconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+        let source = try WPEVideoTextureSource(device: device, videoURL: videoURL)
+        defer { source.invalidate() }
+
+        let first = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 100, cb: 110, cr: 140)
+        source.ingestForTesting(pixelBuffer: first)
+        let second = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 180, cb: 120, cr: 130)
+        source.ingestForTesting(pixelBuffer: second)
+
+        // The first frame's wrappers moved into a pending retirement fenced by
+        // the second publish's conversion buffer — they must not have been
+        // dropped synchronously at replacement.
+        #expect(source.pendingRetirementCountForTesting > 0,
+                "replaced frame must be fence-retired, not released at publish")
+    }
+
+    @Test("Completed fences release retired wrappers on a later publish (no unbounded growth)")
+    func sweepReleasesCompletedRetirements() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticNV12VideoFixture.writeMP4(durationSeconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+        let source = try WPEVideoTextureSource(device: device, videoURL: videoURL)
+        defer { source.invalidate() }
+
+        // Publish a burst, then keep publishing slowly: once the GPU catches
+        // up, each new publish sweeps the completed fences, so the pending
+        // count must settle at 1 (only the entry appended by that publish).
+        for step in 0..<6 {
+            let buffer = try Self.makeNV12PixelBuffer(
+                width: 64, height: 64, luma: UInt8(60 + step * 20), cb: 100, cr: 150
+            )
+            source.ingestForTesting(pixelBuffer: buffer)
+        }
+        var settled = false
+        let deadline = Date().addingTimeInterval(3.0)
+        while Date() < deadline {
+            try await Task.sleep(for: .milliseconds(50))
+            let buffer = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 90, cb: 100, cr: 150)
+            source.ingestForTesting(pixelBuffer: buffer)
+            if source.pendingRetirementCountForTesting == 1 {
+                settled = true
+                break
+            }
+        }
+        #expect(settled, "completed retirements must be swept — pending stuck at \(source.pendingRetirementCountForTesting)")
+    }
+
+    @Test("Suspending playback releases retired wrappers instead of holding a frame")
+    func suspendReleasesRetiredWrappers() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticNV12VideoFixture.writeMP4(durationSeconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+        let source = try WPEVideoTextureSource(device: device, videoURL: videoURL)
+        defer { source.invalidate() }
+
+        let first = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 100, cb: 110, cr: 140)
+        source.ingestForTesting(pixelBuffer: first)
+        let second = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 180, cb: 120, cr: 130)
+        source.ingestForTesting(pixelBuffer: second)
+        #expect(source.pendingRetirementCountForTesting > 0)
+
+        // Pausing stops publishes, so the sweep at the top of `publish` will
+        // never run again — a retired 4K NV12 plane pair (~12 MiB, ~32 MiB on
+        // BGRA) would sit there for the whole suspension.
+        source.applyPerformanceProfile(.suspended)
+        #expect(source.pendingRetirementCountForTesting == 0,
+                "suspend must drain fenced retirements, not hold a frame for the whole pause")
+    }
+
+    @Test("Invalidate with conversion work in flight: no crash, full teardown")
+    func invalidateWithInFlightConversions() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticNV12VideoFixture.writeMP4(durationSeconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+        let source = try WPEVideoTextureSource(device: device, videoURL: videoURL)
+
+        // Burst of publishes so conversion command buffers are still in flight
+        // when invalidate() lands — the earlier hardening attempt crashed in
+        // exactly this window (completed handler vs. pool teardown).
+        for step in 0..<12 {
+            let buffer = try Self.makeNV12PixelBuffer(
+                width: 256, height: 256, luma: UInt8(40 + step * 15), cb: 90, cr: 160
+            )
+            source.ingestForTesting(pixelBuffer: buffer)
+        }
+        #expect(source.pendingRetirementCountForTesting > 0)
+
+        source.invalidate()
+
+        #expect(source.pendingRetirementCountForTesting == 0,
+                "invalidate must drain and release every pending retirement")
+        #expect(source.texture(at: 0) == nil)
+        // Idempotent re-entry stays safe after the drain.
+        source.invalidate()
+    }
+
     // MARK: - Helpers
 
     /// Polls a 1-pixel (0,0) readback until `predicate` passes or 2s elapse.

--- a/LiveWallpaperTests/WPEVideoNV12ConversionTests.swift
+++ b/LiveWallpaperTests/WPEVideoNV12ConversionTests.swift
@@ -272,6 +272,29 @@ struct WPEVideoNV12ConversionTests {
         #expect(settled, "completed retirements must be swept — pending stuck at \(source.pendingRetirementCountForTesting)")
     }
 
+    @Test("Invalidate fences the still-published frame, not just replaced ones")
+    func invalidateFencesTheCurrentFrame() async throws {
+        let device = try #require(MTLCreateSystemDefaultDevice())
+        let videoURL = try await SyntheticNV12VideoFixture.writeMP4(durationSeconds: 0.5)
+        defer { try? FileManager.default.removeItem(at: videoURL) }
+        let source = try WPEVideoTextureSource(device: device, videoURL: videoURL)
+
+        // One publish only: nothing has been replaced, so `pendingRetirements`
+        // is the empty case the drain used to walk right past — the published
+        // frame's wrappers were released with no fence at all.
+        let only = try Self.makeNV12PixelBuffer(width: 64, height: 64, luma: 120, cb: 110, cr: 140)
+        source.ingestForTesting(pixelBuffer: only)
+        let fencesAfterPublish = source.retirementFencesCreatedForTesting
+
+        source.invalidate()
+        #expect(
+            source.retirementFencesCreatedForTesting > fencesAfterPublish,
+            "invalidate released the published frame without fencing it"
+        )
+        #expect(source.pendingRetirementCountForTesting == 0,
+                "every fence must be waited out before teardown")
+    }
+
     @Test("Suspending playback releases retired wrappers instead of holding a frame")
     func suspendReleasesRetiredWrappers() async throws {
         let device = try #require(MTLCreateSystemDefaultDevice())

--- a/LiveWallpaperTests/WallpaperArchitectureTests.swift
+++ b/LiveWallpaperTests/WallpaperArchitectureTests.swift
@@ -2511,8 +2511,14 @@ struct ScreenRuntimeOwnershipTests {
         #expect(renderActorSource.contains(
             "func commitScenePropertyPatch("
         ))
+        // Commit both applies the patch and refreshes the reload source of
+        // truth, so an in-place reload (hibernate wake / retry) can't revert
+        // the committed edits.
         #expect(renderActorSource.contains(
-            "renderer?.applyScenePropertyPatch(prepared.patch)"
+            "renderer.applyScenePropertyPatch(prepared.patch)"
+        ))
+        #expect(renderActorSource.contains(
+            "renderer.descriptor = updatedDescriptor"
         ))
         #expect(sessionSource.contains(
             "waitForScenePropertyPosterCommit"

--- a/LoomscreenInfo.plist
+++ b/LoomscreenInfo.plist
@@ -28,8 +28,6 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
 	<true/>
-	<key>MetalCaptureEnabled</key>
-	<true/>
 	<key>NSAccentColorName</key>
 	<string>AccentColor</string>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Power/FullScreenDetector.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Power/FullScreenDetector.swift
@@ -22,10 +22,10 @@ public final class FullScreenDetector {
     @ObservationIgnored private static let occlusionFractionStep: CGFloat = 0.05
 
     /// Cap on how many windows feed the union-area calculation per display.
-    /// The union is computed by coordinate compression (~O(n²) cells × n
-    /// rects); keeping only the largest few dozen windows bounds the cost
-    /// while losing negligible coverage (tiny windows barely move 85%).
-    @ObservationIgnored private static let occlusionWindowCap = 80
+    /// The union sweep is ~O(n² log n) over the x-strips; keeping only the
+    /// largest few dozen windows bounds the cost while losing negligible
+    /// coverage (tiny windows barely move 85%).
+    @ObservationIgnored private nonisolated static let occlusionWindowCap = 80
 
     // MARK: - Private Properties
 
@@ -55,14 +55,23 @@ public final class FullScreenDetector {
         NSWorkspace.shared.notificationCenter
             .publisher(for: NSWorkspace.activeSpaceDidChangeNotification)
             .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
-            .sink { [weak self] _ in self?.checkFullScreenState() }
+            .sink { [weak self] _ in self?.scanIfDemanded() }
             .store(in: &cancellables)
 
         NSWorkspace.shared.notificationCenter
             .publisher(for: NSWorkspace.didActivateApplicationNotification)
             .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
-            .sink { [weak self] _ in self?.checkFullScreenState() }
+            .sink { [weak self] _ in self?.scanIfDemanded() }
             .store(in: &cancellables)
+    }
+
+    /// Workspace/space churn only matters while something consumes the result
+    /// — the same demand gate as the fallback timer. Explicit `checkNow()`
+    /// bypasses this, and `setFallbackPollingEnabled(true)` rescans, so state
+    /// catches up as soon as a consumer appears.
+    private func scanIfDemanded() {
+        guard isFallbackPollingEnabled else { return }
+        checkFullScreenState()
     }
 
     public var isFallbackPollingEnabled: Bool {
@@ -81,7 +90,9 @@ public final class FullScreenDetector {
     private func startPollingIfNeeded() {
         guard pollTimer == nil else { return }
 
-        pollTimer = Timer.publish(every: pollInterval, on: .main, in: .common)
+        // pollInterval/6 = 5s leeway at the shipped 30s interval, letting the
+        // OS coalesce the fallback tick with other wakeups.
+        pollTimer = Timer.publish(every: pollInterval, tolerance: pollInterval / 6, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in self?.checkFullScreenState() }
     }
@@ -182,11 +193,42 @@ public final class FullScreenDetector {
             }
         }
 
+        // Always synchronous: callers (reconcileMonitorOverlays,
+        // setupFullScreenDetection) read the published state in the same turn,
+        // and the sweep-line union is cheap even at the 80-window cap.
+        applyOcclusionScan(
+            fullScreen: result,
+            seedOcclusion: occlusion,
+            seedFractions: fractions,
+            coverage: Self.unionCoverage(windowsByScreen: windowsByScreen, screenFrames: screenFrames)
+        )
+    }
+
+    /// Raw (unquantized) union-coverage fraction per display.
+    private static func unionCoverage(
+        windowsByScreen: [CGDirectDisplayID: [CGRect]],
+        screenFrames: [(id: CGDirectDisplayID, frame: CGRect)]
+    ) -> [CGDirectDisplayID: CGFloat] {
+        var coverage: [CGDirectDisplayID: CGFloat] = [:]
         for (screenID, cgScreenFrame) in screenFrames {
             let screenArea = cgScreenFrame.width * cgScreenFrame.height
             guard screenArea > 0 else { continue }
             let rects = windowsByScreen[screenID] ?? []
-            let fraction = Self.unionArea(of: rects) / screenArea
+            coverage[screenID] = unionArea(of: rects) / screenArea
+        }
+        return coverage
+    }
+
+    /// Quantization + threshold decision for one scan.
+    private func applyOcclusionScan(
+        fullScreen: [CGDirectDisplayID: Bool],
+        seedOcclusion: [CGDirectDisplayID: Bool],
+        seedFractions: [CGDirectDisplayID: CGFloat],
+        coverage: [CGDirectDisplayID: CGFloat]
+    ) {
+        var occlusion = seedOcclusion
+        var fractions = seedFractions
+        for (screenID, fraction) in coverage {
             // Floor (not round) to the step so a quantized value never exceeds
             // the true coverage — keeps the policy's 0.5/0.4 thresholds honest
             // instead of effectively shifting them to ~0.475/0.375.
@@ -194,14 +236,14 @@ public final class FullScreenDetector {
             fractions[screenID] = min(1, max(0, quantized))
             occlusion[screenID] = fraction >= 0.85
         }
-
-        updateIfChanged(result, occlusion, fractions)
+        updateIfChanged(fullScreen, occlusion, fractions)
     }
 
-    /// Area of the union of `rects` (overlaps counted once) via coordinate
-    /// compression. Only the largest `occlusionWindowCap` rectangles are
-    /// considered to bound the cost.
-    static func unionArea(of rects: [CGRect]) -> CGFloat {
+    /// Area of the union of `rects` (overlaps counted once): sweep the
+    /// compressed x-edges left→right and, per strip, merge the active
+    /// y-intervals into covered length. Only the largest `occlusionWindowCap`
+    /// rectangles are considered to bound the cost.
+    nonisolated static func unionArea(of rects: [CGRect]) -> CGFloat {
         let rects = rects
             .filter { $0.width > 0 && $0.height > 0 }
             .sorted { ($0.width * $0.height) > ($1.width * $1.height) }
@@ -209,33 +251,43 @@ public final class FullScreenDetector {
         guard !rects.isEmpty else { return 0 }
 
         var xSet = Set<CGFloat>()
-        var ySet = Set<CGFloat>()
         for r in rects {
             xSet.insert(r.minX); xSet.insert(r.maxX)
-            ySet.insert(r.minY); ySet.insert(r.maxY)
         }
         let xs = xSet.sorted()
-        let ys = ySet.sorted()
 
         var area: CGFloat = 0
+        var intervals: [(lo: CGFloat, hi: CGFloat)] = []
         for i in 0 ..< (xs.count - 1) {
             let x0 = xs[i], x1 = xs[i + 1]
             let w = x1 - x0
             if w <= 0 {
                 continue
             }
-            let cx = (x0 + x1) / 2
-            for j in 0 ..< (ys.count - 1) {
-                let y0 = ys[j], y1 = ys[j + 1]
-                let h = y1 - y0
-                if h <= 0 {
-                    continue
-                }
-                let cy = (y0 + y1) / 2
-                if rects.contains(where: { $0.minX <= cx && cx < $0.maxX && $0.minY <= cy && cy < $0.maxY }) {
-                    area += w * h
+            // Strips never straddle an x-edge, so a rect is active for the
+            // whole strip or none of it.
+            intervals.removeAll(keepingCapacity: true)
+            for r in rects where r.minX <= x0 && x1 <= r.maxX {
+                intervals.append((r.minY, r.maxY))
+            }
+            if intervals.isEmpty {
+                continue
+            }
+            intervals.sort { $0.lo < $1.lo }
+            var covered: CGFloat = 0
+            var runLo = intervals[0].lo
+            var runHi = intervals[0].hi
+            for interval in intervals.dropFirst() {
+                if interval.lo <= runHi {
+                    runHi = max(runHi, interval.hi)
+                } else {
+                    covered += runHi - runLo
+                    runLo = interval.lo
+                    runHi = interval.hi
                 }
             }
+            covered += runHi - runLo
+            area += w * covered
         }
         return area
     }

--- a/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Power/PowerMonitoring.swift
+++ b/Packages/LiveWallpaperCore/Sources/LiveWallpaperCore/Power/PowerMonitoring.swift
@@ -25,6 +25,11 @@ public protocol FullScreenDetecting: AnyObject {
     func isDesktopOccluded(for screenID: CGDirectDisplayID) -> Bool
     func occlusionFraction(for screenID: CGDirectDisplayID) -> Double
     func checkNow()
+    /// Whether coverage state is being kept current. Space-change and
+    /// app-activation rescans share the fallback timer's demand gate, so with
+    /// this off `hiddenScreens`/`occludedScreens` stay frozen at the last scan —
+    /// a consumer that needs fresh coverage must not read them.
+    var isFallbackPollingEnabled: Bool { get }
     func setFallbackPollingEnabled(_ enabled: Bool)
     /// Permanently releases notification subscriptions and polling owned by
     /// this detector instance. Used by application teardown, not by the

--- a/Packages/LiveWallpaperCore/Tests/LiveWallpaperCoreTests/FullScreenDetectorUnionAreaTests.swift
+++ b/Packages/LiveWallpaperCore/Tests/LiveWallpaperCoreTests/FullScreenDetectorUnionAreaTests.swift
@@ -1,0 +1,139 @@
+import CoreGraphics
+import Testing
+@testable import LiveWallpaperCore
+
+@Suite("FullScreenDetector union-area sweep vs cell reference")
+struct FullScreenDetectorUnionAreaTests {
+
+    // MARK: - Reference implementation
+
+    /// Verbatim port of the pre-sweep coordinate-compression algorithm the
+    /// sweep-line replaced (cell midpoint containment), including its
+    /// filter/sort/cap preamble.
+    private func cellReferenceUnionArea(of rects: [CGRect], cap: Int = 80) -> CGFloat {
+        let rects = rects
+            .filter { $0.width > 0 && $0.height > 0 }
+            .sorted { ($0.width * $0.height) > ($1.width * $1.height) }
+            .prefix(cap)
+        guard !rects.isEmpty else { return 0 }
+
+        var xSet = Set<CGFloat>()
+        var ySet = Set<CGFloat>()
+        for r in rects {
+            xSet.insert(r.minX); xSet.insert(r.maxX)
+            ySet.insert(r.minY); ySet.insert(r.maxY)
+        }
+        let xs = xSet.sorted()
+        let ys = ySet.sorted()
+
+        var area: CGFloat = 0
+        for i in 0 ..< (xs.count - 1) {
+            let x0 = xs[i], x1 = xs[i + 1]
+            let w = x1 - x0
+            if w <= 0 { continue }
+            let cx = (x0 + x1) / 2
+            for j in 0 ..< (ys.count - 1) {
+                let y0 = ys[j], y1 = ys[j + 1]
+                let h = y1 - y0
+                if h <= 0 { continue }
+                let cy = (y0 + y1) / 2
+                if rects.contains(where: { $0.minX <= cx && cx < $0.maxX && $0.minY <= cy && cy < $0.maxY }) {
+                    area += w * h
+                }
+            }
+        }
+        return area
+    }
+
+    // MARK: - Seeded RNG
+
+    private struct SplitMix64: RandomNumberGenerator {
+        var state: UInt64
+        mutating func next() -> UInt64 {
+            state &+= 0x9E37_79B9_7F4A_7C15
+            var z = state
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            return z ^ (z >> 31)
+        }
+    }
+
+    /// Integer-coordinate rects like real CGWindowList bounds: negative
+    /// origins (multi-display global space), overlaps, containments, and a
+    /// sprinkle of degenerate zero-size rects.
+    private func randomIntegerRects(count: Int, using rng: inout SplitMix64) -> [CGRect] {
+        (0 ..< count).map { _ in
+            let degenerate = Int.random(in: 0 ..< 10, using: &rng) == 0
+            let x = CGFloat(Int.random(in: -2000 ... 4000, using: &rng))
+            let y = CGFloat(Int.random(in: -2000 ... 4000, using: &rng))
+            let w = degenerate ? 0 : CGFloat(Int.random(in: 1 ... 2500, using: &rng))
+            let h = degenerate ? 0 : CGFloat(Int.random(in: 1 ... 2500, using: &rng))
+            return CGRect(x: x, y: y, width: w, height: h)
+        }
+    }
+
+    // MARK: - Tests
+
+    @Test("100 randomized integer rect sets match the cell reference exactly")
+    func randomizedSetsMatchReference() {
+        var rng = SplitMix64(state: 0xC0FF_EE00_DEAD_BEEF)
+        for round in 0 ..< 100 {
+            let count = Int.random(in: 1 ... 30, using: &rng)
+            let rects = randomIntegerRects(count: count, using: &rng)
+            let sweep = FullScreenDetector.unionArea(of: rects)
+            let reference = cellReferenceUnionArea(of: rects)
+            // Integer coordinates keep every product/sum exact in Double,
+            // so the two algorithms must agree bit-for-bit.
+            #expect(sweep == reference, "round \(round): sweep \(sweep) != reference \(reference)")
+        }
+    }
+
+    @Test("A set above the 80-window cap still matches the reference")
+    func overCapMatchesReference() {
+        var rng = SplitMix64(state: 42)
+        let rects = randomIntegerRects(count: 100, using: &rng)
+        #expect(FullScreenDetector.unionArea(of: rects) == cellReferenceUnionArea(of: rects))
+    }
+
+    @Test("Fractional coordinates stay within float tolerance of the reference")
+    func fractionalCoordinatesCloseToReference() {
+        var rng = SplitMix64(state: 7)
+        for _ in 0 ..< 20 {
+            let rects: [CGRect] = (0 ..< 20).map { _ in
+                CGRect(
+                    x: CGFloat.random(in: -2000 ... 4000, using: &rng),
+                    y: CGFloat.random(in: -2000 ... 4000, using: &rng),
+                    width: CGFloat.random(in: 0.1 ... 2500, using: &rng),
+                    height: CGFloat.random(in: 0.1 ... 2500, using: &rng)
+                )
+            }
+            let sweep = FullScreenDetector.unionArea(of: rects)
+            let reference = cellReferenceUnionArea(of: rects)
+            #expect(abs(sweep - reference) <= max(1, reference) * 1e-9)
+        }
+    }
+
+    @Test("Empty and all-degenerate inputs are zero")
+    func emptyIsZero() {
+        #expect(FullScreenDetector.unionArea(of: []) == 0)
+        #expect(FullScreenDetector.unionArea(of: [
+            CGRect(x: 5, y: 5, width: 0, height: 300),
+            CGRect(x: 5, y: 5, width: 300, height: 0),
+        ]) == 0)
+    }
+
+    @Test("Exact tiling covers the full screen area once")
+    func fullCoverTiling() {
+        let tiles = [
+            CGRect(x: 0, y: 0, width: 960, height: 540),
+            CGRect(x: 960, y: 0, width: 960, height: 540),
+            CGRect(x: 0, y: 540, width: 960, height: 540),
+            CGRect(x: 960, y: 540, width: 960, height: 540),
+            // Redundant overlap on top must not change the union.
+            CGRect(x: 100, y: 100, width: 1000, height: 800),
+        ]
+        // CGFloat literal: a bare Int literal takes the macro's heterogeneous
+        // == path, which is always false.
+        #expect(FullScreenDetector.unionArea(of: tiles) == CGFloat(1920 * 1080))
+    }
+}

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPEMappedByteSpan.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPEMappedByteSpan.swift
@@ -42,7 +42,13 @@ public struct WPEMappedByteSpan: Sendable {
 
     public func byte(at offset: Int) -> UInt8 {
         precondition(offset >= 0 && offset < count)
-        return owner.withUnsafeBytes { $0[range.lowerBound + offset] }
+        // Explicit parameter type: `Data.withUnsafeBytes` still carries the
+        // deprecated typed-pointer overload, and the shipping compiler (26.6)
+        // cannot pick between them from `$0` alone — 27's can, so an unannotated
+        // closure compiles locally and breaks the release toolchain.
+        return owner.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            buffer[range.lowerBound + offset]
+        }
     }
 
     /// Explicit heap copy — the only way bytes leave the mapping. Callers that

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPEMappedByteSpan.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPEMappedByteSpan.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Zero-copy view into a (typically memory-mapped) `Data` owner. Deliberately
+/// not a `Data.SubSequence`: bridging slices back to `Data`/`NSData` can copy,
+/// and a slice hides which allocation keeps the mapping alive. The span retains
+/// `owner` explicitly, so `.tex` payload views stay valid for as long as any
+/// mip span exists, and mapped clean pages remain reclaimable by the kernel.
+///
+/// `range` is buffer-relative (0-based into the owner's logical bytes),
+/// matching `Data.withUnsafeBytes` coordinates rather than `Data` indices.
+public struct WPEMappedByteSpan: Sendable {
+    public let owner: Data
+    public let range: Range<Int>
+
+    public init(owner: Data, range: Range<Int>) {
+        precondition(range.lowerBound >= 0 && range.upperBound <= owner.count,
+                     "span range \(range) exceeds owner count \(owner.count)")
+        self.owner = owner
+        self.range = range
+    }
+
+    public init(data: Data) {
+        self.owner = data
+        self.range = 0..<data.count
+    }
+
+    public var count: Int { range.count }
+    public var isEmpty: Bool { range.isEmpty }
+
+    public func withUnsafeBytes<R>(
+        _ body: (UnsafeRawBufferPointer) throws -> R
+    ) rethrows -> R {
+        try owner.withUnsafeBytes { buffer in
+            try body(UnsafeRawBufferPointer(rebasing: buffer[range]))
+        }
+    }
+
+    public func prefix(_ maxLength: Int) -> WPEMappedByteSpan {
+        let clamped = Swift.min(Swift.max(maxLength, 0), count)
+        return WPEMappedByteSpan(owner: owner, range: range.lowerBound..<(range.lowerBound + clamped))
+    }
+
+    public func byte(at offset: Int) -> UInt8 {
+        precondition(offset >= 0 && offset < count)
+        return owner.withUnsafeBytes { $0[range.lowerBound + offset] }
+    }
+
+    /// Explicit heap copy — the only way bytes leave the mapping. Callers that
+    /// need a standalone `Data` (ImageIO, disk cache) pay the copy visibly.
+    public func materializedData() -> Data {
+        guard !isEmpty else { return Data() }
+        return withUnsafeBytes { Data($0) }
+    }
+}
+
+extension WPEMappedByteSpan: Equatable {
+    /// Content equality (matches the former `Data` payload semantics).
+    public static func == (lhs: WPEMappedByteSpan, rhs: WPEMappedByteSpan) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        if lhs.isEmpty { return true }
+        return lhs.withUnsafeBytes { lhsBuffer in
+            rhs.withUnsafeBytes { rhsBuffer in
+                memcmp(lhsBuffer.baseAddress!, rhsBuffer.baseAddress!, lhs.count) == 0
+            }
+        }
+    }
+}

--- a/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPETexErrors.swift
+++ b/Packages/LiveWallpaperProWPE/Sources/LiveWallpaperProWPE/Schema/WPETexErrors.swift
@@ -249,7 +249,9 @@ public struct WPETexMipmap: Sendable, Equatable {
     public let height: Int
     public let storedByteCount: Int
     public let decompressedByteCount: Int?
-    public let payload: Data
+    /// View into the container bytes (mmap-backed when the provider maps the
+    /// file) — the compressed payload is never duplicated onto the heap.
+    public let payload: WPEMappedByteSpan
     public let isCompressed: Bool
     public let v4Fields: WPETexMipmapV4Fields?
 
@@ -259,7 +261,7 @@ public struct WPETexMipmap: Sendable, Equatable {
         height: Int,
         storedByteCount: Int,
         decompressedByteCount: Int?,
-        payload: Data,
+        payload: WPEMappedByteSpan,
         isCompressed: Bool,
         v4Fields: WPETexMipmapV4Fields? = nil
     ) {
@@ -358,8 +360,26 @@ public struct WPETexCompressedMipmap: Sendable, Equatable {
     public let width: Int
     public let height: Int
     public let isCompressed: Bool
-    public let compressedBytes: Data
+    /// View into the container bytes (mmap-backed when the provider maps the
+    /// file); the lazy streaming source inflates directly out of the mapping.
+    public let compressedBytes: WPEMappedByteSpan
     public let decompressedByteCount: Int
+
+    public init(
+        index: Int,
+        width: Int,
+        height: Int,
+        isCompressed: Bool,
+        compressedBytes: WPEMappedByteSpan,
+        decompressedByteCount: Int
+    ) {
+        self.index = index
+        self.width = width
+        self.height = height
+        self.isCompressed = isCompressed
+        self.compressedBytes = compressedBytes
+        self.decompressedByteCount = decompressedByteCount
+    }
 
     public init(
         index: Int,
@@ -369,12 +389,14 @@ public struct WPETexCompressedMipmap: Sendable, Equatable {
         compressedBytes: Data,
         decompressedByteCount: Int
     ) {
-        self.index = index
-        self.width = width
-        self.height = height
-        self.isCompressed = isCompressed
-        self.compressedBytes = compressedBytes
-        self.decompressedByteCount = decompressedByteCount
+        self.init(
+            index: index,
+            width: width,
+            height: height,
+            isCompressed: isCompressed,
+            compressedBytes: WPEMappedByteSpan(data: compressedBytes),
+            decompressedByteCount: decompressedByteCount
+        )
     }
 }
 
@@ -403,12 +425,11 @@ public struct WPETexStreamingFrame: Sendable, Equatable {
 }
 
 /// Lazy-decode counterpart to `WPETexTexturePayload`. Holds compressed
-/// per-image bytes plus the TEXS sub-rect schedule; consumers stream
-/// frames out one at a time, keeping a small LRU cache of recently
-/// decompressed images resident in RAM (consumer-controlled — see
-/// `WPETexLazyAnimatedTextureSource.decompressedImageCacheCapacity`).
-/// Peak CPU footprint is therefore the compressed `.tex` file size plus
-/// `cacheCapacity × image-bytes`, not the full eager-decode total.
+/// per-image byte spans plus the TEXS sub-rect schedule; consumers stream
+/// frames out one at a time, keeping recently decompressed images in a
+/// process-wide byte-budget LRU (see `WPEAnimatedFrameByteCache`).
+/// Peak CPU footprint is therefore the mapped `.tex` bytes plus the shared
+/// decoded-frame budget, not the full eager-decode total.
 public struct WPETexStreamingPayload: Sendable, Equatable {
     public let info: WPETexInfo
     public let compressedImages: [WPETexCompressedImage]

--- a/Packages/LiveWallpaperProWPE/Tests/LiveWallpaperProWPETests/WPEMappedByteSpanSlicedOwnerTests.swift
+++ b/Packages/LiveWallpaperProWPE/Tests/LiveWallpaperProWPETests/WPEMappedByteSpanSlicedOwnerTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import LiveWallpaperProWPE
+
+/// `WPEMappedByteSpan.range` is buffer-relative, not `Data` index space.
+/// Every current provider hands the span a whole-file mapping whose
+/// `startIndex == 0`, where the two spaces coincide — so a regression to
+/// `Data`-index arithmetic (e.g. `owner[range.lowerBound + offset]` or
+/// `owner.subdata(in: range)`) would pass every whole-mapping test and only
+/// misread once an owner with `startIndex != 0` appears. These tests pin the
+/// contract on a sliced owner so that regression goes red immediately.
+@Suite("WPEMappedByteSpan over a sliced owner")
+struct WPEMappedByteSpanSlicedOwnerTests {
+
+    /// Bytes 0..<64 so value == absolute file offset; slice drops the first 16.
+    private let full = Data((0..<64).map { UInt8($0) })
+    private var sliced: Data { full[16...] }
+
+    @Test("Sliced owner has a non-zero startIndex (probe precondition)")
+    func slicedOwnerHasNonZeroStartIndex() {
+        #expect(sliced.startIndex == 16)
+        #expect(sliced.count == 48)
+    }
+
+    @Test("byte(at:) reads buffer-relative offsets")
+    func byteAtIsBufferRelative() {
+        let span = WPEMappedByteSpan(owner: sliced, range: 4..<12)
+        #expect(span.byte(at: 0) == 20)
+        #expect(span.byte(at: 7) == 27)
+    }
+
+    @Test("withUnsafeBytes windows the slice, not the original file")
+    func withUnsafeBytesIsBufferRelative() {
+        let span = WPEMappedByteSpan(owner: sliced, range: 4..<12)
+        span.withUnsafeBytes { buffer in
+            #expect(buffer.count == 8)
+            #expect(buffer.first == 20)
+            #expect(buffer.last == 27)
+        }
+    }
+
+    @Test("materializedData and prefix stay buffer-relative")
+    func materializeAndPrefixAreBufferRelative() {
+        let span = WPEMappedByteSpan(owner: sliced, range: 4..<12)
+        #expect(span.materializedData() == Data([20, 21, 22, 23, 24, 25, 26, 27]))
+        #expect(span.prefix(3).materializedData() == Data([20, 21, 22]))
+    }
+
+    @Test("init(data:) over a slice covers exactly the slice bytes")
+    func initDataOverSliceCoversSliceBytes() {
+        let span = WPEMappedByteSpan(data: sliced)
+        #expect(span.count == 48)
+        #expect(span.byte(at: 0) == 16)
+        #expect(span.byte(at: 47) == 63)
+    }
+
+    @Test("Content equality holds across sliced and whole owners")
+    func equalityAcrossSlicedAndWholeOwners() {
+        let fromSlice = WPEMappedByteSpan(owner: sliced, range: 4..<8)
+        let fromWhole = WPEMappedByteSpan(owner: full, range: 20..<24)
+        #expect(fromSlice == fromWhole)
+    }
+}


### PR DESCRIPTION
Cuts memory and CPU across the scene runtime in three waves, and closes out a
long-running resident-memory leak whose root cause turned out to be a shipped
debug capability.

## The leak

`MetalCaptureEnabled` in both SKU `Info.plist`s made every release launch load
GPUToolsCapture. Its per-draw encoder interposition grew the AGX
`DataBufferAllocator` arena in 4MB segments that are never returned — about one
segment every 11 seconds, 40-60MB/min on a scene wallpaper, with **zero
object-level growth**, which is why four earlier rounds of heap and object
attribution came up empty.

Found by breakpointing `AGX::DataBufferAllocator<45ul>::grow` and reading the
backtrace; confirmed by removing the key and re-signing the built app: the
`Untagged (graphics)` region class disappears entirely and dirty Untagged drops
from ~40MB (growing) to 80KB (flat). Debug captures now go through Xcode attach
or `MTL_CAPTURE_ENABLED=1`; a guard test keeps the key out of both plists.

## What else is in here

**W1** — video texture cache leak (-96%), texture budget per memory tier,
pointer-monitor gating, script fault backoff, FFT pull throttling, sweep-line
full-screen detection, particle live-slot bitset.

**W2a** — mapped `.tex`/pkg byte spans, process-wide animation-frame byte LRU,
NV12 video decode (IOSurface resident -60MB measured), frame-demand tracking
with deep hibernate, settings window destroyed on close, per-field Monitor
sampling.

**Residual close-out** — video frame wrappers now retire behind a GPU fence
instead of dropping at the next publish; real 10-bit HEVC PQ media exercised
end to end; the macOS 14 item-level output path made reachable and tested;
hibernation extended to critical memory pressure and long manual pauses; the
process-table walk moved to its own 5s cadence.

## Review rounds

Three independent reviews (codex, plus two agent passes) produced 11 findings.
Nine were fixed, two were declined with code evidence recorded in the ledger —
including one suggestion that would have blanked the video layer of a visible,
paused wallpaper. Two findings were regressions introduced by this branch's own
hardening and are fixed here.

## Verification

- App suite: **2783 tests / 305 suites** green
- Packages: ProWPE 24, Core 190 green
- Lite: `BUILD SUCCEEDED`
- Oracle: 5 scenes, pass sequences and per-pass vertex counts identical; 3/5
  byte-identical finals (the other 2 are inherently nondeterministic, proven by
  same-build control runs)
- Mutation-verified guards on the capture-layer plist fence, the mapped-package
  write fence, the wrapper retention, and the invalidate drain

## Known before merge

This branch conflicts with `main` in one file, one hunk:
`WPETexLazyAnimatedTextureSource.swift` in commit `7280f86`, against the four
commits `main` has gained since the merge base. Happy to rebase and re-run the
gate on request.
